### PR TITLE
Remove changes to the schema.rb which shouldn't be in develop yet

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,17 +57,6 @@ ActiveRecord::Schema.define(version: 2019_06_18_091607) do
     t.index ["code"], name: "index_detailed_school_types_on_code", unique: true
   end
 
-  create_table "expired_vacancy_feedbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "vacancy_id"
-    t.integer "listed_elsewhere"
-    t.integer "hired_status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.uuid "user_id"
-    t.index ["user_id"], name: "index_expired_vacancy_feedbacks_on_user_id"
-    t.index ["vacancy_id"], name: "index_expired_vacancy_feedbacks_on_vacancy_id", unique: true
-  end
-
   create_table "friendly_id_slugs", force: :cascade do |t|
     t.string "slug", null: false
     t.uuid "sluggable_id", null: false
@@ -220,8 +209,6 @@ ActiveRecord::Schema.define(version: 2019_06_18_091607) do
     t.datetime "total_get_more_info_clicks_updated_at"
     t.integer "working_patterns", array: true
     t.boolean "pro_rata_salary"
-    t.integer "listed_elsewhere"
-    t.integer "hired_status"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"
     t.index ["leadership_id"], name: "index_vacancies_on_leadership_id"


### PR DESCRIPTION
They were introduced by d85e0ae1dc0180683993cd2247f4ed3254743ff4
because the machine `db:migrate` was run on had other schema changes
from other commits not yet merged into develop.