### PR TITLE
Remove remote working as an option

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -6,8 +6,7 @@ class Vacancy < ApplicationRecord
     'part_time' => 100,
     'job_share' => 101,
     'compressed_hours' => 102,
-    'staggered_hours' => 104,
-    'remote_working' => 103
+    'staggered_hours' => 103
   }.freeze
 
   WORKING_PATTERN_OPTIONS = {

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -230,20 +230,20 @@ RSpec.describe Api::VacanciesController, type: :controller do
           expect(json.to_h).to include('employmentType': 'COMPRESSED_HOURS')
         end
 
-        it 'maps remote_working working pattern to REMOTE_WORKING' do
-          vacancy = create(:vacancy, working_patterns: ['remote_working'])
+        it 'maps staggered_hours working pattern to STAGGERED_HOURS' do
+          vacancy = create(:vacancy, working_patterns: ['staggered_hours'])
 
           get :show, params: { id: vacancy.id, api_version: 1 }
 
-          expect(json.to_h).to include('employmentType': 'REMOTE_WORKING')
+          expect(json.to_h).to include('employmentType': 'STAGGERED_HOURS')
         end
 
         it 'maps multiple values to an array' do
-          vacancy = create(:vacancy, working_patterns: ['part_time', 'job_share', 'remote_working'])
+          vacancy = create(:vacancy, working_patterns: ['part_time', 'job_share', 'staggered_hours'])
 
           get :show, params: { id: vacancy.id, api_version: 1 }
 
-          expect(json.to_h).to include('employmentType': 'PART_TIME, JOB_SHARE, REMOTE_WORKING')
+          expect(json.to_h).to include('employmentType': 'PART_TIME, JOB_SHARE, STAGGERED_HOURS')
         end
       end
 

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe VacanciesHelper, type: :helper do
           ['Part-time', 'part_time'],
           ['Job share', 'job_share'],
           ['Compressed hours', 'compressed_hours'],
-          ['Staggered hours', 'staggered_hours'],
-          ['Remote working', 'remote_working']
+          ['Staggered hours', 'staggered_hours']
         ]
       )
     end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/4owuXmAO/762-update-working-pattern-options-so-there-is-more-flexibility-around-types-of-role-reflecting-the-needs-of-jobseekers-schools

## Changes in this PR:

Remove remote working as an option. The guidance includes it as a footnote, but suggests that it's uncommon. We think that including it would be misleading without further explanation.