### PR TITLE
(chore) changing server error content

### DIFF
--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -20,7 +20,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
   rescue Authorisation::ExternalServerError => error
     Rollbar.log(:error, error)
     respond_to do |format|
-      format.html { render 'errors/external_server_error', status: :server_error }
+      format.html { render 'errors/internal_server_error', status: :server_error }
     end
   end
 

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -17,11 +17,6 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
     else
       perform_non_dfe_sign_in_authorisation
     end
-  rescue Authorisation::ExternalServerError => error
-    Rollbar.log(:error, error)
-    respond_to do |format|
-      format.html { render 'errors/internal_server_error', status: :server_error }
-    end
   end
 
   private

--- a/app/views/errors/external_server_error.html.haml
+++ b/app/views/errors/external_server_error.html.haml
@@ -1,4 +1,0 @@
-- content_for :page_title_prefix, t('error_pages.external_server_error.dfe_sign_in')
-
-%h1.govuk-heading-xl=t('error_pages.external_server_error.dfe_sign_in')
-%p You can email #{mail_to t('help.email'), t('help.email'), class: 'govuk-link'} if the problem persists.

--- a/app/views/errors/internal_server_error.html.haml
+++ b/app/views/errors/internal_server_error.html.haml
@@ -1,4 +1,5 @@
 - content_for :page_title_prefix, t('error_pages.server_error')
 
 %h1.govuk-heading-xl=t('error_pages.server_error')
-%p You can email #{mail_to t('help.email'), t('help.email'), class: 'govuk-link'} if the problem persists.
+%p We’re working to fix this, so please try again shortly. 
+%p If you continue to have problems accessing Teaching Vacancies you can email #{mail_to t('help.email'), t('help.email'), class: 'govuk-link'}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -405,8 +405,6 @@ en:
     not_found: Page not found.
     trashed_vacancy_found: Page not found.
     server_error: Sorry, there’s a technical issue at our end
-    external_server_error:
-      dfe_sign_in: There was a problem with DfE Sign-in, please try again in a moment.
 
   help:
     email: teaching.vacancies@education.gov.uk

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -404,7 +404,7 @@ en:
     unprocessable_entity: We're unable to process your request.
     not_found: Page not found.
     trashed_vacancy_found: Page not found.
-    server_error: Something went wrong at our end.
+    server_error: Sorry, there’s a technical issue at our end
     external_server_error:
       dfe_sign_in: There was a problem with DfE Sign-in, please try again in a moment.
 

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -133,7 +133,7 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
 
         sign_in_user
 
-        expect(page).to have_content(I18n.t('error_pages.external_server_error.dfe_sign_in'))
+        expect(page).to have_content(I18n.t('error_pages.server_error'))
       end
     end
   end

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -128,12 +128,10 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         stub_authorisation_step_with_external_error
       end
 
-      it 'renders an error page advising of a problem with DSI rather than this service' do
+      it 'raises an error' do
         visit root_path
 
-        sign_in_user
-
-        expect(page).to have_content(I18n.t('error_pages.server_error'))
+        expect { sign_in_user }.to raise_error(Authorisation::ExternalServerError)
       end
     end
   end


### PR DESCRIPTION
##  Trello card URL: 
https://trello.com/c/fR9rlofE/935-review-the-page-which-is-shown-when-there-is-an-error-with-the-dfe-authorisation-application-3
## Changes in this PR:
Change the content of internal server error 
## Screenshots of UI changes:

### Before:
![]( https://trello-attachments.s3.amazonaws.com/5aba73b9c2614d4bf1b92709/5d0a54c349d434294a2a1629/467a32d97c811b5ebd0c12f19f648a72/Screenshot_2019-07-08_at_10.19.37.png)

### After:
![]( https://trello-attachments.s3.amazonaws.com/5aba73b9c2614d4bf1b92709/5d0a54c349d434294a2a1629/913fb0343f344a823e6106d48f8252c6/Screenshot_2019-07-10_at_15.28.27.png)