### PR TITLE
Fix change organisation link display

### DIFF
--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -32,7 +32,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
   end
 
   def update_session(authorisation_permissions)
-    session.update(session_id: user_id, urn: school_urn, multiple_schools: authorisation_permissions.many?)
+    session.update(session_id: user_id, urn: school_urn, multiple_schools: authorisation_permissions.many_schools?)
     audit_successful_authorisation
   end
 

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -12,6 +12,8 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
 
   def create
     Rails.logger.warn("Hiring staff signed in: #{user_id}")
+    audit_successful_authentication
+
     if DfeSignInAuthorisationFeature.enabled?
       perform_dfe_sign_in_authorisation
     else
@@ -29,13 +31,8 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
     render 'user-not-authorised'
   end
 
-  def update_session(authorisation)
-    session.update(session_id: user_id, urn: school_urn, multiple_schools: authorisation.many?)
-    audit_successful_authorisation
-  end
-
-  def update_non_dsi_session(school_urn, permissions)
-    session.update(session_id: user_id, urn: school_urn, multiple_schools: permissions.many?)
+  def update_session(authorisation_permissions)
+    session.update(session_id: user_id, urn: school_urn, multiple_schools: authorisation_permissions.many?)
     audit_successful_authorisation
   end
 
@@ -60,26 +57,20 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
   end
 
   def perform_dfe_sign_in_authorisation
-    audit_successful_authentication
-
     authorisation = Authorisation.new(organisation_id: organisation_id, user_id: user_id)
     authorisation.call
-    if authorisation.authorised?
-      update_session(authorisation)
-      redirect_to school_path
-    else
-      not_authorised
-    end
+    check_authorisation(authorisation)
   end
 
   def perform_non_dfe_sign_in_authorisation
     permissions = TeacherVacancyAuthorisation::Permissions.new
     permissions.authorise(identifier, school_urn)
+    check_authorisation(permissions)
+  end
 
-    audit_successful_authentication
-
-    if permissions.authorised?
-      update_non_dsi_session(permissions.school_urn, permissions)
+  def check_authorisation(authorisation_permissions)
+    if authorisation_permissions.authorised?
+      update_session(authorisation_permissions)
       redirect_to school_path
     else
       not_authorised

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -29,8 +29,8 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
     render 'user-not-authorised'
   end
 
-  def update_session
-    session.update(session_id: user_id, urn: school_urn)
+  def update_session(authorisation)
+    session.update(session_id: user_id, urn: school_urn, multiple_schools: authorisation.many?)
     audit_successful_authorisation
   end
 
@@ -62,9 +62,10 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
   def perform_dfe_sign_in_authorisation
     audit_successful_authentication
 
-    authorisation = Authorisation.new(organisation_id: organisation_id, user_id: user_id).call
+    authorisation = Authorisation.new(organisation_id: organisation_id, user_id: user_id)
+    authorisation.call
     if authorisation.authorised?
-      update_session
+      update_session(authorisation)
       redirect_to school_path
     else
       not_authorised

--- a/app/services/authorisation.rb
+++ b/app/services/authorisation.rb
@@ -37,6 +37,13 @@ class Authorisation
     role_ids.include?(dfe_sign_in_service_access_role_id)
   end
 
+  def many?
+    response = JSON.parse(retrieve_organisations.body)
+    return true if response.count > 1
+
+    false
+  end
+
   private
 
   def generate_jwt_token
@@ -51,6 +58,20 @@ class Authorisation
   def build_response
     uri = URI(dfe_sign_in_url)
     uri.path = "/services/#{dfe_sign_in_service_id}/organisations/#{organisation_id}/users/#{user_id}"
+
+    request = Net::HTTP::Get.new(uri)
+    request['Authorization'] = "bearer #{generate_jwt_token}"
+    request['Content-Type'] = 'application/json'
+
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(request)
+    end
+  end
+
+  def retrieve_organisations
+    uri = URI(dfe_sign_in_url)
+    # "https://test-url.local/users/#{user_id}/organisations"
+    uri.path = "/users/#{user_id}/organisations"
 
     request = Net::HTTP::Get.new(uri)
     request['Authorization'] = "bearer #{generate_jwt_token}"

