### PR TITLE
(fix) remove data-module attribute from tabs

### DIFF
--- a/app/views/hiring_staff/schools/_vacancies.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies.html.haml
@@ -1,4 +1,4 @@
-.govuk-tabs{"data-module" => "tabs"}
+.govuk-tabs
   %h2.govuk-tabs__title
     = t('aria_labels.content')
   %ul.govuk-tabs__list.tab-list{ class: 'govuk-!-margin-top-6' }


### PR DESCRIPTION
The data-module attribute on the tab element for vacancy listings on a
school page was encountering a null attribute error from the gov uk
frontend JS.

This fix removes the attribute as the tabs are only used for their
visual appearence. The frontent toolkit JS functionality adds the
ability to switch which panel is visible, but this isn't used as we
reload the panel using AJAX instead.
