### PR TITLE
(chore) Set a specific user to a published vacancy

### DIFF
--- a/app/controllers/hiring_staff/vacancies/publish_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/publish_controller.rb
@@ -1,9 +1,10 @@
 class HiringStaff::Vacancies::PublishController < HiringStaff::Vacancies::ApplicationController
   def create
     vacancy = Vacancy.find(vacancy_id)
+    user = current_user
     return redirect_to school_job_path(vacancy.id), notice: I18n.t('jobs.already_published') if vacancy.published?
 
-    if PublishVacancy.new(vacancy).call
+    if PublishVacancy.new(vacancy, user).call
       Auditor::Audit.new(vacancy, 'vacancy.publish', current_session_id).log
       AuditPublishedVacancyJob.perform_later(vacancy.id)
       update_google_index(vacancy) if vacancy.listed?

--- a/app/controllers/hiring_staff/vacancies/publish_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/publish_controller.rb
@@ -1,10 +1,9 @@
 class HiringStaff::Vacancies::PublishController < HiringStaff::Vacancies::ApplicationController
   def create
     vacancy = Vacancy.find(vacancy_id)
-    user = current_user
     return redirect_to school_job_path(vacancy.id), notice: I18n.t('jobs.already_published') if vacancy.published?
 
-    if PublishVacancy.new(vacancy, user).call
+    if PublishVacancy.new(vacancy, current_user).call
       Auditor::Audit.new(vacancy, 'vacancy.publish', current_session_id).log
       AuditPublishedVacancyJob.perform_later(vacancy.id)
       update_google_index(vacancy) if vacancy.listed?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -23,6 +23,8 @@ class Vacancy < ApplicationRecord
   include Elasticsearch::Model
   include Redis::Objects
 
