### PR TITLE
(Hotfix) [885] Fix phase JSON invalid Array to String conversion

### DIFF
--- a/app/services/alert_result_finder.rb
+++ b/app/services/alert_result_finder.rb
@@ -3,8 +3,8 @@ class AlertResultFinder
 
   attr_reader :query, :results
 
-  def initialize(search_criteria, from_date, to_date)
-    filters = VacancyAlertFilters.new(search_criteria)
+  def initialize(search_criteria_h, from_date, to_date)
+    filters = VacancyAlertFilters.new(search_criteria_h)
     @query = VacancyAlertSearchBuilder.new(filters: filters,
                                            from: from_date, to: to_date).call
   end

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -13,8 +13,8 @@ class VacancyFilters
     @job_title = args[:job_title]
     @minimum_salary = args[:minimum_salary]
     @newly_qualified_teacher = args[:newly_qualified_teacher]
-    @working_pattern = extract_working_pattern(args)
-    @phases = extract_phases(args)
+    @working_pattern = extract_working_pattern(args[:working_pattern])
+    @phases = extract_phases(args[:phases])
   end
 
   def to_hash
@@ -57,13 +57,15 @@ class VacancyFilters
 
   private
 
-  def extract_working_pattern(params)
-    params[:working_pattern] if Vacancy.working_patterns.include?(params[:working_pattern])
+  def extract_working_pattern(working_pattern)
+    working_pattern if Vacancy.working_patterns.include?(working_pattern)
   end
 
-  def extract_phases(params)
-    return if params[:phases].blank?
+  def extract_phases(phases)
+    return if phases.blank?
 
-    JSON.parse(params[:phases]).select { |phase| School.phases.include?(phase) }.presence
+    phases = JSON.parse(phases) if phases.is_a?(String)
+
+    phases.select { |phase| School.phases.include?(phase) }.presence
   end
 end


### PR DESCRIPTION
Alerts already parse the full JSON when they get passed in to the filter, while the param from a search is a string.

This is blocking the daily alerts from sending.

Resolves https://rollbar.com/dfe/teacher-vacancies/items/476/

**This is a hotfix directly on to `master`**