### PR TITLE
(WIP) User location search radius should be geographically not as the crow flies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'rubocop', '~> 0.65.0', require: false # Not in Test group due to: https://g
 gem 'activerecord-session_store'
 gem 'public_activity'
 gem 'high_voltage', '~> 3.1'
+gem 'geokit-rails'
 gem 'google_drive', require: false
 gem 'google-api-client'
 gem 'browser'

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'activerecord-session_store'
 gem 'public_activity'
 gem 'high_voltage', '~> 3.1'
 gem 'geokit-rails'
+gem 'google_distance_matrix'
 gem 'google_drive', require: false
 gem 'google-api-client'
 gem 'browser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,12 @@ GEM
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
       signet (~> 0.10)
+    google_business_api_url_signer (0.1.3)
+      activesupport (>= 3.2.0)
+    google_distance_matrix (0.6.1)
+      activemodel (>= 3.2.13, < 5.3)
+      activesupport (>= 3.2.13, < 5.3)
+      google_business_api_url_signer (~> 0.1.3)
     google_drive (3.0.2)
       google-api-client (>= 0.11.0, < 0.29.0)
       googleauth (>= 0.5.0, < 1.0.0)
@@ -516,6 +522,7 @@ DEPENDENCIES
   geocoder
   geokit-rails
   google-api-client
+  google_distance_matrix
   google_drive
   gov_uk_date_fields!
   haml-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,10 @@ GEM
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
     geocoder (1.5.1)