--- a/app/services/authorisation.rb
+++ b/app/services/authorisation.rb
@@ -38,12 +38,12 @@ class Authorisation
     role_ids.include?(dfe_sign_in_service_access_role_id)
   end
 
-  def many?
+  def many_schools?
     org_api_path = "/users/#{user_id}/organisations"
     response = get_dfe_sign_in_api_response(org_api_path)
     return JSON.parse(response.body).count > 1 if response.code.eql?('200')
 
-    false
+    nil
   end
 
   private

--- a/app/services/authorisation.rb
+++ b/app/services/authorisation.rb
@@ -40,8 +40,8 @@ class Authorisation
 
   def many?
     org_api_path = "/users/#{user_id}/organisations"
-    response = JSON.parse(get_dfe_sign_in_api_response(org_api_path).body)
-    return true if response.count > 1
+    response = get_dfe_sign_in_api_response(org_api_path)
+    return JSON.parse(response.body).count > 1 if response.code.eql?('200')
 
     false
   end

--- a/app/services/teacher_vacancy_authorisation.rb
+++ b/app/services/teacher_vacancy_authorisation.rb
@@ -30,7 +30,7 @@ module TeacherVacancyAuthorisation
       user_permissions.first['school_urn']
     end
 
-    def many?
+    def many_schools?
       user_permissions && user_permissions.count > 1
     end
 

--- a/app/views/hiring_staff/schools/show.html.haml
+++ b/app/views/hiring_staff/schools/show.html.haml
@@ -8,11 +8,7 @@
   .govuk-grid-column-full
     %h1.govuk-heading-l.mb0
       = t('schools.jobs.index', school: @school.name)
-    - if @multiple_schools && !(DfeSignInAuthorisationFeature.enabled?)
-      = link_to t('sign_in.organisation.change'), auth_dfe_callback_path, class: 'govuk-link'
-      %br
-      %br
-    - if DfeSignInAuthorisationFeature.enabled?
+    - if @multiple_schools
       = link_to t('sign_in.organisation.change'), auth_dfe_callback_path, class: 'govuk-link'
       %br
       %br

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -77,6 +77,7 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
       before(:each) do
         stub_authentication_step
         stub_authorisation_step
+        stub_sign_in_with_multiple_organisations
 
         visit root_path
 

--- a/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'School viewing public listings' do
         stub_accepted_terms_and_condition
         stub_authentication_step(school_urn: '110627')
         stub_authorisation_step
+        stub_sign_in_with_multiple_organisations
       end
 
       scenario 'A signed in school should see a link back to their own dashboard when viewing public listings' do

--- a/spec/fixtures/dfe_sign_in_user_organisations_response.json
+++ b/spec/fixtures/dfe_sign_in_user_organisations_response.json
@@ -1,0 +1,48 @@
+[
+  {
+      "id": "939eac36-0777-48c2-9c2c-b87c948a9ee0",
+      "name": "Organisation Foo",
+      "category": {
+          "id": "001",
+          "name": "Early Year Setting"
+      },
+      "urn": "org-urn",
+      "uid": null,
+      "ukprn": null,
+      "establishmentNumber": null,
+      "status": {
+          "id": 1,
+          "name": "Open"
+      },
+      "closedOn": null,
+      "address": null,
+      "telephone": null,
+      "statutoryLowAge": null,
+      "statutoryHighAge": null,
+      "legacyId": "legacy-id",
+      "companyRegistrationNumber": null
+  },
+    {
+      "id": "E8C509A2-3AD8-485C-957F-BEE7047FDA8D",
+      "name": "Organisation Bar",
+      "category": {
+          "id": "1112",
+          "name": "Early Year Setting"
+      },
+      "urn": "org-urn",
+      "uid": null,
+      "ukprn": null,
+      "establishmentNumber": null,
+      "status": {
+          "id": 1,
+          "name": "Open"
+      },
+      "closedOn": null,
+      "address": null,
+      "telephone": null,
+      "statutoryLowAge": null,
+      "statutoryHighAge": null,
+      "legacyId": "legacy-id",
+      "companyRegistrationNumber": null
+  }
+]

