### PR TITLE
[881] Remove phase to phases task & terraform

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -6,23 +6,4 @@ namespace :data do
       UpdateSchoolsDataFromSourceJob.perform_later
     end
   end
-
-  desc 'Migrate subscription search criteria phase'
-  namespace :phase do
-    task migrate: :environment do
-      Rails.logger.debug("Running subscription search criteria phase migration task in #{Rails.env}")
-
-      Subscription.all.each do |subscription|
-        search_criteria = subscription.search_criteria_to_h
-
-        next unless search_criteria.key?('phase')
-        next if search_criteria.key?('phases')
-
-        search_criteria['phases'] = [search_criteria['phase']]
-        search_criteria.delete('phase')
-
-        subscription.update!(search_criteria: search_criteria.to_json)
-      end
-    end
-  end
 end

--- a/terraform.tf
+++ b/terraform.tf
@@ -105,8 +105,6 @@ module "ecs" {
   performance_platform_submit_task_schedule    = "${var.performance_platform_submit_task_schedule}"
   performance_platform_submit_all_task_command = "${var.performance_platform_submit_all_task_command}"
 
-  migrate_phase_to_phases_task_command = "${var.migrate_phase_to_phases_task_command}"
-
   migrate_working_pattern_task_command = "${var.migrate_working_pattern_task_command}"
 
   vacancies_statistics_refresh_cache_task_command  = "${var.vacancies_statistics_refresh_cache_task_command}"

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -465,18 +465,6 @@ module "seed_vacancies_from_api_task" {
   task_role_arn      = "${aws_iam_role.ecs_execution_role.arn}"
 }
 
-module "migrate_phase_to_phases_task" {
-  source = "../ecs-task"
-
-  task_name    = "${var.ecs_service_web_task_name}_migrate_phase_to_phases"
-  task_command = "${var.migrate_phase_to_phases_task_command}"
-
-  container_definition_template = "${module.rake_container_definition.template}"
-
-  execution_role_arn = "${aws_iam_role.ecs_execution_role.arn}"
-  task_role_arn      = "${aws_iam_role.ecs_execution_role.arn}"
-}
-
 module "migrate_working_pattern_task" {
   source = "../ecs-task"
 

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -128,10 +128,6 @@ variable "performance_platform_submit_all_task_command" {
   type = "list"
 }
 
-variable "migrate_phase_to_phases_task_command" {
-  type = "list"
-}
-
 variable "migrate_working_pattern_task_command" {
   type = "list"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -219,11 +219,6 @@ variable "performance_platform_submit_all_task_command" {
   default     = ["rake", "verbose", "performance_platform:submit_data_up_to_today"]
 }
 
-variable "migrate_phase_to_phases_task_command" {
-  description = "The Entrypoint for the migrate_phase_to_phases task"
-  default     = ["rake", "verbose", "data:phase:migrate"]
-}
-
 variable "migrate_working_pattern_task_command" {
   description = "The Entrypoint for the migrate_working_pattern task"
   default     = ["rake", "verbose", "data:working_pattern:migrate"]


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/kYAoaHDI/881-remove-the-phase-to-phases-migration-rake-task-and-related-terraform

## Changes in this PR:
- Remove `rake data:phase:migrate` task.
- Remove related terraform 

## Next steps:

- [ ] Deploy terraform
