### PR TITLE
[896] Map the Sidekiq docker container volume to the local filesystem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,9 @@ services:
       ELASTICSEARCH_URL: "http://elasticsearch:9200"
     env_file:
       - docker-compose.env
+    volumes:
+      - .:/srv/dfe-tvs:cached
+      - node_modules:/srv/dfe-tvs/node_modules
     command: bundle exec sidekiq -C config/sidekiq.yml
     depends_on:
       - redis_queue


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/WTaVNDMr/896-add-a-volume-to-the-sidekiq-docker-container