--- a/spec/fixtures/dfe_sign_in_user_organisations_response.json
+++ b/spec/fixtures/dfe_sign_in_user_organisations_response.json
@@ -1,48 +1,48 @@
 [
-  {
-      "id": "939eac36-0777-48c2-9c2c-b87c948a9ee0",
-      "name": "Organisation Foo",
-      "category": {
-          "id": "001",
-          "name": "Early Year Setting"
-      },
-      "urn": "org-urn",
-      "uid": null,
-      "ukprn": null,
-      "establishmentNumber": null,
-      "status": {
-          "id": 1,
-          "name": "Open"
-      },
-      "closedOn": null,
-      "address": null,
-      "telephone": null,
-      "statutoryLowAge": null,
-      "statutoryHighAge": null,
-      "legacyId": "legacy-id",
-      "companyRegistrationNumber": null
-  },
     {
-      "id": "E8C509A2-3AD8-485C-957F-BEE7047FDA8D",
-      "name": "Organisation Bar",
-      "category": {
-          "id": "1112",
-          "name": "Early Year Setting"
-      },
-      "urn": "org-urn",
-      "uid": null,
-      "ukprn": null,
-      "establishmentNumber": null,
-      "status": {
-          "id": 1,
-          "name": "Open"
-      },
-      "closedOn": null,
-      "address": null,
-      "telephone": null,
-      "statutoryLowAge": null,
-      "statutoryHighAge": null,
-      "legacyId": "legacy-id",
-      "companyRegistrationNumber": null
-  }
+        "id": "939eac36-0777-48c2-9c2c-b87c948a9ee0",
+        "name": "Organisation Foo",
+        "category": {
+            "id": "001",
+            "name": "Early Year Setting"
+        },
+        "urn": "org-urn",
+        "uid": null,
+        "ukprn": null,
+        "establishmentNumber": null,
+        "status": {
+            "id": 1,
+            "name": "Open"
+        },
+        "closedOn": null,
+        "address": null,
+        "telephone": null,
+        "statutoryLowAge": null,
+        "statutoryHighAge": null,
+        "legacyId": "legacy-id",
+        "companyRegistrationNumber": null
+    },
+    {
+        "id": "E8C509A2-3AD8-485C-957F-BEE7047FDA8D",
+        "name": "Organisation Bar",
+        "category": {
+            "id": "1112",
+            "name": "Early Year Setting"
+        },
+        "urn": "org-urn",
+        "uid": null,
+        "ukprn": null,
+        "establishmentNumber": null,
+        "status": {
+            "id": 1,
+            "name": "Open"
+        },
+        "closedOn": null,
+        "address": null,
+        "telephone": null,
+        "statutoryLowAge": null,
+        "statutoryHighAge": null,
+        "legacyId": "legacy-id",
+        "companyRegistrationNumber": null
+    }
 ]

--- a/spec/fixtures/dfe_sing_in_user_user_organisations_response_with_single.json
+++ b/spec/fixtures/dfe_sing_in_user_user_organisations_response_with_single.json
@@ -1,0 +1,25 @@
+[
+  {
+      "id": "939eac36-0777-48c2-9c2c-b87c948a9ee0",
+      "name": "Organisation Foo",
+      "category": {
+          "id": "001",
+          "name": "Early Year Setting"
+      },
+      "urn": "org-urn",
+      "uid": null,
+      "ukprn": null,
+      "establishmentNumber": null,
+      "status": {
+          "id": 1,
+          "name": "Open"
+      },
+      "closedOn": null,
+      "address": null,
+      "telephone": null,
+      "statutoryLowAge": null,
+      "statutoryHighAge": null,
+      "legacyId": "legacy-id",
+      "companyRegistrationNumber": null
+  }
+]

