### PR TITLE
Feature/946 setup basic smoke test for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2
+jobs:
+  run_smoke_test:
+    working_directory: ~/teacher-vacancy-service
+    docker:
+      - image: circleci/ruby:2.6.1-node-browsers-legacy
+        environment:
+        RAILS_ENV: test
+    steps:
+      - checkout
+      - run: gem install bundler
+      - run: bundle install
+      - run: bundle exec rspec --tag smoke_test spec/smoke_test/
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - run_smoke_test
+  scheduled-smoke-tests:
+    triggers:
+      - schedule:
+          cron: "5,10,15,20,25,30,35,40,45,50,55,0 * * * *"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - run_smoke_test

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---require spec_helper
+--require spec_helper --tag ~smoke_test

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -40,7 +40,7 @@ class VacanciesController < ApplicationController
 
     @vacancy = VacancyPresenter.new(vacancy)
 
-    VacancyPageView.new(vacancy).track unless authenticated?
+    VacancyPageView.new(vacancy).track unless authenticated? || smoke_test?
 
     expires_in 5.minutes, public: true
   end
@@ -125,5 +125,9 @@ class VacanciesController < ApplicationController
 
   def set_headers
     response.set_header('X-Robots-Tag', 'noarchive')
+  end
+
+  def smoke_test?
+    cookies[:smoke_test] != nil
   end
 end

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -23,7 +23,7 @@ class VacanciesController < ApplicationController
     @filters = VacancyFilters.new(search_params.to_hash)
     @sort = VacancySort.new.update(column: sort_column, order: sort_order)
     @vacancies = VacanciesFinder.new(@filters, @sort, page_number).vacancies
-
+    AuditSearchEventJob.perform_later(audit_row) if valid_search?
     expires_in 5.minutes, public: true
   end
 
@@ -129,5 +129,13 @@ class VacanciesController < ApplicationController
 
   def smoke_test?
     cookies[:smoke_test] != nil
+  end
+
+  def valid_search?
+    @filters.any? && !smoke_test?
+  end
+
+  def audit_row
+    { total_count: @vacancies.total_count }.merge(@filters.audit_hash)
   end
 end

--- a/app/services/vacancies_finder.rb
+++ b/app/services/vacancies_finder.rb
@@ -6,7 +6,6 @@ class VacanciesFinder
     @sort = sort
     @page_number = page_number
     @vacancies = VacanciesPresenter.new(records, searched: search_filters_given?)
-    audit_search_event if search_filters_given?
   end
 
   private
@@ -32,13 +31,5 @@ class VacanciesFinder
            .order(sort.column => sort.order)
            .includes(:school)
            .page(page_number)
-  end
-
-  def audit_search_event
-    AuditSearchEventJob.perform_later(audit_row)
-  end
-
-  def audit_row
-    { total_count: vacancies.total_count }.merge(filters.audit_hash)
   end
 end

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -60,6 +60,33 @@ RSpec.describe VacanciesController, type: :controller do
           subject
         end
       end
+
+      context 'search audiotor' do
+        let(:params) do
+          {
+            subject: 'foo'
+          }
+        end
+
+        it 'should call the search auditor' do
+          expect(AuditSearchEventJob).to receive(:perform_later)
+
+          subject
+        end
+
+        it 'should not call the search auditor if its a smoke test' do
+          cookies[:smoke_test] = 1
+          expect(AuditSearchEventJob).to_not receive(:perform_later)
+
+          subject
+        end
+
+        it 'should not call the search auditor if no search parameters are given' do
+          expect(AuditSearchEventJob).to_not receive(:perform_later)
+
+          get :index
+        end
+      end
     end
 
     context 'feature flagging' do

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -61,15 +61,22 @@ RSpec.describe VacanciesController, type: :controller do
         end
       end
 
-      context 'search audiotor' do
+      context 'search auditor' do
         let(:params) do
           {
-            subject: 'foo'
+            job_title: 'Should have three match'
           }
         end
 