+    geokit (1.13.1)
+    geokit-rails (2.3.1)
+      geokit (~> 1.5)
+      rails (>= 3.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     google-api-client (0.25.0)
@@ -510,6 +514,7 @@ DEPENDENCIES
   figaro
   friendly_id
   geocoder
+  geokit-rails
   google-api-client
   google_drive
   gov_uk_date_fields!

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,5 +1,8 @@
 require 'breasal'
 class School < ApplicationRecord
+  acts_as_mappable lat_column_name: :latitude,
+                   lng_column_name: :longitude
+
   include Auditor::Model
 
   belongs_to :school_type, optional: false

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -38,6 +38,10 @@ class School < ApplicationRecord
     GoogleDistanceMatrix::Place.new(lat: latitude, lng: longitude)
   end
 
+  def geolocation?
+    (latitude && longitude).present?
+  end
+
   private
 
   def set_geolocation_from_easting_and_northing

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -34,16 +34,21 @@ class School < ApplicationRecord
   private
 
   def set_geolocation_from_easting_and_northing
-    if easting && northing
-      wgs84 = Breasal::EastingNorthing.new(
-        easting: easting.to_i,
-        northing: northing.to_i,
-        type: :gb
-      ).to_wgs84
+    self.latitude = wgs84[:latitude]
+    self.longitude = wgs84[:longitude]
+  end
 
-      geolocation = [wgs84[:latitude], wgs84[:longitude]]
-    end
+  def wgs84
+    return {} if invalid_coords?
 
-    self.geolocation = geolocation
+    Breasal::EastingNorthing.new(
+      easting: easting.to_i,
+      northing: northing.to_i,
+      type: :gb
+    ).to_wgs84
+  end
+
+  def invalid_coords?
+    easting.blank? || northing.blank?
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -34,6 +34,10 @@ class School < ApplicationRecord
     set_geolocation_from_easting_and_northing
   end
 
+  def place
+    GoogleDistanceMatrix::Place.new(lat: latitude, lng: longitude)
+  end
+
   private
 
   def set_geolocation_from_easting_and_northing

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -45,11 +45,13 @@ class School < ApplicationRecord
   private
 
   def set_geolocation_from_easting_and_northing
+    wgs84 = easting_northing_to_latlng
+
     self.latitude = wgs84[:latitude]
     self.longitude = wgs84[:longitude]
   end
 
-  def wgs84
+  def easting_northing_to_latlng
     return {} if invalid_coords?
 
     Breasal::EastingNorthing.new(

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -90,7 +90,8 @@ class Vacancy < ApplicationRecord
   has_one :feedback
 
   delegate :name, to: :school, prefix: true, allow_nil: false
-  delegate :geolocation, to: :school, prefix: true, allow_nil: true
+  delegate :latitude, to: :school, prefix: true, allow_nil: true
+  delegate :longitude, to: :school, prefix: true, allow_nil: true
 
   acts_as_gov_uk_date :starts_on, :ends_on, :publish_on, :expires_on
 
@@ -118,11 +119,11 @@ class Vacancy < ApplicationRecord
   end
 
   def coordinates
-    return if school_geolocation.nil?
+    return if school_latitude.nil? && school_longitude.nil?
 
     {
-      lat: school_geolocation.x.to_f,
-      lon: school_geolocation.y.to_f
+      lat: school_latitude.to_f,
+      lon: school_longitude.to_f
     }
   end
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -37,6 +37,7 @@ class Vacancy < ApplicationRecord
     mappings dynamic: 'false' do
       indexes :job_title, type: :text, analyzer: :stopwords
       indexes :job_description, analyzer: 'english'
+      indexes :school_id, type: :keyword
 
       indexes :school do
         indexes :name, analyzer: 'english'
@@ -67,7 +68,6 @@ class Vacancy < ApplicationRecord
       indexes :working_pattern, type: :keyword
       indexes :minimum_salary, type: :integer
       indexes :maximum_salary, type: :integer
-      indexes :coordinates, type: :geo_point, ignore_malformed: true
       indexes :newly_qualified_teacher, type: :boolean
     end
   end
@@ -90,6 +90,7 @@ class Vacancy < ApplicationRecord
   has_one :feedback
 
   delegate :name, to: :school, prefix: true, allow_nil: false
+  delegate :id, to: :school, prefix: true, allow_nil: false
   delegate :latitude, to: :school, prefix: true, allow_nil: true
   delegate :longitude, to: :school, prefix: true, allow_nil: true
 

--- a/app/services/schools_in_area.rb
+++ b/app/services/schools_in_area.rb
@@ -8,13 +8,23 @@ class SchoolsInArea
   end
 
   def results
+    schools.each_slice(25).map do |school_slice|
+      filter_schools_by_distance(school_slice)
+    end.flatten
+  end
+
+  private
+
+  def filter_schools_by_distance(schools)
     schools.select do |s|
-      place = data.find { |d| d.destination == s.place }
+      place = find_school_from_place(s)
       distance_in_miles(place.distance_in_meters) <= radius
     end
   end
 
-  private
+  def find_school_from_place(school)
+    data.find { |d| d.destination == school.place }
+  end
 
   def distance_in_miles(metres)
     metres * 0.00062137

--- a/app/services/schools_in_area.rb
+++ b/app/services/schools_in_area.rb
@@ -1,0 +1,45 @@
+class SchoolsInArea
+  attr_reader :lat, :lng, :radius
+
+  def initialize(lat:, lng:, radius:)
+    @lat = lat
+    @lng = lng
+    @radius = radius
+  end
+
+  def results
+    schools.select do |s|
+      place = data.find { |d| d.destination == s.place }
+      distance_in_miles(place.distance_in_meters) <= radius
+    end
+  end
+
+  private
+
+  def distance_in_miles(metres)
+    metres * 0.00062137
+  end
+
+  def schools
+    @schools ||= School.within(radius, origin: [lat, lng])
+                       .joins(:vacancies)
+                       .merge(Vacancy.live)
+                       .distinct
+                       .order(:id)
+  end
+
+  def matrix
+    @matrix ||= begin
+      matrix = GoogleDistanceMatrix::Matrix.new
+      matrix.origins << GoogleDistanceMatrix::Place.new(lat: lat, lng: lng)
+      schools.each do |s|
+        matrix.destinations << s.place
+      end
+      matrix
+    end
+  end
+
+  def data
+    @data ||= matrix.data.first
+  end
+end

--- a/app/views/hiring_staff/vacancies/_show.html.haml
+++ b/app/views/hiring_staff/vacancies/_show.html.haml
@@ -78,11 +78,11 @@
           %dd
             = link_to("#{@vacancy.school.name} website (opens in a new window)", @vacancy.school.url, class: 'govuk-link wordwrap', target: '_blank')
 
-      - if @vacancy.school.geolocation
+      - if @vacancy.school.latitude && @vacancy.school.longitude
         %div#map_zoom
         = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.school.name,
-                                                              lat: @vacancy.school_geolocation.x,
-                                                              lng: @vacancy.school_geolocation.y }
+                                                              lat: @vacancy.school.latitude,
+                                                              lng: @vacancy.school.longitude }
 
         %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap" }
 