--- a/spec/services/authorisation_spec.rb
+++ b/spec/services/authorisation_spec.rb
@@ -115,15 +115,31 @@ RSpec.describe Authorisation do
     subject do
       described_class.new(
         organisation_id: '939eac36-0777-48c2-9c2c-b87c948a9ee0',
-        user_id: '161d1f6a-44f1-4a1a-940d-d1088c439da7'
+        user_id: user_id
       )
     end
+    let(:user_id) { 'default_id' }
 
-    before(:each) do
-      stub_sign_in_with_multiple_organisations
+    context 'user is a member of multiple organisations' do
+      let(:user_id) { '161d1f6a-44f1-4a1a-940d-d1088c439da7' }
+      it 'should find that the user is a member of multiple organisations' do
+        stub_sign_in_with_multiple_organisations(user_id: user_id)
+        expect(subject.many?).to be(true)
+      end
+
+      let(:user_id) { 'another_user_id' }
+      it 'should check if another user is a member of multiple organisations' do
+        stub_sign_in_with_multiple_organisations(user_id: user_id)
+        expect(subject.many?).to be(true)
+      end
     end
-    it 'should check if the user is a member of multiple organisations' do
-      expect(subject.many?).to be(true)
+
+    context 'user is member of a single organisation' do
+      let(:user_id) { 'another_user_id' }
+      it 'should find that user is member of a single organisation' do
+        stub_sign_in_with_single_organisation(user_id: user_id)
+        expect(subject.many?).to be(false)
+      end
     end
   end
 end

--- a/spec/services/authorisation_spec.rb
+++ b/spec/services/authorisation_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Authorisation do
     end
   end
 
-  describe '#many?' do
+  describe '#many_schools?' do
     subject do
       described_class.new(
         organisation_id: '939eac36-0777-48c2-9c2c-b87c948a9ee0',
@@ -122,23 +122,36 @@ RSpec.describe Authorisation do
 
     context 'user is a member of multiple organisations' do
       let(:user_id) { '161d1f6a-44f1-4a1a-940d-d1088c439da7' }
-      it 'should find that the user is a member of multiple organisations' do
+      it 'has many' do
         stub_sign_in_with_multiple_organisations(user_id: user_id)
-        expect(subject.many?).to be(true)
+        expect(subject.many_schools?).to be(true)
       end
+    end
 
+    context 'another user is a member of multiple organisations' do
       let(:user_id) { 'another_user_id' }
-      it 'should check if another user is a member of multiple organisations' do
+      it 'has many' do
         stub_sign_in_with_multiple_organisations(user_id: user_id)
-        expect(subject.many?).to be(true)
+        expect(subject.many_schools?).to be(true)
       end
     end
 
     context 'user is member of a single organisation' do
       let(:user_id) { 'another_user_id' }
-      it 'should find that user is member of a single organisation' do
+      it 'does not have many' do
         stub_sign_in_with_single_organisation(user_id: user_id)
-        expect(subject.many?).to be(false)
+        expect(subject.many_schools?).to be(false)
+      end
+    end
+
+    context 'DfE sign-in has an internal server error' do
+      let(:user_id) { 'another_user_id' }
+      it 'is nil' do
+        stub_request(
+          :get,
+          "https://test-url.local/users/#{user_id}/organisations"
+        ).to_return(status: 500)
+        expect(subject.many_schools?).to be(nil)
       end
     end
   end

--- a/spec/services/authorisation_spec.rb
+++ b/spec/services/authorisation_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Authorisation do
     before(:each) do
       stub_sign_in_with_multiple_organisations
     end
-    it 'should be true if user is part of multiple organisations' do
+    it 'should check if the user is a member of multiple organisations' do
       expect(subject.many?).to be(true)
     end
   end

--- a/spec/services/authorisation_spec.rb
+++ b/spec/services/authorisation_spec.rb
@@ -110,4 +110,20 @@ RSpec.describe Authorisation do
       end
     end
   end
+
+  describe '#many?' do
+    subject do
+      described_class.new(
+        organisation_id: '939eac36-0777-48c2-9c2c-b87c948a9ee0',
+        user_id: '161d1f6a-44f1-4a1a-940d-d1088c439da7'
+      )
+    end
+
+    before(:each) do
+      stub_sign_in_with_multiple_organisations
+    end
+    it 'should be true if user is part of multiple organisations' do
+      expect(subject.many?).to be(true)
+    end
+  end
 end

--- a/spec/services/teacher_vacancy_authorisation_spec.rb
+++ b/spec/services/teacher_vacancy_authorisation_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'TeacherVacancyAuthorisation::Permissions' do
     end
   end
 
-  describe '#many?' do
+  describe '#many_schools?' do
     it 'returns true if there are multiple schools that the user is authorised with' do
       response = { user: { permissions: [{ school_urn: '12345' }, { school_urn: '23412' }] } }.to_json
       mock_http = double(:http, request: double(:reponse, code: '200', body: response))
@@ -78,7 +78,7 @@ RSpec.describe 'TeacherVacancyAuthorisation::Permissions' do
       expect(mock_http).to receive(:use_ssl=).with(true)
 
       service.authorise('sample-token')
-      expect(service.many?).to eq(true)
+      expect(service.many_schools?).to eq(true)
     end
 
     it 'returns false if there are multiple schools that the user is authorised with' do
@@ -90,7 +90,7 @@ RSpec.describe 'TeacherVacancyAuthorisation::Permissions' do
       expect(mock_http).to receive(:use_ssl=).with(true)
 
       service.authorise('sample-token')
-      expect(service.many?).to eq(false)
+      expect(service.many_schools?).to eq(false)
     end
   end
 

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -93,6 +93,17 @@ module AuthHelpers
       "https://test-url.local/users/#{user_id}/organisations"
     ).to_return(body: authorisation_response, status: 200)
   end