-        it 'should call the search auditor' do
-          expect(AuditSearchEventJob).to receive(:perform_later)
+        it 'should call the search auditor', elasticsearch: true do
+          3.times { create(:vacancy, job_title: 'Should have three match') }
+          Vacancy.__elasticsearch__.client.indices.flush
+          expect(AuditSearchEventJob).to receive(:perform_later).with(
+            hash_including(
+              total_count: 3,
+              job_title: 'Should have three match'
+            )
+          )
 
           subject
         end

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -114,5 +114,25 @@ RSpec.describe VacanciesController, type: :controller do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'when using cookies' do
+      let(:vacancy) { create(:vacancy) }
+      let(:params) { { id: vacancy.slug } }
+      let(:vacancy_page_view) { instance_double(VacancyPageView) }
+
+      it 'should call the track method if cookies not set' do
+        expect(VacancyPageView).to receive(:new).with(vacancy).and_return(vacancy_page_view)
+        expect(vacancy_page_view).to receive(:track)
+
+        subject
+      end
+
+      it 'should not call the track method if smoke_test cookies set' do
+        expect(VacancyPageView).not_to receive(:new).with(vacancy)
+        cookies[:smoke_test] = '1'
+
+        subject
+      end
+    end
   end
 end

--- a/spec/i18n_helper.rb
+++ b/spec/i18n_helper.rb
@@ -1,0 +1,2 @@
+require 'i18n'
+I18n.load_path << Dir[File.expand_path('config/locales') + '/*.yml']

--- a/spec/services/vacancies_finder_spec.rb
+++ b/spec/services/vacancies_finder_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe VacanciesFinder do
       expect(Vacancy).to receive(:public_search).ordered.and_return(elasticsearch_response)
       expect(elasticsearch_response).to receive(:page).ordered.and_return(elasticsearch_response)
       expect(elasticsearch_response).to receive(:records).ordered.and_return(records)
-      expect(records).to receive(:total_count) { 0 }
       expect(records).to receive(:map)
 
       subject

--- a/spec/smoke_test/job_seekers_can_view_homepage_spec.rb
+++ b/spec/smoke_test/job_seekers_can_view_homepage_spec.rb
@@ -1,0 +1,27 @@
+require 'browser_test_helper'
+require 'i18n_helper'
+
+RSpec.describe 'Page availability', js: true, smoke_test: true do
+  context 'Job seeker visits vacancy page' do
+    it 'should ensure users can search and view a job vacancy page' do
+      page = Capybara::Session.new(:poltergeist)
+      page.driver.set_cookie('smoke_test', '1', domain: 'teaching-vacancies.service.gov.uk')
+
+      page.visit 'https://teaching-vacancies.service.gov.uk/'
+      expect(page).to have_content(I18n.t('jobs.heading'))
+
+      page.within '.filters-form' do
+        page.fill_in I18n.t('jobs.filters.subject'), with: 'Maths'
+        page.first('.govuk-button[type=submit]').click
+      end
+      expect(page).to have_content(I18n.t('subscriptions.button'))
+
+      vacancy_page = page.first('.view-vacancy-link')
+      unless vacancy_page.nil?
+        vacancy_page.click
+        expect(page).to have_content(I18n.t('jobs.description'))
+        expect(page.current_url).to include('https://teaching-vacancies.service.gov.uk/jobs/')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pull Request template

## Trello card URL:
https://trello.com/c/gxKqZ7aC/946-high-level-smoke-tests-for-key-jobseeker-journey-through-tvs-and-to-send-alerts-if-triggered-8

## Changes in this PR:
Add two test to visit the vacancy page, run a search and visit the first result 
Add Circle CI config file with scheduled smoke tests

## Next steps:
- Add more tests for better coverage
- Discover caching with Circle CI to avoid rebuilding before every test run and minimise test time