### PR TITLE
(Fix) Add working patterns to Vacancy Spreadsheet

### DIFF
--- a/app/jobs/add_vacancies_to_spreadsheet_job.rb
+++ b/app/jobs/add_vacancies_to_spreadsheet_job.rb
@@ -1,0 +1,9 @@
+require 'add_vacancies_to_spreadsheet'
+
+class AddVacanciesToSpreadsheetJob < ApplicationJob
+  queue_as :audit_vacancies
+
+  def perform
+    AddVacanciesToSpreadsheet.new.run!
+  end
+end

--- a/lib/add_audit_data_to_spreadsheet.rb
+++ b/lib/add_audit_data_to_spreadsheet.rb
@@ -6,4 +6,8 @@ class AddAuditDataToSpreadsheet < ExportToSpreadsheet
   def query
     AuditData.where(category: @category)
   end
+
+  def present(audit_data)
+    audit_data.to_row
+  end
 end

--- a/lib/add_general_feedback_to_spreadsheet.rb
+++ b/lib/add_general_feedback_to_spreadsheet.rb
@@ -10,4 +10,8 @@ class AddGeneralFeedbackToSpreadsheet < ExportToSpreadsheet
   def query
     GeneralFeedback.all
   end
+
+  def present(general_feedback)
+    general_feedback.to_row
+  end
 end

--- a/lib/add_vacancies_to_spreadsheet.rb
+++ b/lib/add_vacancies_to_spreadsheet.rb
@@ -12,24 +12,24 @@ class AddVacanciesToSpreadsheet < ExportToSpreadsheet
   end
 
   def to_row(vacancy)
-    {
-      id: vacancy.id,
-      slug: vacancy.slug,
-      created_at: vacancy.created_at.to_s,
-      status: vacancy.status,
-      publish_on: vacancy.publish_on,
-      expires_on: vacancy.expires_on,
-      starts_on: vacancy.starts_on,
-      ends_on: vacancy.ends_on,
-      weekly_hours: vacancy.weekly_hours,
-      flexible_working: vacancy.working_patterns.join(','),
-      school_urn: vacancy.school.urn,
-      school_county: vacancy.school.county
-    }
+    [
+      Time.zone.now.to_s,
+      vacancy.id,
+      vacancy.slug,
+      vacancy.created_at.to_s,
+      vacancy.status,
+      vacancy.publish_on,
+      vacancy.expires_on,
+      vacancy.starts_on,
+      vacancy.ends_on,
+      vacancy.weekly_hours,
+      vacancy.working_patterns.join(','),
+      vacancy.school.urn,
+      vacancy.school.county
+    ]
   end
 
   def present(vacancy)
-    row = to_row(vacancy)
-    row.values.unshift(Time.zone.now.to_s)
+    to_row(vacancy)
   end
 end

--- a/lib/add_vacancies_to_spreadsheet.rb
+++ b/lib/add_vacancies_to_spreadsheet.rb
@@ -1,0 +1,35 @@
+require 'export_to_spreadsheet'
+
+class AddVacanciesToSpreadsheet < ExportToSpreadsheet
+  def initialize
+    @category = 'vacancy'
+  end
+
+  private
+
+  def query
+    Vacancy.all
+  end
+
+  def to_row(vacancy)
+    {
+      id: vacancy.id,
+      slug: vacancy.slug,
+      created_at: vacancy.created_at.to_s,
+      status: vacancy.status,
+      publish_on: vacancy.publish_on,
+      expires_on: vacancy.expires_on,
+      starts_on: vacancy.starts_on,
+      ends_on: vacancy.ends_on,
+      weekly_hours: vacancy.weekly_hours,
+      flexible_working: vacancy.working_patterns.join(','),
+      school_urn: vacancy.school.urn,
+      school_county: vacancy.school.county
+    }
+  end
+
+  def present(vacancy)
+    row = to_row(vacancy)
+    row.values.unshift(Time.zone.now.to_s)
+  end
+end

--- a/lib/add_vacancy_publish_feedback_to_spreadsheet.rb
+++ b/lib/add_vacancy_publish_feedback_to_spreadsheet.rb
@@ -10,4 +10,8 @@ class AddVacancyPublishFeedbackToSpreadsheet < ExportToSpreadsheet
   def query
     VacancyPublishFeedback.all
   end
+
+  def present(vacancy_publish_feedback)
+    vacancy_publish_feedback.to_row
+  end
 end

--- a/lib/export_to_spreadsheet.rb
+++ b/lib/export_to_spreadsheet.rb
@@ -20,7 +20,7 @@ class ExportToSpreadsheet
   end
 
   def data_array
