### PR TITLE
(chore) Add email to users table

### DIFF
--- a/db/migrate/20190717140656_add_email_to_users.rb
+++ b/db/migrate/20190717140656_add_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_18_093245) do
+ActiveRecord::Schema.define(version: 2019_07_17_140656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -168,6 +168,7 @@ ActiveRecord::Schema.define(version: 2019_06_18_093245) do
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "oid"
     t.datetime "accepted_terms_at"
+    t.string "email"
     t.index ["oid"], name: "index_users_on_oid", unique: true
   end
 


### PR DESCRIPTION
We want to start recording user emails when they log into the site so that we can remind hiring staff to provide feedback for expired vacancies. 
We've performed a migration to add an email column to the users table as a prerequisite to this.