### PR TITLE
(chore) Instruct GA to accept linker parameters

### DIFF
--- a/app/views/shared/_gtag.html.haml
+++ b/app/views/shared/_gtag.html.haml
@@ -4,4 +4,4 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', "#{ENV['GOOGLE_ANALYTICS']}", { 'anonymize_ip': true });
+  gtag('config', "#{ENV['GOOGLE_ANALYTICS']}", { 'anonymize_ip': true, 'linker': { 'accept_incoming': 'true' } });


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/g8vatPQm/981-configure-our-site-to-accept-linker-parameters

## Changes in this PR:
So that we can track users journey from before they got to the
GOV.UK pages, we need to enable "cross-domain measurement" in
Google Analytics.

For more information on this see:
https://developers.google.com/analytics/devguides/collection/gtagjs/cross-domain#configuring_a_site_to_accept_linker_parameters