--- a/app/views/hiring_staff/vacancies/_show.html.haml
+++ b/app/views/hiring_staff/vacancies/_show.html.haml
@@ -78,7 +78,7 @@
           %dd
             = link_to("#{@vacancy.school.name} website (opens in a new window)", @vacancy.school.url, class: 'govuk-link wordwrap', target: '_blank')
 
-      - if @vacancy.school.latitude && @vacancy.school.longitude
+      - if @vacancy.school.geolocation?
         %div#map_zoom
         = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.school.name,
                                                               lat: @vacancy.school.latitude,

--- a/app/views/vacancies/_show.html+phone.haml
+++ b/app/views/vacancies/_show.html+phone.haml
@@ -23,11 +23,11 @@
 
     = render partial: 'school_details'
 
-    - if @vacancy.school.geolocation
+    - if @vacancy.school.latitude && @vacancy.school.longitude
       #map_zoom{style: 'height: 200px; margin-bottom: 20px;'}
       = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.school.name,
-                                                            lat: @vacancy.school_geolocation.x,
-                                                            lng: @vacancy.school_geolocation.y }
+                                                            lat: @vacancy.school.latitude,
+                                                            lng: @vacancy.school.longitude }
 
       %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap" }
 
@@ -111,7 +111,7 @@
     %h2.govuk-heading-m.share-this-job
       = t('jobs.share_this_job')
     = render partial: '/shared/vacancy/share_buttons'
-    
+
     %aside.vacancy--metadata
       - if @vacancy.application_link.present?
         %p.govuk-body-s=t('jobs.aria_labels.apply_link')

--- a/app/views/vacancies/_show.html+phone.haml
+++ b/app/views/vacancies/_show.html+phone.haml
@@ -23,7 +23,7 @@
 
     = render partial: 'school_details'
 
-    - if @vacancy.school.latitude && @vacancy.school.longitude
+    - if @vacancy.school.geolocation?
       #map_zoom{style: 'height: 200px; margin-bottom: 20px;'}
       = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.school.name,
                                                             lat: @vacancy.school.latitude,

--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -44,7 +44,7 @@
 
     = render partial: 'school_details'
 
-    - if @vacancy.school.latitude && @vacancy.school.longitude
+    - if @vacancy.school.geolocation?
       %div#map_zoom
       = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.school.name,
                                                             lat: @vacancy.school.latitude,

--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -44,18 +44,18 @@
 
     = render partial: 'school_details'
 
-    - if @vacancy.school.geolocation
+    - if @vacancy.school.latitude && @vacancy.school.longitude
       %div#map_zoom
       = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.school.name,
-                                                            lat: @vacancy.school_geolocation.x,
-                                                            lng: @vacancy.school_geolocation.y }
+                                                            lat: @vacancy.school.latitude,
+                                                            lng: @vacancy.school.longitude }
 
       %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}
 
     %h2.govuk-heading-m.share-this-job
       = t('jobs.share_this_job')
     = render partial: '/shared/vacancy/share_buttons'
-    
+
   .govuk-grid-column-one-third
     %aside.vacancy--metadata
       - if @vacancy.application_link.present?

--- a/app/views/vacancies/_vacancies_for_map.json.jbuilder
+++ b/app/views/vacancies/_vacancies_for_map.json.jbuilder
@@ -1,7 +1,0 @@
-json.array! vacancies.select do |vacancy|
-  json.school vacancy.school.name
-  json.job_title vacancy.job_title
-  json.link job_path(vacancy)
-  json.lat vacancy.school.latitude
-  json.lng vacancy.school.longitude
-end

--- a/app/views/vacancies/_vacancies_for_map.json.jbuilder
+++ b/app/views/vacancies/_vacancies_for_map.json.jbuilder
@@ -1,7 +1,7 @@
-json.array! vacancies.select(&:school_geolocation) do |vacancy|
+json.array! vacancies.select do |vacancy|
   json.school vacancy.school.name
   json.job_title vacancy.job_title
   json.link job_path(vacancy)
-  json.lat vacancy.school.geolocation.x
-  json.lng vacancy.school.geolocation.y
+  json.lat vacancy.school.latitude
+  json.lng vacancy.school.longitude
 end