-    results.map(&:to_row)
+    results.map(&method(:present))
   end
 
   def results

--- a/spec/jobs/add_vacancies_to_spreadsheet_job_spec.rb
+++ b/spec/jobs/add_vacancies_to_spreadsheet_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe AddVacanciesToSpreadsheetJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the audit_vacancies queue' do
+    expect(job.queue_name).to eq('audit_vacancies')
+  end
+
+  it 'writes to the spreadsheet' do
+    add_vacancies_to_spreadsheet = double(:add_vacancies_to_spreadsheet)
+    expect(AddVacanciesToSpreadsheet).to receive(:new) { add_vacancies_to_spreadsheet }
+    expect(add_vacancies_to_spreadsheet).to receive(:run!)
+
+    perform_enqueued_jobs { job }
+  end
+end

--- a/spec/lib/add_audit_data_to_spreadsheet_spec.rb
+++ b/spec/lib/add_audit_data_to_spreadsheet_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe AddAuditDataToSpreadsheet do
   let!(:existing_data) { Timecop.freeze(2.days.ago) { create_list(:audit_data, 3, category: 'vacancies') } }
   let!(:new_data) { create_list(:audit_data, 3, category: 'vacancies') }
   let!(:other_data) { create_list(:audit_data, 3, category: 'sign_in_events') }
+  let(:expected_spreadsheet_rows) { new_data.map(&:to_row) }
 
   subject { described_class.new(category) }
 

--- a/spec/lib/add_audit_data_to_spreadsheet_spec.rb
+++ b/spec/lib/add_audit_data_to_spreadsheet_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AddAuditDataToSpreadsheet do
   let!(:existing_data) { Timecop.freeze(2.days.ago) { create_list(:audit_data, 3, category: 'vacancies') } }
   let!(:new_data) { create_list(:audit_data, 3, category: 'vacancies') }
   let!(:other_data) { create_list(:audit_data, 3, category: 'sign_in_events') }
-  let(:expected_spreadsheet_rows) { new_data.map(&:to_row) }
+  let(:expected_new_spreadsheet_rows) { new_data.map(&:to_row) }
 
   subject { described_class.new(category) }
 

--- a/spec/lib/add_general_feedback_to_spreadsheet_spec.rb
+++ b/spec/lib/add_general_feedback_to_spreadsheet_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe AddGeneralFeedbackToSpreadsheet do
 
   let!(:existing_data) { Timecop.freeze(2.days.ago) { create_list(:general_feedback, 3) } }
   let!(:new_data) { create_list(:general_feedback, 3) }
+  let(:expected_spreadsheet_rows) { new_data.map(&:to_row) }
 
   subject { described_class.new }
 

--- a/spec/lib/add_general_feedback_to_spreadsheet_spec.rb
+++ b/spec/lib/add_general_feedback_to_spreadsheet_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AddGeneralFeedbackToSpreadsheet do
 
   let!(:existing_data) { Timecop.freeze(2.days.ago) { create_list(:general_feedback, 3) } }
   let!(:new_data) { create_list(:general_feedback, 3) }
-  let(:expected_spreadsheet_rows) { new_data.map(&:to_row) }
+  let(:expected_new_spreadsheet_rows) { new_data.map(&:to_row) }
 
   subject { described_class.new }
 

--- a/spec/lib/add_vacancies_to_spreadsheet_spec.rb
+++ b/spec/lib/add_vacancies_to_spreadsheet_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+require 'add_vacancies_to_spreadsheet'
+
+RSpec.describe AddVacanciesToSpreadsheet do
+  let(:category) { 'vacancy' }
+  let(:spreadsheet_id) { 'VACANCY_FEEDBACK_SPREADSHEET_ID' }
+
+  let!(:existing_data) { Timecop.freeze(2.days.ago) { create_list(:vacancy, 3) } }
+  let!(:new_data) { create_list(:vacancy, 3) }
+  let(:expected_spreadsheet_rows) do
+    new_data.map do |vacancy|
+      [
+        Time.zone.now.to_s,
+        vacancy.id,
+        vacancy.slug,
+        vacancy.created_at.to_s,
+        vacancy.status,
+        vacancy.publish_on,
+        vacancy.expires_on,
+        vacancy.starts_on,
+        vacancy.ends_on,
+        vacancy.weekly_hours,
+        vacancy.working_patterns.join(','),
+        vacancy.school.urn,
+        vacancy.school.county
+      ]
+    end
+  end
+
+  subject { described_class.new }
+
+  it_behaves_like 'ExportToSpreadsheet'
+end