+
+  def stub_sign_in_with_single_organisation(user_id: 'some-user-id',
+                                            fixture_file:
+                                            'dfe_sing_in_user_user_organisations_response_with_single.json')
+    authorisation_response = File.read(Rails.root.join('spec', 'fixtures', fixture_file))
+
+    stub_request(
+      :get,
+      "https://test-url.local/users/#{user_id}/organisations"
+    ).to_return(body: authorisation_response, status: 200)
+  end
 end
 
 RSpec.shared_examples 'basic auth' do

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -84,7 +84,7 @@ module AuthHelpers
   end
 
   def stub_sign_in_with_multiple_organisations(user_id: '161d1f6a-44f1-4a1a-940d-d1088c439da7',
-                                              fixture_file: 'dfe_sign_in_user_organisations_response.json')
+                                               fixture_file: 'dfe_sign_in_user_organisations_response.json')
 
     authorisation_response = File.read(Rails.root.join('spec', 'fixtures', fixture_file))
 

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -82,6 +82,17 @@ module AuthHelpers
       'https://test-url.local/services/test-service-id/organisations/939eac36-0777-48c2-9c2c-b87c948a9ee0/users/161d1f6a-44f1-4a1a-940d-d1088c439da7'
     ).to_return(body: authorisation_response, status: 500)
   end
+
+  def stub_sign_in_with_multiple_organisations(user_id: '161d1f6a-44f1-4a1a-940d-d1088c439da7',
+                                              fixture_file: 'dfe_sign_in_user_organisations_response.json')
+
+    authorisation_response = File.read(Rails.root.join('spec', 'fixtures', fixture_file))
+
+    stub_request(
+      :get,
+      "https://test-url.local/users/#{user_id}/organisations"
+    ).to_return(body: authorisation_response, status: 200)
+  end
 end
 
 RSpec.shared_examples 'basic auth' do


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/FcMjGS2t/933-only-show-the-change-organisation-link-when-the-logged-in-user-is-invited-into-multiple-organisations-5

## Changes in this PR:

- show change organisation link to user only if they are part of multiple organisations (regardless of whether the DfE sign in feature flag is toggled on or off) 
