### PR TITLE
(chore) Expose DB ports on host machine

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -29,6 +29,8 @@ services:
       - pg_test_data:/var/lib/postgresql/data/:cached
     networks:
       - tests
+    ports:
+      - "25432:5432"
     restart: on-failure
 
   elasticsearch-test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     image: postgres
     volumes:
       - pg_data:/var/lib/postgresql/data/:cached
+    ports:
+      - "15432:5432"
     restart: on-failure
 
   elasticsearch:


### PR DESCRIPTION
This will allow me (and others) to use database inspection tools
such as `psql` running on our development machine.