--- a/spec/lib/add_vacancies_to_spreadsheet_spec.rb
+++ b/spec/lib/add_vacancies_to_spreadsheet_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AddVacanciesToSpreadsheet do
 
   let!(:existing_data) { Timecop.freeze(2.days.ago) { create_list(:vacancy, 3) } }
   let!(:new_data) { create_list(:vacancy, 3) }
-  let(:expected_spreadsheet_rows) do
+  let(:expected_new_spreadsheet_rows) do
     new_data.map do |vacancy|
       [
         Time.zone.now.to_s,

--- a/spec/lib/add_vacancy_publish_feedback_to_spreadsheet_spec.rb
+++ b/spec/lib/add_vacancy_publish_feedback_to_spreadsheet_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AddVacancyPublishFeedbackToSpreadsheet do
 
   let!(:existing_data) { Timecop.freeze(2.days.ago) { create_list(:vacancy_publish_feedback, 3) } }
   let!(:new_data) { create_list(:vacancy_publish_feedback, 3) }
-  let(:expected_spreadsheet_rows) { new_data.map(&:to_row) }
+  let(:expected_new_spreadsheet_rows) { new_data.map(&:to_row) }
 
   subject { described_class.new }
 

--- a/spec/lib/add_vacancy_publish_feedback_to_spreadsheet_spec.rb
+++ b/spec/lib/add_vacancy_publish_feedback_to_spreadsheet_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe AddVacancyPublishFeedbackToSpreadsheet do
 
   let!(:existing_data) { Timecop.freeze(2.days.ago) { create_list(:vacancy_publish_feedback, 3) } }
   let!(:new_data) { create_list(:vacancy_publish_feedback, 3) }
+  let(:expected_spreadsheet_rows) { new_data.map(&:to_row) }
 
   subject { described_class.new }
 
@@ -14,6 +15,7 @@ RSpec.describe AddVacancyPublishFeedbackToSpreadsheet do
 
   context 'with no user attached to the feedback' do
     let!(:new_data) { create_list(:vacancy_publish_feedback, 3, :old_with_no_user) }
+
     it_behaves_like 'ExportToSpreadsheet'
   end
 end

--- a/spec/support/shared_examples/export_to_spreadsheet.rb
+++ b/spec/support/shared_examples/export_to_spreadsheet.rb
@@ -30,8 +30,7 @@ RSpec.shared_examples_for 'ExportToSpreadsheet' do
     end
 
     it 'adds the new data to the spreadsheet' do
-      data = new_data.map(&:to_row)
-      expect(worksheet).to receive(:append_rows).with(data)
+      expect(worksheet).to receive(:append_rows).with(expected_spreadsheet_rows)
       subject.run!
     end
   end
@@ -59,7 +58,7 @@ RSpec.shared_examples_for 'ExportToSpreadsheet' do
     end
 
     it 'adds all the data to the spreadsheet' do
-      data = (existing_data + new_data).map(&:to_row)
+      data = (existing_data + new_data).map(&subject.method(:present))
       expect(worksheet).to receive(:append_rows).with(data)
       subject.run!
     end

--- a/spec/support/shared_examples/export_to_spreadsheet.rb
+++ b/spec/support/shared_examples/export_to_spreadsheet.rb
@@ -30,7 +30,7 @@ RSpec.shared_examples_for 'ExportToSpreadsheet' do
     end
 
     it 'adds the new data to the spreadsheet' do
-      expect(worksheet).to receive(:append_rows).with(expected_spreadsheet_rows)
+      expect(worksheet).to receive(:append_rows).with(expected_new_spreadsheet_rows)
       subject.run!
     end
   end
@@ -57,9 +57,11 @@ RSpec.shared_examples_for 'ExportToSpreadsheet' do
       allow(worksheet).to receive(:last_row) { nil }
     end
 
+    let(:expected_existing_data) { existing_data.map(&subject.method(:present)) }
+    let(:full_worksheet_data) { expected_existing_data + expected_new_spreadsheet_rows }
+
     it 'adds all the data to the spreadsheet' do
-      data = (existing_data + new_data).map(&subject.method(:present))
-      expect(worksheet).to receive(:append_rows).with(data)
+      expect(worksheet).to receive(:append_rows).with(full_worksheet_data)
       subject.run!
     end
   end


### PR DESCRIPTION
Since it went live, working pattern data was not being written to the spreadsheet.

This change adds an `add_vacancy_to_spreadsheet` job that fills in the missing working patterns data in the published vacancy sheet.

The code might require some refactoring but this should be timeboxed.