### PR TITLE
(chore) Fix label+checkbox alignment

### DIFF
--- a/app/assets/stylesheets/components/filter_vacancies.scss
+++ b/app/assets/stylesheets/components/filter_vacancies.scss
@@ -25,6 +25,10 @@
     background: govuk-colour("white");
     .govuk-checkboxes__item {
       max-height: 40px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-content: center;
     }
     label {
       background: govuk-colour("grey-3");
@@ -39,6 +43,9 @@
     &--scrollable {
       height: 220px;
       overflow: auto;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
     }
     padding: 10px 10px 0 10px;
     border: 2px solid govuk-colour("grey-1");


### PR DESCRIPTION
The text in the education phase search box was misaligned, this
fix uses the flex display property to align things properly.

## Trello card URL:
https://trello.com/c/Uc0OaSZh/959-misaligned-text-in-education-phase-search-box
### Before
![alt text](https://trello-attachments.s3.amazonaws.com/5ceffb569d58d308b5e2f310/528x468/d0f54be211a9cab0da01d83eb1460d3b/image.png)
### After
<img width="300" alt="Screenshot 2019-07-16 at 12 17 01" src="https://user-images.githubusercontent.com/22743709/61290473-dbd2d700-a7c3-11e9-935c-018a671c25cb.png">
