### PR TITLE
Validate the presence of search criteria on a subscription

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,7 +8,7 @@ class Subscription < ApplicationRecord
   validates :email, email_address: { presence: true }
   validates :reference, presence: true
   validates :frequency, presence: true
-  validates :search_criteria, uniqueness: { scope: %i[email expires_on frequency] }
+  validates :search_criteria, presence: true, uniqueness: { scope: %i[email expires_on frequency] }
 
   scope :ongoing, -> { where('expires_on >= current_date') }
 

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -4,6 +4,14 @@ FactoryBot.define do
     email { Faker::Internet.email }
     reference { Faker::Lorem.sentence }
     frequency { :daily }
+    search_criteria do
+      {
+        location: 'EC1A 1AA',
+        radius: 20,
+        working_pattern: 'full_time',
+        phases: ['primary', 'secondary']
+      }.to_json
+    end
 
     factory :daily_subscription do
       frequency { :daily }

--- a/spec/geocoder_helper.rb
+++ b/spec/geocoder_helper.rb
@@ -1,0 +1,21 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    Geocoder.configure(lookup: :test)
+  end
+
+  config.before(:each) do
+    Geocoder::Lookup::Test.set_default_stub(
+      [
+        {
+          'coordinates' => [1, 1],
+          'longitude' => '1',
+          'latitude' => '1',
+        }
+      ]
+    )
+  end
+
+  config.after(:each) do
+    Geocoder::Lookup::Test.reset
+  end
+end

--- a/spec/jobs/send_daily_alert_email_job_spec.rb
+++ b/spec/jobs/send_daily_alert_email_job_spec.rb
@@ -5,15 +5,7 @@ RSpec.describe SendDailyAlertEmailJob, type: :job do
 
   subject(:job) { described_class.perform_later }
 
-  let(:search_criteria) do
-    {
-      subject: 'English',
-      working_pattern: 'full_time',
-      phases: ['primary', 'secondary']
-    }.to_json
-  end
-
-  let!(:subscription) { create(:subscription, search_criteria: search_criteria, frequency: :daily) }
+  let!(:subscription) { create(:subscription, frequency: :daily) }
   let!(:vacancies) { create_list(:vacancy, 5, :published_slugged) }
 
   let(:mail) { double(:mail) }
@@ -73,9 +65,7 @@ RSpec.describe SendDailyAlertEmailJob, type: :job do
   end
 
   context 'when a subscription is expired' do
-    let!(:subscription) do
-      create(:daily_subscription, search_criteria: search_criteria, expires_on: Time.zone.today - 1.day)
-    end
+    let!(:subscription) { create(:daily_subscription, expires_on: Time.zone.today - 1.day) }
 
     it 'deletes the subscription' do
       expect { perform_enqueued_jobs { job } }.to change { Subscription.all.count }.by(-1)
@@ -83,9 +73,7 @@ RSpec.describe SendDailyAlertEmailJob, type: :job do
   end
 
   context 'when a subscription is not expired' do
-    let!(:subscription) do
-      create(:daily_subscription, search_criteria: search_criteria, expires_on: Time.zone.today + 5.days)
-    end
+    let!(:subscription) { create(:daily_subscription, expires_on: Time.zone.today + 5.days) }
 
     it 'does not delete the subscription' do
       expect { perform_enqueued_jobs { job } }.to change { Subscription.all.count }.by(0)

--- a/spec/lib/geocoding_spec.rb
+++ b/spec/lib/geocoding_spec.rb
@@ -2,11 +2,6 @@ require 'rails_helper'
 require 'geocoding'
 
 RSpec.describe Geocoding do
-  before do
-    require 'geocoder'
-    Geocoder.configure(lookup: :test)
-  end
-
   context 'Retrieving the coordinates for a postcode' do
     it 'returns the correct value when the input is a valid postcode' do
       Geocoder::Lookup::Test.add_stub(
@@ -18,14 +13,15 @@ RSpec.describe Geocoding do
           }
         ]
       )
+
       geocoding = Geocoding.new('TS14 6RD')
       expect(geocoding.coordinates).to eq([-1.04577, 54.541098])
     end
 
     it 'returns [0,0] when the input is invalid' do
-      Geocoder::Lookup::Test.add_stub('TS14', [{}])
+      Geocoder::Lookup::Test.add_stub('invalid location', [{}])
 
-      geocoding = Geocoding.new('TS14')
+      geocoding = Geocoding.new('invalid location')
       expect(geocoding.coordinates).to eq([0, 0])
     end
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -4,14 +4,12 @@ RSpec.describe Subscription, type: :model do
   it { should have_many(:alert_runs) }
 
   context 'validations' do
+    it { should validate_presence_of(:email) }
+    it { should validate_presence_of(:reference) }
+    it { should validate_presence_of(:frequency) }
+    it { should validate_presence_of(:search_criteria) }
+
     context 'email' do
-      it 'ensures an email is set' do
-        subscription = Subscription.new
-
-        expect(subscription.valid?).to eq(false)
-        expect(subscription.errors.messages[:email]).to eq(['can\'t be blank'])
-      end
-
       it 'ensures a valid email address is used' do
         subscription = Subscription.new email: 'inv@al@.id.email.com'
 
@@ -23,11 +21,15 @@ RSpec.describe Subscription, type: :model do
     context 'unique index' do
       it 'validates uniqueness of email, expires_on, frequency and search_criteria' do
         create(:subscription, email: 'jane@doe.com',
-                              reference: 'A reference',
-                              frequency: :daily)
+                              expires_on: 3.months.from_now.to_date,
+                              frequency: :daily,
+                              search_criteria: { radius: 20, subject: 'English' },
+                              reference: 'A reference')
         subscription = build(:subscription, email: 'jane@doe.com',
-                                            reference: 'B reference',
-                                            frequency: :daily)
+                                            expires_on: 3.months.from_now.to_date,
+                                            frequency: :daily,
+                                            search_criteria: { radius: 20, subject: 'English' },
+                                            reference: 'B reference')
 
         expect(subscription.valid?).to eq(false)
         expect(subscription.errors.messages[:search_criteria]).to eq(['has already been taken'])

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ require 'rspec/rails'
 require 'factory_bot_rails'
 require 'database_cleaner_helper'
 require 'browser_test_helper'
+require 'geocoder_helper'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 

--- a/spec/services/subscription_finder_spec.rb
+++ b/spec/services/subscription_finder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SubscriptionFinder do
   end
 
   describe '#exists?' do
-    let(:params) { { email: 'foo@email.com', search_criteria: 'bar', frequency: 'daily' } }
+    let(:params) { { email: 'foo@email.com', search_criteria: { radius: 20 }.to_json, frequency: 'daily' } }
     context 'when there are no existing subscriptions' do
       it 'returns false' do
         service = described_class.new(params)
@@ -22,7 +22,7 @@ RSpec.describe SubscriptionFinder do
         create(
           :daily_subscription,
           email: 'foo@email.com',
-          search_criteria: 'bar',
+          search_criteria: { radius: 20 }.to_json,
           frequency: 'daily'
         )
       end


### PR DESCRIPTION
## Changes in this PR:

This makes `search_criteria` required on subscriptions.