--- a/config/initializers/google_distance_matrix.rb
+++ b/config/initializers/google_distance_matrix.rb
@@ -1,0 +1,3 @@
+GoogleDistanceMatrix.configure_defaults do |config|
+  config.google_api_key = ENV['GOOGLE_GEOCODING_API_KEY']
+end

--- a/db/migrate/20190408143457_add_lat_and_lng_to_schools.rb
+++ b/db/migrate/20190408143457_add_lat_and_lng_to_schools.rb
@@ -1,0 +1,7 @@
+class AddLatAndLngToSchools < ActiveRecord::Migration[5.2]
+  def change
+    add_column :schools, :latitude, :float
+    add_column :schools, :longitude, :float
+    remove_column :schools, :geolocation
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_21_142008) do
+ActiveRecord::Schema.define(version: 2019_04_08_143457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -127,7 +127,8 @@ ActiveRecord::Schema.define(version: 2019_03_21_142008) do
     t.uuid "detailed_school_type_id"
     t.text "easting"
     t.text "northing"
-    t.point "geolocation"
+    t.float "latitude"
+    t.float "longitude"
     t.index ["detailed_school_type_id"], name: "index_schools_on_detailed_school_type_id"
     t.index ["region_id"], name: "index_schools_on_region_id"
     t.index ["school_type_id"], name: "index_schools_on_school_type_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,7 +43,8 @@ ealing_school = FactoryBot.create(:school, name: 'Macmillan Academy ',
                                    postcode: 'TS5 4AG',
                                    url: 'http://www.macmillan-academy.org.uk',
                                    region: london,
-                                   geolocation: '(54.565770,-1.264489)')
+                                   latitude: 54.565770,
+                                   longitude: -1.264489)
 
 bromley_school = FactoryBot.create(:school,
                                     name: 'Burnsfield Infant School',
@@ -55,7 +56,8 @@ bromley_school = FactoryBot.create(:school,
                                     county: 'Cambridgeshire',
                                     postcode: 'PE16 6ET',
                                     region: se,
-                                    geolocation: '(52.455421,0.043325)')
+                                    latitude: 52.455421,
+                                    longitude: 0.043325)
 
 payscale = PayScale.limit(5).sample(1).first
 leadership = Leadership.limit(1).sample(1).first

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -21,5 +21,17 @@ FactoryBot.define do
     trait :secondary do
       phase { :secondary }
     end
+
+    trait :with_live_vacancies do
+      after(:create) do |school, _evaluator|
+        create_list(:vacancy, 2, :published, school: school)
+      end
+    end
+
+    trait :with_expired_vacancies do
+      after(:create) do |school, _evaluator|
+        create_list(:vacancy, 2, :expired, school: school)
+      end
+    end
   end
 end

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Filtering vacancies' do
       end
     end
 
-    scenario 'Search results can be filtered by the selected location and radius' do
+    scenario 'Search results can be filtered by the selected location and radius', :vcr do
       expect(Geocoder).to receive(:coordinates).with('enfield', params: { region: 'uk' })
                                                .and_return([51.6622925, -0.1180655])
       enfield_vacancy = create(:vacancy, :published,

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -38,7 +38,8 @@ RSpec.feature 'Filtering vacancies' do
       enfield_vacancy = create(:vacancy, :published,
                                school: build(:school, name: 'St James School',
                                                       town: 'Enfield',
-                                                      geolocation: '(51.6580645, -0.0448643)'))
+                                                      latitude: 51.6580645,
+                                                      longitude: -0.0448643))
       penzance_vacancy = create(:vacancy, :published, school: build(:school, name: 'St James School',
                                                                              town: 'Penzance'))
 

--- a/spec/features/job_seekers_can_see_a_map_spec.rb
+++ b/spec/features/job_seekers_can_see_a_map_spec.rb
@@ -5,7 +5,8 @@ RSpec.feature 'Viewing a vacancy' do
     school = create(:school,
                     easting: '537224',
                     northing: '177395',
-                    geolocation: '51.4788757883318, 0.0253328559417984')
+                    latitude: 51.4788757883318,
+                    longitude: 0.0253328559417984)
     vacancy = create(:vacancy, school: school)
     visit job_path(vacancy)
     expect(page).to have_css('div#map_zoom')

