### PR TITLE
Amend job alert confirmation email and confirmation page text

### DIFF
--- a/app/helpers/notify_view_helper.rb
+++ b/app/helpers/notify_view_helper.rb
@@ -4,7 +4,7 @@ module NotifyViewHelper
   end
 
   def unsubscribe_link(token)
-    link_text = I18n.t('subscriptions.email.unsubscribe_link_text')
+    link_text = t('subscriptions.email.unsubscribe_link_text')
     notify_link(subscription_unsubscribe_url(subscription_id: token), link_text)
   end
 end

--- a/app/helpers/notify_view_helper.rb
+++ b/app/helpers/notify_view_helper.rb
@@ -4,7 +4,7 @@ module NotifyViewHelper
   end
 
   def unsubscribe_link(token)
-    link_text = t('subscriptions.email.unsubscribe_link_text')
+    link_text = I18n.t('subscriptions.email.unsubscribe_link_text')
     notify_link(subscription_unsubscribe_url(subscription_id: token), link_text)
   end
 end

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -3,13 +3,9 @@ class AlertMailer < ApplicationMailer
   add_template_helper(DateHelper)
 
   def daily_alert(subscription_id, vacancy_ids)
-    subscription = Subscription.find(subscription_id)
+    @subscription = Subscription.find(subscription_id)
     vacancies = Vacancy.where(id: vacancy_ids).order(:expires_on)
 
-    @email = subscription.email
-    @subscription_reference = subscription.reference
-    @expires_on = subscription.expires_on
-    @unsubscribe_token = subscription.token
     @vacancies = VacanciesPresenter.new(vacancies, searched: false)
 
     subject_key = if @vacancies.many?
@@ -20,8 +16,8 @@ class AlertMailer < ApplicationMailer
 
     view_mail(
       NOTIFY_SUBSCRIPTION_DAILY_TEMPLATE,
-      to: subscription.email,
-      subject: I18n.t(subject_key, reference: subscription.reference),
+      to: @subscription.email,
+      subject: I18n.t(subject_key, reference: @subscription.reference),
     )
   end
 end

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -1,11 +1,7 @@
 class SubscriptionMailer < ApplicationMailer
   def confirmation(subscription_id)