+  belongs_to :publisher_user, class_name: 'User', optional: true
+
   index_name [Rails.env, model_name.collection.tr('\/', '-')].join('_')
   document_type 'vacancy'
   settings index: {

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -23,8 +23,6 @@ class Vacancy < ApplicationRecord
   include Elasticsearch::Model
   include Redis::Objects
 
-  belongs_to :publisher_user, class_name: 'User', optional: true
-
   index_name [Rails.env, model_name.collection.tr('\/', '-')].join('_')
   document_type 'vacancy'
   settings index: {
@@ -109,6 +107,7 @@ class Vacancy < ApplicationRecord
     hired_dont_know: 6
   }
 
+  belongs_to :publisher_user, class_name: 'User', optional: true
   belongs_to :school, optional: false
   belongs_to :subject, optional: true
   belongs_to :first_supporting_subject, class_name: 'Subject', optional: true

--- a/app/services/publish_vacancy.rb
+++ b/app/services/publish_vacancy.rb
@@ -1,11 +1,13 @@
 class PublishVacancy
-  def initialize(vacancy)
+  def initialize(vacancy, current_user)
     @vacancy = vacancy
+    @current_user = current_user
   end
 
   def call
     return false unless @vacancy.valid?
 
+    @vacancy.publisher_user_id = @current_user.id
     @vacancy.status = :published
     @vacancy.save
   end

--- a/db/migrate/20190719093146_add_user_ref_to_vacancies.rb
+++ b/db/migrate/20190719093146_add_user_ref_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddUserRefToVacancies < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :vacancies, :user, foreign_key: true, type: :uuid
+  end
+end

--- a/db/migrate/20190722142115_change_foreign_key_for_vacancies.rb
+++ b/db/migrate/20190722142115_change_foreign_key_for_vacancies.rb
@@ -1,0 +1,5 @@
+class ChangeForeignKeyForVacancies < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :vacancies, :user_id, :publisher_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_17_140656) do
+ActiveRecord::Schema.define(version: 2019_07_22_142115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -213,11 +213,13 @@ ActiveRecord::Schema.define(version: 2019_07_17_140656) do
     t.integer "listed_elsewhere"
     t.integer "hired_status"
     t.datetime "stats_updated_at"
+    t.uuid "publisher_user_id"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"
     t.index ["leadership_id"], name: "index_vacancies_on_leadership_id"
     t.index ["max_pay_scale_id"], name: "index_vacancies_on_max_pay_scale_id"
     t.index ["min_pay_scale_id"], name: "index_vacancies_on_min_pay_scale_id"
+    t.index ["publisher_user_id"], name: "index_vacancies_on_publisher_user_id"
     t.index ["school_id"], name: "index_vacancies_on_school_id"
     t.index ["second_supporting_subject_id"], name: "index_vacancies_on_second_supporting_subject_id"
     t.index ["subject_id"], name: "index_vacancies_on_subject_id"
@@ -235,4 +237,5 @@ ActiveRecord::Schema.define(version: 2019_07_17_140656) do
   end
 
   add_foreign_key "schools", "detailed_school_types"
+  add_foreign_key "vacancies", "users", column: "publisher_user_id"
 end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     association :subject
     association :leadership
     association :school
+    association :publisher_user, factory: :user
 
     job_title { Faker::Lorem.sentence[1...30].strip }
     job_description { Faker::Lorem.paragraph(4) }

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     association :subject
     association :leadership
     association :school
-    association :publisher_user, factory: :user
 
     job_title { Faker::Lorem.sentence[1...30].strip }
     job_description { Faker::Lorem.paragraph(4) }

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -468,10 +468,10 @@ RSpec.feature 'Creating a vacancy' do
         current_user = User.find_by(oid: session_id)
         vacancy = create(:vacancy, :draft, school: school)
 
-        expect(PublishVacancy).to receive(:new).with(vacancy, current_user).and_call_original
-
         visit school_job_review_path(vacancy.id)
         click_on 'Confirm and submit job'
+
+        expect(vacancy.reload.publisher_user_id).to eq(current_user.id)
       end
 
       scenario 'view the published listing as a job seeker' do

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -464,6 +464,16 @@ RSpec.feature 'Creating a vacancy' do
     end
 
     context '#publish' do
+      scenario 'adds the current user as a contact for feedback on the published vacancy' do
+        current_user = User.find_by(oid: session_id)
+        vacancy = create(:vacancy, :draft, school: school)
+
+        expect(PublishVacancy).to receive(:new).with(vacancy, current_user).and_call_original
+
+        visit school_job_review_path(vacancy.id)
+        click_on 'Confirm and submit job'
+      end
+
       scenario 'view the published listing as a job seeker' do
         vacancy = create(:vacancy, :draft, school_id: school.id)
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 RSpec.describe Vacancy, type: :model do
   subject { Vacancy.new(school: build(:school)) }
   it { should belong_to(:school) }
+  it { should belong_to(:publisher_user) }
 
   describe '.public_search' do
     context 'when there were no results' do

--- a/spec/services/publish_vacancy_spec.rb
+++ b/spec/services/publish_vacancy_spec.rb
@@ -1,13 +1,21 @@
 require 'rails_helper'
 
-RSpec.describe VacancySearchBuilder do
-  let(:vacancy) { create(:vacancy, :draft) }
+RSpec.describe PublishVacancy do
+  let(:user) { create(:user) }
+  let(:vacancy) { create(:vacancy, :draft, publisher_user: nil) }
 
   describe '#call' do
     it "updates the vacancy's status to published" do
-      PublishVacancy.new(vacancy).call
+      PublishVacancy.new(vacancy, user).call
 
       expect(vacancy.status).to eq('published')
+    end
+
+    it 'updates the id of the user who confirmed the publishing of a vacancy' do
+      PublishVacancy.new(vacancy, user).call
+      vacancy.reload
+
+      expect(vacancy.publisher_user_id).to eq(user.id)
     end
   end
 end


### PR DESCRIPTION
As part of a feature to nudge users into giving feedback on expired vacancies that are older than 2 weeks. 
We needed to:
- Associate a published vacancy with a user id.
- Identify which user to target with this feature i.e `publisher_user`
- Identify where in the application we would retrieve the user information.