--- a/spec/lib/schools_in_area_spec.rb
+++ b/spec/lib/schools_in_area_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'SchoolsInArea' do
+  subject { SchoolsInArea.new(lat: lat, lng: lng, radius: 20) }
+
+  let!(:school1) { create(:school, :with_live_vacancies, latitude: 53.148326, longitude: 0.337303) }
+  let!(:school2) { create(:school, :with_live_vacancies, latitude: 52.820173, longitude: 0.517886) }
+  let!(:school3) { create(:school, :with_expired_vacancies, latitude: 52.820173, longitude: 0.517886) }
+
+  let(:lat) { 52.93493 }
+  let(:lng) { 0.483486 }
+
+  describe '#schools' do
+    it 'only gets schools with vacancies' do
+      expect(subject.send(:schools)).to match_array([school1, school2])
+    end
+  end
+
+  describe '#data' do
+    it 'makes the correct call to the Distance Matrix API' do
+      destinations = [school1, school2].map do |s|
+        [
+          '(?=.*',
+          Regexp.escape(s.latitude.round(5).to_s),
+          ',',
+          Regexp.escape(s.longitude.round(5).to_s),
+          ')'
+        ].join
+      end.join
+
+      url_regexp = %r{https:\/\/maps\.googleapis\.com\/maps\/api\/distancematrix\/json\?destinations\=#{destinations}.*}
+      stub = stub_request(:get, url_regexp).and_return(body: { rows: [], status: 'OK' }.to_json)
+
+      subject.send(:data)
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe '#results' do
+    let(:results) { subject.results }
+
+    it 'only includes the school within the radius' do
+      allow(subject).to receive(:data) {
+        [
+          double(GoogleDistanceMatrix::Route, destination: school1.place, distance_in_meters: 113835),
+          double(GoogleDistanceMatrix::Route, destination: school2.place, distance_in_meters: 17179)
+        ]
+      }
+
+      expect(results.count).to eq(1)
+      expect(results).to_not include(school1)
+      expect(results).to include(school2)
+    end
+  end
+end

--- a/spec/lib/schools_in_area_spec.rb
+++ b/spec/lib/schools_in_area_spec.rb
@@ -53,4 +53,24 @@ RSpec.describe 'SchoolsInArea' do
       expect(results).to include(school2)
     end
   end
+
+  context 'when there more than 25 schools' do
+    let(:schools) { build_list(:school, 55, :with_live_vacancies) }
+    let(:route) { double(GoogleDistanceMatrix::Route, distance_in_meters: 1000) }
+
+    before do
+      allow(subject).to receive(:schools) { schools }
+      allow(subject).to receive(:find_school_from_place) { route }
+      allow(subject).to receive(:distance_in_miles) { 20 }
+    end
+
+    it 'splits schools into batches' do
+      expect(subject).to receive(:filter_schools_by_distance).exactly(3).times
+      subject.results
+    end
+
+    it 'gets the expected results' do
+      expect(subject.results).to match_array(schools)
+    end
+  end
 end

--- a/spec/lib/update_school_data_spec.rb
+++ b/spec/lib/update_school_data_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe UpdateSchoolData do
         expect(school.phase).to eql('primary')
         expect(school.easting).to eql('533498')
         expect(school.northing).to eql('181201')
-        expect(school.geolocation.x).to be_within(0.0000000000001).of(51.51396894535262)
-        expect(school.geolocation.y).to be_within(0.0000000000001).of(-0.07751626505544208)
+        expect(school.latitude).to be_within(0.0000000000001).of(51.51396894535262)
+        expect(school.longitude).to be_within(0.0000000000001).of(-0.07751626505544208)
 
         school = School.find_by(urn: '100001')
         expect(school.name).to eql('City of London School for Girls')
@@ -131,8 +131,8 @@ RSpec.describe UpdateSchoolData do
         expect(school.phase).to eql('not_applicable')
         expect(school.easting).to eql('532301')
         expect(school.northing).to eql('181746')
-        expect(school.geolocation.x).to be_within(0.0000000000001).of(51.51914791336013)
-        expect(school.geolocation.y).to be_within(0.0000000000001).of(-0.09455174037405477)
+        expect(school.latitude).to be_within(0.0000000000001).of(51.51914791336013)
+        expect(school.longitude).to be_within(0.0000000000001).of(-0.09455174037405477)
 
         expect(School.find_by(urn: '100002')).to be_present
         expect(School.find_by(urn: '100003')).to be_present

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -20,15 +20,17 @@ RSpec.describe School, type: :model do
           school.easting = 533498
           school.northing = 181201
 
-          expect(school.geolocation.x).to eql(51.51396894535262)
-          expect(school.geolocation.y).to eql(-0.07751626505544208)
+          expect(school.latitude).to eql(51.51396894535262)
+          expect(school.longitude).to eql(-0.07751626505544208)
         end
       end
 
       context 'when setting just a GB easting' do
         it 'should not set a geolocation' do
           school.easting = 533498
-          expect(school.geolocation).to eql(nil)
+
+          expect(school.latitude).to eql(nil)
+          expect(school.longitude).to eql(nil)
         end
       end
 
@@ -36,7 +38,8 @@ RSpec.describe School, type: :model do
         it 'should not set a geolocation' do
           school.northing = 308885
 
-          expect(school.geolocation).to eql(nil)
+          expect(school.latitude).to eql(nil)
+          expect(school.longitude).to eql(nil)
         end
       end
     end
@@ -49,8 +52,8 @@ RSpec.describe School, type: :model do
           school.easting = 533498
           school.northing = 181201
 
-          expect(school.geolocation.x).to eql(51.51396894535262)
-          expect(school.geolocation.y).to eql(-0.07751626505544208)
+          expect(school.latitude).to eql(51.51396894535262)
+          expect(school.longitude).to eql(-0.07751626505544208)
         end
       end
 
@@ -59,7 +62,8 @@ RSpec.describe School, type: :model do
           school.easting = 533498
           school.northing = nil
 
-          expect(school.geolocation).to eql(nil)
+          expect(school.latitude).to eql(nil)
+          expect(school.longitude).to eql(nil)
         end
       end
 
@@ -68,7 +72,8 @@ RSpec.describe School, type: :model do
           school.northing = 308885
           school.easting = nil
 
-          expect(school.geolocation).to eql(nil)
+          expect(school.latitude).to eql(nil)
+          expect(school.longitude).to eql(nil)
         end
       end
     end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -78,4 +78,24 @@ RSpec.describe School, type: :model do
       end
     end
   end
+
+  describe '#geolocation?' do
+    let(:school) { create(:school, latitude: 51.5139689453526, longitude: -0.07751626505544208) }
+
+    context 'when there is a latitude and longitude' do
+      it { expect(school.geolocation?).to eq(true) }
+    end
+
+    context 'when there is no latitude' do
+      before { school.latitude = nil }
+
+      it { expect(school.geolocation?).to eq(false) }
+    end
+
+    context 'when there is no longitude' do
+      before { school.longitude = nil }
+
+      it { expect(school.geolocation?).to eq(false) }
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ RSpec.configure do |config|
     'es', # Required for CI. Defined in ./buildspec.yml
     'pg', # Required for CI. Defined in ./buildspec.yml
   ]
+
   WebMock.disable_net_connect!(allow: allowed_http_requests)
 
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/Zi8Eu8w9/513-user-location-search-radius-should-be-geographically-not-as-the-crow-flies

## Changes in this PR:

This PR uses the [Google Distance Matrix API](https://developers.google.com/maps/documentation/distance-matrix/start) to check if vacancies are really in an area before presenting them to a user. This can occur if a user is searching a large radius in somewhere like Cardiff where there are vacancies over the Bristol Channel in somewhere like Weston-Super-Mare. 

It works like so:

* User enters a location and radius
* We geocode the location, and search for schools within that radius as the crow flies (using the [GeoKit gem](https://github.com/geokit/geokit), which, under the hood, generates a Postgres query using the [Haversine formula](https://en.wikipedia.org/wiki/Haversine_formula)
* We then pass the user's location and the latlngs to the Distance Matrix API, filtering any schools that are not actually reachable by land
* We then pass the IDs of those schools to the ElasticSearch query, so we know that only vacancies at those schools will be returned

The only drawback with this is that we are now making an extra API call to Google when a user carries out a distance search, which may come with extra costs / a performance hit. Might be worth getting this up on Edge and see if we notice any change in Skylight.