-    @subscription = Subscription.find(subscription_id)
-
-    @subscription_reference = @subscription.reference
-    @search_criteria = SubscriptionPresenter.new(@subscription).filtered_search_criteria
-    @expires_on = @subscription.expires_on
-    @unsubscribe_token = @subscription.token
+    subscription = Subscription.find(subscription_id)
+    @subscription = SubscriptionPresenter.new(subscription)
 
     view_mail(
       NOTIFY_SUBSCRIPTION_CONFIRMATION_TEMPLATE,

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -1,16 +1,16 @@
 class SubscriptionMailer < ApplicationMailer
   def confirmation(subscription_id)
-    subscription = Subscription.find(subscription_id)
+    @subscription = Subscription.find(subscription_id)
 
-    @subscription_reference = subscription.reference
-    @search_criteria = SubscriptionPresenter.new(subscription).filtered_search_criteria
-    @expires_on = subscription.expires_on
-    @unsubscribe_token = subscription.token
+    @subscription_reference = @subscription.reference
+    @search_criteria = SubscriptionPresenter.new(@subscription).filtered_search_criteria
+    @expires_on = @subscription.expires_on
+    @unsubscribe_token = @subscription.token
 
     view_mail(
       NOTIFY_SUBSCRIPTION_CONFIRMATION_TEMPLATE,
-      to: subscription.email,
-      subject: I18n.t('job_alerts.confirmation.email.subject', reference: subscription.reference),
+      to: @subscription.email,
+      subject: I18n.t('job_alerts.confirmation.email.subject', reference: @subscription.reference),
     )
   end
 end

--- a/app/views/alert_mailer/daily_alert.text.haml
+++ b/app/views/alert_mailer/daily_alert.text.haml
@@ -19,4 +19,4 @@ Visit #{notify_link('https://teaching-vacancies.service.gov.uk', t('app.title'))
 
 \---
 
-= t('subscriptions.email.unsubscribe_text_html', unsubscribe_link: unsubscribe_link(@unsubscribe_token))
+= t('subscriptions.email.unsubscribe_text_html', unsubscribe_link: unsubscribe_link(@subscription.token))

--- a/app/views/alert_mailer/daily_alert.text.haml
+++ b/app/views/alert_mailer/daily_alert.text.haml
@@ -15,7 +15,7 @@
   \---
   \
 \
-Visit #{notify_link('https://teaching-vacancies.service.gov.uk', t('app.title'))} -  the free service for schools in England to list teaching roles and for jobseekers to find them.
+Visit #{notify_link('https://teaching-vacancies.service.gov.uk', t('app.title'))} - the free service for schools in England to list teaching roles and for jobseekers to find them.
 
 \---
 

--- a/app/views/alert_mailer/daily_alert.text.haml
+++ b/app/views/alert_mailer/daily_alert.text.haml
@@ -1,5 +1,5 @@
 \# #{t('app.title')}
-\## #{t('job_alerts.alert.email.daily.summary', count: @vacancies.count)}
+\## #{t('job_alerts.alert.email.daily.summary', count: @vacancies.count, reference: @subscription.reference)}
 \
 \---
 \
@@ -15,8 +15,8 @@
   \---
   \
 \
-Visit #{notify_link('https://teaching-vacancies.service.gov.uk', t('app.title'))} - the free service for schools in England to list teaching roles and for jobseekers to find them.
+Visit #{notify_link('https://teaching-vacancies.service.gov.uk', t('app.title'))} -  the free service for schools in England to list teaching roles and for jobseekers to find them.
 
 \---
 
-= t('subscriptions.email.unsubscribe_text_html', unsubscribe_link: unsubscribe_link(@subscription.token))
+= t('job_alerts.alert.email.daily.unsubscribe', unsubscribe_link: unsubscribe_link(@subscription.token))

--- a/app/views/alert_mailer/daily_alert.text.haml
+++ b/app/views/alert_mailer/daily_alert.text.haml
@@ -19,4 +19,4 @@ Visit #{notify_link('https://teaching-vacancies.service.gov.uk', t('app.title'))
 
 \---
 
-= t('subscriptions.email.unsubscribe_text_html', link: unsubscribe_link(@unsubscribe_token))
+= t('subscriptions.email.unsubscribe_text_html', unsubscribe_link: unsubscribe_link(@unsubscribe_token))

--- a/app/views/subscription_mailer/confirmation.text.haml
+++ b/app/views/subscription_mailer/confirmation.text.haml
@@ -12,4 +12,4 @@
 
 \---
 
-= t('subscriptions.email.unsubscribe_link_text', unsubscribe_link: unsubscribe_link(@subscription.token))
+= unsubscribe_link(@subscription.token)

--- a/app/views/subscription_mailer/confirmation.text.haml
+++ b/app/views/subscription_mailer/confirmation.text.haml
@@ -1,13 +1,13 @@
 \# #{t('app.title')}
-\## #{t('subscriptions.email.confirmation.subject', reference: @subscription_reference)}
+\## #{t('subscriptions.email.confirmation.subject', reference: @subscription.reference)}
 \
 = t('subscriptions.email.confirmation.subheading', email: @subscription.email)
 \
-- @search_criteria.each_pair do |k, v|
+- @subscription.filtered_search_criteria.each_pair do |k, v|
   * #{[k&.titleize, v].reject(&:blank?).join(': ')}
 \
-= t('subscriptions.email.confirmation.expiry_text_html', date: l(@expires_on))
+= t('subscriptions.email.confirmation.expiry_text_html', date: l(@subscription.expires_on))
 
 \---
 
-= t('subscriptions.email.unsubscribe_text_html', unsubscribe_link: unsubscribe_link(@unsubscribe_token))
+= t('subscriptions.email.unsubscribe_text_html', unsubscribe_link: unsubscribe_link(@subscription.token))

--- a/app/views/subscription_mailer/confirmation.text.haml
+++ b/app/views/subscription_mailer/confirmation.text.haml
@@ -6,8 +6,10 @@
 - @subscription.filtered_search_criteria.each_pair do |k, v|
   * #{[k&.titleize, v].reject(&:blank?).join(': ')}
 \
-= t('subscriptions.email.confirmation.expiry_text_html', date: l(@subscription.expires_on))
+= t('subscriptions.next_steps')
+\
+= t('subscriptions.email.unsubscribe_text_html')
 
 \---
 
-= t('subscriptions.email.unsubscribe_text_html', unsubscribe_link: unsubscribe_link(@subscription.token))
+= t('subscriptions.email.unsubscribe_link_text', unsubscribe_link: unsubscribe_link(@subscription.token))

--- a/app/views/subscription_mailer/confirmation.text.haml
+++ b/app/views/subscription_mailer/confirmation.text.haml
@@ -1,5 +1,5 @@
 \# #{t('app.title')}
-\## #{t('subscriptions.email.confirmation.subject', reference: @subscription.reference)}
+\## #{t('subscriptions.email.confirmation.heading', reference: @subscription.reference)}
 \
 = t('subscriptions.email.confirmation.subheading', email: @subscription.email)
 \

--- a/app/views/subscription_mailer/confirmation.text.haml
+++ b/app/views/subscription_mailer/confirmation.text.haml
@@ -1,13 +1,13 @@
 \# #{t('app.title')}
-\# #{@subscription_reference}
+\## #{t('subscriptions.email.confirmation.subject', reference: @subscription_reference)}
 \
-= t('subscriptions.email.confirmation.subheading')
+= t('subscriptions.email.confirmation.subheading', email: @subscription.email)
 \
 - @search_criteria.each_pair do |k, v|
   * #{[k&.titleize, v].reject(&:blank?).join(': ')}
 \
-= t('subscriptions.email.confirmation.expiry_text_html', distance: '6 months', date: l(@expires_on))
+= t('subscriptions.email.confirmation.expiry_text_html', date: l(@expires_on))
 
 \---
 
-= t('subscriptions.email.unsubscribe_text_html', link: unsubscribe_link(@unsubscribe_token))
+= t('subscriptions.email.unsubscribe_text_html', unsubscribe_link: unsubscribe_link(@unsubscribe_token))

--- a/app/views/subscriptions/confirm.html.haml
+++ b/app/views/subscriptions/confirm.html.haml
@@ -3,16 +3,15 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     .govuk-panel.govuk-panel--confirmation
-      %h1.govuk-panel__title= t('subscriptions.confirmation.header')
+      %h1.govuk-panel__title= t('subscriptions.confirmation.header').html_safe
       .govuk-panel__body
         = t('subscriptions.reference')
-        %br
-        %strong= @subscription.reference
+        %strong= "'#{@subscription.reference}'"
 
     %p.govuk-body=t('subscriptions.confirmation.receipt_confirmation')
 
     %h3.govuk-heading-m=t('subscriptions.confirmation.next_step')
-    %p.govuk-body=t('subscriptions.confirmation.next_step_details', email: @subscription.email, date: l(@subscription.expires_on))
+    %p.govuk-body=t('subscriptions.confirmation.next_step_details', email: @subscription.email)
     %div.govuk-inset-text
       %ul.govuk-list
         - @subscription.filtered_search_criteria.each_pair do |filter, value|
@@ -21,6 +20,6 @@
               %span{ class: 'govuk-!-font-weight-bold'} #{filter.humanize}:
             = value
 
-    %p.govuk-body= t('subscriptions.confirmation.unsubscribe')
+    %p.govuk-body= t('subscriptions.confirmation.unsubscribe', date: l(@subscription.expires_on))
     %p.govuk-body
       = link_to t('subscriptions.back_to_search_results'), root_path(@subscription.search_criteria_to_h), class: 'govuk-link'

--- a/app/views/subscriptions/confirm.html.haml
+++ b/app/views/subscriptions/confirm.html.haml
@@ -5,13 +5,12 @@
     .govuk-panel.govuk-panel--confirmation
       %h1.govuk-panel__title= t('subscriptions.confirmation.header').html_safe
       .govuk-panel__body
-        = t('subscriptions.reference')
-        %strong= "'#{@subscription.reference}'"
+        %strong= t('subscriptions.confirmation.reference', reference: @subscription.reference)
 
-    %p.govuk-body=t('subscriptions.confirmation.receipt_confirmation')
+    %p.govuk-body=t('subscriptions.confirmation.receipt_confirmation', email: @subscription.email)
 
     %h3.govuk-heading-m=t('subscriptions.confirmation.next_step')
-    %p.govuk-body=t('subscriptions.confirmation.next_step_details', email: @subscription.email)
+    %p.govuk-body=t('subscriptions.confirmation.next_step_details')
     %div.govuk-inset-text
       %ul.govuk-list
         - @subscription.filtered_search_criteria.each_pair do |filter, value|
@@ -20,6 +19,7 @@
               %span{ class: 'govuk-!-font-weight-bold'} #{filter.humanize}:
             = value
 
-    %p.govuk-body= t('subscriptions.confirmation.unsubscribe', date: l(@subscription.expires_on))
+    %p.govuk-body=t('subscriptions.next_steps')
+    %p.govuk-body= t('subscriptions.confirmation.unsubscribe')
     %p.govuk-body
       = link_to t('subscriptions.back_to_search_results'), root_path(@subscription.search_criteria_to_h), class: 'govuk-link'

--- a/app/views/subscriptions/confirm.html.haml
+++ b/app/views/subscriptions/confirm.html.haml
@@ -3,7 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     .govuk-panel.govuk-panel--confirmation
-      %h1.govuk-panel__title= t('subscriptions.confirmation.header').html_safe
+      %h1.govuk-panel__title= t('subscriptions.confirmation.header')
       .govuk-panel__body
         %strong= t('subscriptions.confirmation.reference', reference: @subscription.reference)
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -33,6 +33,7 @@
               - if filter.present?
                 %span{ class: 'govuk-!-font-weight-bold'} #{filter.humanize}:
               = value
+      %p.govuk-body-l=t('subscriptions.next_steps')
       = f.input :email, as: :email, input_html: { class: 'govuk-input' }, required: true
       = f.input :reference, as: :string, input_html: { class: 'govuk-input', placeholder: 'e.g. Maths jobs within 20 miles of Oxford' }
 

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -71,4 +71,5 @@ en:
         reference: Your reference
     hints:
       defaults:
-        reference: This text will appear in the subject line of the email we send you when a new job matches your criteria. Feel free to change it.
+        email: Enter your email address. We'll only use it to send you job alerts.
+        reference: This text will appear in the subject line of emails for this job alert subscription. Feel free to change it.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,6 +323,7 @@ en:
       unsubscribe_link_text: "Unsubscribe here"
       confirmation:
         subject: "Teaching Vacancies job alert confirmation for '%{reference}'"
+        heading: "You have subscribed to a job alert for '%{reference}'."
         subheading: 'We’ll email you details of any new jobs that match the following search criteria:'
         expiry_text_html: "Your job alert subscription will end on %{date}."
     manage: Manage your subscription

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -338,9 +338,9 @@ en:
             one: "Teaching Vacancies job alert for '%{reference}'"
             many: "Teaching Vacancies job alerts for '%{reference}'"
           summary:
-            one: "A new job matching your search criteria was posted yesterday."
-            other: "%{count} new jobs matching your search criteria were posted yesterday."
-          unsubscribe: Follow this link to unsubscribe.
+            one: "A new job matching your search criteria '%{reference}' was posted yesterday."
+            other: "%{count} new jobs matching your search criteria '%{reference}' were posted yesterday."
+          unsubscribe: Don’t want to receive these email alerts? <a href= '%{unsubscribe_link}'>Unsubscribe here.</a>
   terms_and_conditions:
     page_title: 'Terms and Conditions'
     intro: 'Before listing any role at your school on Teaching Vacancies you must first read our Terms and Conditions and agree to abide by them.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -301,13 +301,13 @@ en:
     new: Sign up for a job alert
     info: Subscribers will be emailed new listings that match their search criteria. Subscriptions expire after 6 months or can be cancelled using the link at the bottom of alert emails.
     location_text: Within %{radius} miles of %{location}
-    reference: 'Your reference:'
+    reference: 'for'
     confirmation:
-      header: Your email subscription has started
+      header: 'You have subscribed to <span class="nobreak">a job alert</span>'
       receipt_confirmation: We have sent you a confirmation email.
       next_step: 'What happens next'
-      unsubscribe: "You can unsubscribe from this subscription at any time by following the 'stop receiving emails for this search' link in the email."
-      next_step_details: 'We will run a search matching your search criteria and send a daily email with the results to %{email} for the next 6 months, until %{date}.'
+      unsubscribe: "Your job alert subscription will end on %{date}. You can unsubscribe from or renew your subscription by following the links at the end of any job alert email."
+      next_step_details: 'Job details will be emailed to %{email} on any day when 1 or more new jobs matching the following criteria are published:'
     deletion:
       title: Subscription deleted
       header: Your email subscription has been deleted
@@ -317,11 +317,12 @@ en:
       resubscribe_link_text: resubscribe here
     back_to_search_results: 'Return to your search results'
     email:
-      unsubscribe_text_html: "Don't want to receive these email alerts? %{link}"
-      unsubscribe_link_text: Unsubscribe here
+      unsubscribe_text_html: "You can %{unsubscribe_link} from job alerts or renew your subscription at any time. "
+      unsubscribe_link_text: unsubscribe
       confirmation:
-        subheading: 'You have subscribed to email notifications for jobs that match the following search criteria:'
-        expiry_text_html: Your subscription will expire in %{distance}, on the %{date}.
+        subject: "You have subscribed to a job alert for '%{reference}'"
+        subheading: 'Job details will be emailed to %{email} on any day when 1 or more new jobs matching the following criteria are published to Teaching Vacancies:'
+        expiry_text_html: 'Your job alert subscription will end on %{date}.'
     manage: Manage your subscription
     unsubscribe: Unsubscribe
   job_alerts:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,17 +297,19 @@ en:
           - 'end date (for fixed-term jobs)'
   subscriptions:
     button: 'Sign up for a job alert matching your search'
-    intro: 'You’ll be sent an email listing new jobs that match the following search criteria:'
+    intro: 'We’ll email you details of any new jobs that match the following search criteria:'
     new: Sign up for a job alert
-    info: Subscribers will be emailed new listings that match their search criteria. Subscriptions expire after 6 months or can be cancelled using the link at the bottom of alert emails.
+    info: You can unsubscribe at any time using the link at the bottom of any email you receive for this job alert.
     location_text: Within %{radius} miles of %{location}
     reference: 'for'
+    next_steps: "You'll receive a single job alert email at the end of any day when 1 or more matching jobs are first published."
     confirmation:
-      header: 'You have subscribed to <span class="nobreak">a job alert</span>'
-      receipt_confirmation: We have sent you a confirmation email.
+      header: 'Your email subscription has started'
+      receipt_confirmation: We have sent a confirmation email to %{email}.
       next_step: 'What happens next'
-      unsubscribe: "Your job alert subscription will end on %{date}. You can unsubscribe from or renew your subscription by following the links at the end of any job alert email."
-      next_step_details: 'Job details will be emailed to %{email} on any day when 1 or more new jobs matching the following criteria are published:'
+      reference: 'Your reference: %{reference}'
+      unsubscribe: "You can unsubscribe by following the link at the bottom of these emails."
+      next_step_details: 'We’ll email you details of any new jobs that match the following search criteria:'
     deletion:
       title: Subscription deleted
       header: Your email subscription has been deleted

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,7 +320,7 @@ en:
     back_to_search_results: 'Return to your search results'
     email:
       unsubscribe_text_html: "You can unsubscribe by following the link at the bottom of these emails."
-      unsubscribe_link_text: "%{unsubscribe_link}"
+      unsubscribe_link_text: "Unsubscribe here"
       confirmation:
         subject: "Teaching Vacancies job alert confirmation for '%{reference}'"
         subheading: 'We’ll email you details of any new jobs that match the following search criteria:'
@@ -340,7 +340,7 @@ en:
           summary:
             one: "A new job matching your search criteria '%{reference}' was posted yesterday."
             other: "%{count} new jobs matching your search criteria '%{reference}' were posted yesterday."
-          unsubscribe: Don’t want to receive these email alerts? <a href= '%{unsubscribe_link}'>Unsubscribe here.</a>
+          unsubscribe: Don’t want to receive these email alerts? %{unsubscribe_link}
   terms_and_conditions:
     page_title: 'Terms and Conditions'
     intro: 'Before listing any role at your school on Teaching Vacancies you must first read our Terms and Conditions and agree to abide by them.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -319,12 +319,12 @@ en:
       resubscribe_link_text: resubscribe here
     back_to_search_results: 'Return to your search results'
     email:
-      unsubscribe_text_html: "You can %{unsubscribe_link} from job alerts or renew your subscription at any time. "
-      unsubscribe_link_text: unsubscribe
+      unsubscribe_text_html: "You can unsubscribe by following the link at the bottom of these emails."
+      unsubscribe_link_text: "%{unsubscribe_link}"
       confirmation:
-        subject: "You have subscribed to a job alert for '%{reference}'"
-        subheading: 'Job details will be emailed to %{email} on any day when 1 or more new jobs matching the following criteria are published to Teaching Vacancies:'
-        expiry_text_html: 'Your job alert subscription will end on %{date}.'
+        subject: "Teaching Vacancies job alert confirmation for '%{reference}'"
+        subheading: 'We’ll email you details of any new jobs that match the following search criteria:'
+        expiry_text_html: "Your job alert subscription will end on %{date}."
     manage: Manage your subscription
     unsubscribe: Unsubscribe
   job_alerts:

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
-        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
+        expect(page.html).to include(I18n.t('subscriptions.confirmation.header'))
       end
 
       scenario 'when the email address is associated with other active subscriptions' do
@@ -56,7 +56,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
-        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
+        expect(page.html).to include(I18n.t('subscriptions.confirmation.header'))
       end
 
       scenario 'when the email address is associated with the same inactive subscriptions' do
@@ -68,7 +68,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
-        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
+        expect(page.html).to include(I18n.t('subscriptions.confirmation.header'))
       end
 
       scenario 'when no reference is set' do
@@ -76,7 +76,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
-        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
+        expect(page.html).to include(I18n.t('subscriptions.confirmation.header'))
       end
 
       context 'and is redirected to the confirmation page' do
@@ -86,7 +86,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
           fill_in 'subscription[reference]', with: 'Daily alert reference'
           click_on 'Subscribe'
 
-          expect(page).to have_content(/Your reference: Daily alert reference/)
+          expect(page).to have_content(/Daily alert reference/)
         end
 
         scenario 'where they can go back to the filtered search' do
@@ -155,7 +155,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
       expect(message_delivery).to receive(:deliver_later)
       click_on 'Subscribe'
 
-      expect(page).to have_content('Your email subscription has started')
+      expect(page.html).to include(I18n.t('subscriptions.confirmation.header'))
       click_on 'Return to your search results'
 
       expect(page).to have_content('3 jobs match your search')

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
-        expect(page.html).to include(I18n.t('subscriptions.confirmation.header'))
+        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
       end
 
       scenario 'when the email address is associated with other active subscriptions' do
@@ -56,7 +56,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
-        expect(page.html).to include(I18n.t('subscriptions.confirmation.header'))
+        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
       end
 
       scenario 'when the email address is associated with the same inactive subscriptions' do
@@ -68,7 +68,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
-        expect(page.html).to include(I18n.t('subscriptions.confirmation.header'))
+        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
       end
 
       scenario 'when no reference is set' do
@@ -76,7 +76,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
-        expect(page.html).to include(I18n.t('subscriptions.confirmation.header'))
+        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
       end
 
       context 'and is redirected to the confirmation page' do
@@ -155,7 +155,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
       expect(message_delivery).to receive(:deliver_later)
       click_on 'Subscribe'
 
-      expect(page.html).to include(I18n.t('subscriptions.confirmation.header'))
+      expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
       click_on 'Return to your search results'
 
       expect(page).to have_content('3 jobs match your search')

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe AlertMailer, type: :mailer do
         expect(mail.to).to eq([subscription.email])
 
         expect(body).to match(/# #{I18n.t('app.title')}/)
-        expect(body).to match(/# #{I18n.t('job_alerts.alert.email.daily.summary.one')}/)
+        expect(body).to match(
+          /A new job matching your search criteria &#39;#{subscription.reference}&#39; was posted yesterday/
+        )
         expect(body).to match(/---/)
         expect(body).to match(/#{Regexp.escape(vacancy_presenter.share_url(campaign_params))}/)
         expect(body).to match(/#{vacancy_presenter.location}/)
@@ -45,6 +47,9 @@ RSpec.describe AlertMailer, type: :mailer do
         expect(body).to match(/#{vacancy_presenter.working_patterns}/)
 
         expect(body).to match(/#{format_date(vacancy_presenter.expires_on)}/)
+        expect(body).to match(
+          /Don&#39;t want to receive these email alerts? Unsubscribe here/
+        )
       end
     end
 

--- a/spec/mailers/subscription_spec.rb
+++ b/spec/mailers/subscription_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe SubscriptionMailer, type: :mailer do
 
   after(:each) { Timecop.return }
 
+  let(:email) { 'an@email.com' }
   let(:subscription) do
-    subscription = create(:daily_subscription, email: 'an@email.com',
+    subscription = create(:daily_subscription, email: email,
                                                reference: 'a-reference',
                                                search_criteria: {
                                                  subject: 'English',
@@ -31,8 +32,8 @@ RSpec.describe SubscriptionMailer, type: :mailer do
     expect(mail.subject).to eq(I18n.t('job_alerts.confirmation.email.subject', reference: subscription.reference))
     expect(mail.to).to eq([subscription.email])
     expect(body_lines[0]).to match(/# #{I18n.t('app.title')}/)
-    expect(body_lines[1]).to match(/# #{subscription.reference}/)
-    expect(body_lines[3]).to match(/#{I18n.t('subscriptions.email.confirmation.subheading')}/)
+    expect(body_lines[1]).to match(/You have subscribed to a job alert for &#39;#{subscription.reference}&#39;/)
+    expect(body_lines[3]).to match(/#{I18n.t('subscriptions.email.confirmation.subheading', email: email)}/)
     expect(body_lines[5]).to match(/\* Subject: English/)
     expect(body_lines[6]).to match(/\* Minimum Salary: £20,000/)
     expect(body_lines[7]).to match(/\* Maximum Salary: £40,000/)

--- a/spec/mailers/subscription_spec.rb
+++ b/spec/mailers/subscription_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe SubscriptionMailer, type: :mailer do
     expect(mail.subject).to eq(I18n.t('job_alerts.confirmation.email.subject', reference: subscription.reference))
     expect(mail.to).to eq([subscription.email])
     expect(body_lines[0]).to match(/# #{I18n.t('app.title')}/)
-    expect(body_lines[1]).to match(/Teaching Vacancies job alert confirmation for &#39;#{subscription.reference}&#39;/)
+    expect(body_lines[1]).to match(
+      /#{escape_single_quotes(I18n.t('subscriptions.email.confirmation.heading', reference: subscription.reference))}/
+    )
     expect(body_lines[3]).to match(/#{I18n.t('subscriptions.email.confirmation.subheading', email: email)}/)
     expect(body_lines[5]).to match(/\* Subject: English/)
     expect(body_lines[6]).to match(/\* Minimum Salary: £20,000/)
@@ -44,5 +46,9 @@ RSpec.describe SubscriptionMailer, type: :mailer do
   it 'has an unsubscribe link' do
     expect(body_lines[12]).to match(/#{I18n.t('subscriptions.email.unsubscribe_text_html')}/)
     expect(body_lines[14]).to match(%r{http:\/\/localhost:3000\/subscriptions\/#{subscription.token}\/unsubscribe})
+  end
+
+  def escape_single_quotes(unescaped_string)
+    ERB::Util.html_escape(unescaped_string)
   end
 end

--- a/spec/mailers/subscription_spec.rb
+++ b/spec/mailers/subscription_spec.rb
@@ -32,16 +32,17 @@ RSpec.describe SubscriptionMailer, type: :mailer do
     expect(mail.subject).to eq(I18n.t('job_alerts.confirmation.email.subject', reference: subscription.reference))
     expect(mail.to).to eq([subscription.email])
     expect(body_lines[0]).to match(/# #{I18n.t('app.title')}/)
-    expect(body_lines[1]).to match(/You have subscribed to a job alert for &#39;#{subscription.reference}&#39;/)
+    expect(body_lines[1]).to match(/Teaching Vacancies job alert confirmation for &#39;#{subscription.reference}&#39;/)
     expect(body_lines[3]).to match(/#{I18n.t('subscriptions.email.confirmation.subheading', email: email)}/)
     expect(body_lines[5]).to match(/\* Subject: English/)
     expect(body_lines[6]).to match(/\* Minimum Salary: £20,000/)
     expect(body_lines[7]).to match(/\* Maximum Salary: £40,000/)
     expect(body_lines[8]).to match(/\Suitable for NQTs/)
-    expect(body_lines[10]).to match(/1 April 2019/)
+    expect(body_lines[10]).to include('You&#39;ll receive a single job alert email at the end of any day')
   end
 
   it 'has an unsubscribe link' do
-    expect(body_lines[12]).to match(%r{http:\/\/localhost:3000\/subscriptions\/#{subscription.token}\/unsubscribe})
+    expect(body_lines[12]).to match(/You can unsubscribe by following the link at the bottom of these emails./)
+    expect(body_lines[14]).to match(%r{http:\/\/localhost:3000\/subscriptions\/#{subscription.token}\/unsubscribe})
   end
 end

--- a/spec/mailers/subscription_spec.rb
+++ b/spec/mailers/subscription_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SubscriptionMailer, type: :mailer do
   end
 
   it 'has an unsubscribe link' do
-    expect(body_lines[12]).to match(/You can unsubscribe by following the link at the bottom of these emails./)
+    expect(body_lines[12]).to match(/#{I18n.t('subscriptions.email.unsubscribe_text_html')}/)
     expect(body_lines[14]).to match(%r{http:\/\/localhost:3000\/subscriptions\/#{subscription.token}\/unsubscribe})
   end
 end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/AfFF070i/870-amend-job-alert-confirmation-email-and-confirmation-page-text

## Changes in this PR:

Tweaks some of the content in the job alert confirmation email to: 

- confirm that link at bottom offers both unsubscribe and resubscribe
- fix the representation of the expiry date ("the 2 of November" is incorrect)
- make sure it refers to 'job alerts' rather than 'email notifications'

The confirmation page text has also been tweaked.