### PR TITLE
(fix) Don't run a transaction around :all tests

### DIFF
--- a/spec/database_cleaner_helper.rb
+++ b/spec/database_cleaner_helper.rb
@@ -21,12 +21,4 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
-
-  config.before(:all) do
-    DatabaseCleaner.start
-  end
-
-  config.after(:all) do
-    DatabaseCleaner.clean
-  end
 end

--- a/spec/presenters/school_vacancies_presenter_spec.rb
+++ b/spec/presenters/school_vacancies_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 RSpec.describe SchoolVacanciesPresenter do
-  before(:all) do
+  before do
     @school = create(:school)
     @draft_vacancies = create_list(:vacancy, 5, :draft, school: @school)
     @pending_vacancies = create_list(:vacancy, 4, :future_publish, school: @school)


### PR DESCRIPTION
The previous configuration of the Database Cleaner meant that a
transaction was opened before every test suite, including ones with JS
tests.

This open transaction was preventing the TRUNCATION (also configured
by the database cleaner) inside the JS test from completing, causing a
deadlock + timeout from inside the JS test.

![2C131ADC-7026-44DC-BE77-09C11D42F7B3](https://user-images.githubusercontent.com/976274/59027767-cd52e080-8851-11e9-81e3-84773b61c62f.jpeg)

## Trello card URL:
https://trello.com/c/6RlYb1Cf/922-update-databasecleaner-helper-to-support-enabling-javascript-for-capybara-tests
