### PR TITLE
(Fix) Implement UI changes from staging review for jobs awaiting feedback tab

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,7 @@ $govuk-image-url-function: 'image-url';
 @import 'components/select';
 @import 'components/tabs';
 @import 'components/checkboxes';
+@import 'components/awaiting_feedback_vacancies';
 @import 'ie';
 
 input[type='search'] {

--- a/app/assets/stylesheets/components/awaiting_feedback_vacancies.scss
+++ b/app/assets/stylesheets/components/awaiting_feedback_vacancies.scss
@@ -1,0 +1,3 @@
+.job-title-table-header {
+  width: 195px;
+}

--- a/app/views/hiring_staff/schools/_vacancies_awaiting_feedback.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_awaiting_feedback.html.haml
@@ -9,7 +9,7 @@
     %table{class: 'vacancies govuk-table govuk-!-margin-top-4', id: 'awaiting_feedback'}
       %thead.govuk-table__head
         %tr.govuk-table__row
-          %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'awaiting_feedback', column: 'job_title', sort: @sort)
+          %th{class: 'govuk-table__header job-title-table-header'}= table_header_sort_by(t('jobs.job_title'), 'awaiting_feedback', column: 'job_title', sort: @sort)
           %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), 'awaiting_feedback', column: 'publish_on', sort: @sort)
           %th.govuk-table__header= table_header_sort_by(t('jobs.expired_on'), 'awaiting_feedback', column: 'expires_on', sort: @sort)
           %th{class: 'govuk-table__header govuk-!-width-one-quarter'}= t('jobs.job_filled')

--- a/app/views/hiring_staff/schools/_vacancies_awaiting_feedback.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_awaiting_feedback.html.haml
@@ -2,22 +2,22 @@
 %section.govuk-tabs__panel
   %h2.govuk-heading-m= t('jobs.awaiting_feedback_jobs')
 
-  %p.govuk-body#awaiting_feedback_intro=t('jobs.awaiting_feedback_intro')
-
   - if presenter.vacancies.any?
+
+    %p.govuk-body#awaiting_feedback_intro=t('jobs.awaiting_feedback_intro')
 
     %table{class: 'vacancies govuk-table govuk-!-margin-top-4', id: 'awaiting_feedback'}
       %thead.govuk-table__head
         %tr.govuk-table__row
-          %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'expired', column: 'job_title', sort: @sort)
-          %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), 'expired', column: 'publish_on', sort: @sort)
-          %th.govuk-table__header= table_header_sort_by(t('jobs.expired_on'), 'expired', column: 'expires_on', sort: @sort)
-          %th.govuk-table__header= t('jobs.job_filled')
-          %th.govuk-table__header= t('jobs.listed_elsewhere')
+          %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'awaiting_feedback', column: 'job_title', sort: @sort)
+          %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), 'awaiting_feedback', column: 'publish_on', sort: @sort)
+          %th.govuk-table__header= table_header_sort_by(t('jobs.expired_on'), 'awaiting_feedback', column: 'expires_on', sort: @sort)
+          %th{class: 'govuk-table__header govuk-!-width-one-quarter'}= t('jobs.job_filled')
+          %th{class: 'govuk-table__header govuk-!-width-one-quarter'}= t('jobs.listed_elsewhere')
           %th.govuk-table__header= t('jobs.actions')
       %tbody.govuk-table__body
         - presenter.vacancies.each do |vacancy|
           = render partial: 'vacancy_awaiting_feedback', locals: { vacancy: vacancy, school: presenter.school }
 
   - else
-    %p.govuk-body-l= t("jobs.no_awaiting_feedback")
+    %p.govuk-body= t("jobs.no_awaiting_feedback")

--- a/spec/features/hiring_staff_can_add_stats_to_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_add_stats_to_a_vacancy_spec.rb
@@ -158,9 +158,10 @@ RSpec.feature 'Submitting effectiveness feedback on expired vacancies', js: true
 
   context 'when there are no vacancies awaiting feedback' do
     scenario 'hiring staff can not see notification badge' do
-      visit school_path
+      visit jobs_with_type_school_path(type: :awaiting_feedback)
 
       expect(page).to_not have_selector(NOTIFICATION_BADGE_SELECTOR)
+      expect(page).to have_content(I18n.t('jobs.no_awaiting_feedback'))
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR:
- Fixed column header width for select boxes
- Fixed header links which would previously redirect to another tab rather than sort the column on the currently active tab.
- Removed the `'Please tell us...' intro text` when there are no jobs awaiting feedback.
- Reduced the font size for `'There are no jobs...' no awaiting feedback text`

## Screenshots of UI changes:

### Before
**1.** ![image](https://user-images.githubusercontent.com/32823756/59849749-6f99ba80-9360-11e9-9f95-524c9cfbfc1d.png)

------------------------------------------------------------------------------------------------------

**2.** ![image (1)](https://user-images.githubusercontent.com/32823756/59849833-a7086700-9360-11e9-8bc6-52f37f51ad06.png)

------------------------------------------------------------------------------------------------------

### After
**1.**  <img width="1265" alt="Screenshot 2019-06-20 at 12 35 48" src="https://user-images.githubusercontent.com/32823756/59849792-8b9d5c00-9360-11e9-9fc0-9a931f1319c9.png">

------------------------------------------------------------------------------------------------------

**2.** <img width="1245" alt="Screenshot 2019-06-20 at 13 05 11" src="https://user-images.githubusercontent.com/32823756/59849867-c0a9ae80-9360-11e9-9719-60e5be711831.png">