### PR TITLE
Add monitoring of freeable memory to redis cache cluster

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -185,6 +185,7 @@ module "cloudwatch" {
   ops_genie_api_key      = "${var.cloudwatch_ops_genie_api_key}"
   autoscaling_group_name = "${module.core.ecs_autoscaling_group_name}"
   pipeline_name          = "${module.pipeline.pipeline_name}"
+  redis_cache_cluster_id = "${module.elasticache_redis.redis_cache_cluster_id}"
 }
 
 module "pipeline" {

--- a/terraform/modules/cloudwatch/cloudwatch.tf
+++ b/terraform/modules/cloudwatch/cloudwatch.tf
@@ -116,12 +116,12 @@ resource "aws_cloudwatch_metric_alarm" "redis-cache-free-memory" {
   statistic           = "Average"
   threshold           = "512000000" # Move this into a variable file?
 
-  alarm_description = "This metric monitors the redis cache freeable memory for ${aws_elasticache_cluster.redis_cache.cluster_id}"
+  alarm_description = "This metric monitors the redis cache freeable memory for ${var.redis_cache_cluster_id}"
   alarm_actions     = ["${aws_sns_topic.cloudwatch_alerts.arn}"]
   ok_actions        = ["${aws_sns_topic.cloudwatch_alerts.arn}"]
 
   dimensions {
-    CacheClusterId = "${aws_elasticache_cluster.redis_cache.cluster_id}"
+    CacheClusterId = "${var.redis_cache_cluster_id}"
   }
 }
 

--- a/terraform/modules/cloudwatch/cloudwatch.tf
+++ b/terraform/modules/cloudwatch/cloudwatch.tf
@@ -106,6 +106,25 @@ resource "aws_cloudwatch_metric_alarm" "cpu" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "redis-cache-free-memory" {
+  alarm_name          = "${var.project_name}-${var.environment}-redis-cache-free-memory"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "FreeableMemory"
+  namespace           = "AWS/ElastiCache"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "512000000" # Move this into a variable file?
+
+  alarm_description = "This metric monitors the redis cache freeable memory for ${aws_elasticache_cluster.redis_cache.cluster_id}"
+  alarm_actions     = ["${aws_sns_topic.cloudwatch_alerts.arn}"]
+  ok_actions        = ["${aws_sns_topic.cloudwatch_alerts.arn}"]
+
+  dimensions {
+    CacheClusterId = "${aws_elasticache_cluster.redis_cache.cluster_id}"
+  }
+}
+
 resource "aws_cloudwatch_event_rule" "code_pipeline_fail" {
   name        = "${var.project_name}-${var.environment}-code-pipeline-fail"
   description = "Notify on CodePipeline Failures"

--- a/terraform/modules/cloudwatch/cloudwatch.tf
+++ b/terraform/modules/cloudwatch/cloudwatch.tf
@@ -114,7 +114,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-cache-free-memory" {
   namespace           = "AWS/ElastiCache"
   period              = "120"
   statistic           = "Average"
-  threshold           = "512000000" # Move this into a variable file?
+  threshold           = "512000000"
 
   alarm_description = "This metric monitors the redis cache freeable memory for ${var.redis_cache_cluster_id}"
   alarm_actions     = ["${aws_sns_topic.cloudwatch_alerts.arn}"]

--- a/terraform/modules/cloudwatch/input.tf
+++ b/terraform/modules/cloudwatch/input.tf
@@ -5,3 +5,4 @@ variable "slack_channel" {}
 variable "ops_genie_api_key" {}
 variable "autoscaling_group_name" {}
 variable "pipeline_name" {}
+variable "redis_cache_cluster_id" {}

--- a/terraform/modules/elasticache-redis/outputs.tf
+++ b/terraform/modules/elasticache-redis/outputs.tf
@@ -15,6 +15,10 @@ output "redis_cache_endpoint" {
   value = "${join(":", list(aws_elasticache_cluster.redis_cache.cache_nodes.0.address, aws_elasticache_cluster.redis_cache.cache_nodes.0.port))}"
 }
 
+output "redis_cache_cluster_id" {
+  value = "${aws_elasticache_cluster.redis_cache.cluster_id}"
+}
+
 # Redis instance for queuing
 output "redis_queue_hostname" {
   value = "${aws_elasticache_cluster.redis_queue.cache_nodes.0.address}"


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/rgUlNDoF/944-add-monitoring-and-alerts-to-the-redis-service-5

## Changes in this PR:

* Add CloudWatch alarm to monitor freeable memory on the Redis cache cluster
* Alarm if it hits or falls below 512MB remaining - can discuss an appropriate amount for this

## Next steps:

- [ ] Terraform deployment required
