### PR TITLE
Remove service rating section on general feedback page

### DIFF
--- a/app/assets/stylesheets/components/feedback_form.scss
+++ b/app/assets/stylesheets/components/feedback_form.scss
@@ -5,12 +5,3 @@
     margin-top: 0;
   }
 }
-
-.general-feedback-form-group {
-  margin-top: 50px;
-  margin-bottom: 0px;
-
-  &:first-child {
-    margin-top: 0;
-  }
-}

--- a/app/assets/stylesheets/components/feedback_form.scss
+++ b/app/assets/stylesheets/components/feedback_form.scss
@@ -5,3 +5,12 @@
     margin-top: 0;
   }
 }
+
+.general-feedback-form-group {
+  margin-top: 50px;
+  margin-bottom: 0px;
+
+  &:first-child {
+    margin-top: 0;
+  }
+}

--- a/app/controllers/general_feedback_controller.rb
+++ b/app/controllers/general_feedback_controller.rb
@@ -16,6 +16,6 @@ class GeneralFeedbackController < ApplicationController
   private
 
   def general_feedback_params
-    params.require(:general_feedback).permit(:visit_purpose, :visit_purpose_comment, :rating, :comment)
+    params.require(:general_feedback).permit(:visit_purpose, :visit_purpose_comment, :comment)
   end
 end

--- a/app/models/general_feedback.rb
+++ b/app/models/general_feedback.rb
@@ -5,7 +5,6 @@ class GeneralFeedback < ApplicationRecord
 
   validates :visit_purpose, presence: true
   validates :visit_purpose_comment, length: { maximum: 1200 }, if: :visit_purpose_comment?
-  validates :rating, presence: true
   validates :comment, length: { maximum: 1200 }, if: :comment?
 
   scope :published_on, (->(date) { where(created_at: date.all_day) })

--- a/app/views/general_feedback/new.html.haml
+++ b/app/views/general_feedback/new.html.haml
@@ -5,7 +5,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
 
-      .govuk-form-group.general-feedback-form-group
+      .govuk-form-group.feedback-form-group
         %fieldset.govuk-fieldset
           %legend.govuk-fieldset__legend.govuk-fieldset__legend--m
             %h2.govuk-fieldset__heading
@@ -23,15 +23,15 @@
                 hint: t('general_feedback.visit_purpose_hint_text').html_safe,
                 input_html: { class: 'form-control form-control-4-4', rows: '5' }
 
-      .govuk-form-group.general-feedback-form-group
+      .govuk-form-group.feedback-form-group
         %fieldset.govuk-fieldset
           %legend.govuk-fieldset__legend.govuk-fieldset__legend--m
             %h2.govuk-fieldset__heading
               = t('feedback.comment_label')
 
-      = f.input :comment, as: :text,
-                  wrapper: :textarea,
-                  label: false,
-                  input_html: { class: 'form-control form-control-4-4', rows: '5' }
+        = f.input :comment, as: :text,
+                    wrapper: :textarea,
+                    label: false,
+                    input_html: { class: 'form-control form-control-4-4', rows: '5' }
 
       = f.submit t('feedback.submit'), class: 'govuk-button'

--- a/app/views/general_feedback/new.html.haml
+++ b/app/views/general_feedback/new.html.haml
@@ -5,7 +5,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
 
-      .govuk-form-group.feedback-form-group
+      .govuk-form-group.general-feedback-form-group
         %fieldset.govuk-fieldset
           %legend.govuk-fieldset__legend.govuk-fieldset__legend--m
             %h2.govuk-fieldset__heading
@@ -23,6 +23,15 @@
                 hint: t('general_feedback.visit_purpose_hint_text').html_safe,
                 input_html: { class: 'form-control form-control-4-4', rows: '5' }
 
-      = render partial: '/feedback/fields', locals: { form: f }
+      .govuk-form-group.general-feedback-form-group
+        %fieldset.govuk-fieldset
+          %legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+            %h2.govuk-fieldset__heading
+              = t('feedback.comment_label')
+
+      = f.input :comment, as: :text,
+                  wrapper: :textarea,
+                  label: false,
+                  input_html: { class: 'form-control form-control-4-4', rows: '5' }
 
       = f.submit t('feedback.submit'), class: 'govuk-button'

--- a/spec/features/general_feedback_spec.rb
+++ b/spec/features/general_feedback_spec.rb
@@ -2,22 +2,8 @@ require 'rails_helper'
 RSpec.feature 'Giving general feedback for the service' do
   before(:each) { visit new_feedback_path }
 
-  context 'when viewing the visiting purpose section' do
-    it 'displays the section heading' do
-      expect(page).to have_content(I18n.t('general_feedback.visit_purpose_legend'))
-    end
-
-    it 'displays the visiting purpose options' do
-      expect(page).to have_content(I18n.t('general_feedback.visit_purpose_options.find_teaching_job'))
-      expect(page).to have_content(I18n.t('general_feedback.visit_purpose_options.list_teaching_job'))
-      expect(page).to have_content(I18n.t('general_feedback.visit_purpose_options.other_purpose'))
-    end
-  end
-
-  context 'when viewing the service rating comment section' do
-    it 'displays the section heading' do
-      expect(page).to have_content(I18n.t('feedback.comment_label'))
-    end
+  it 'displays the general feedback page' do
+    expect(page).to have_content(I18n.t('feedback.heading'))
   end
 
   scenario 'successfully submitting feedback for the service' do

--- a/spec/features/general_feedback_spec.rb
+++ b/spec/features/general_feedback_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+RSpec.feature 'Giving general feedback for the service' do
+  before(:each) { visit new_feedback_path }
+
+  context 'when viewing the visiting purpose section' do
+    it 'displays the section heading' do
+      expect(page).to have_content(I18n.t('general_feedback.visit_purpose_legend'))
+    end
+
+    it 'displays the visiting purpose options' do
+      expect(page).to have_content(I18n.t('general_feedback.visit_purpose_options.find_teaching_job'))
+      expect(page).to have_content(I18n.t('general_feedback.visit_purpose_options.list_teaching_job'))
+      expect(page).to have_content(I18n.t('general_feedback.visit_purpose_options.other_purpose'))
+    end
+  end
+
+  context 'when viewing the service rating comment section' do
+    it 'displays the section heading' do
+      expect(page).to have_content(I18n.t('feedback.comment_label'))
+    end
+  end
+
+  scenario 'successfully submitting feedback for the service' do
+    choose 'Find a job in teaching'
+
+    fill_in 'general_feedback_comment', with: 'Keep going!'
+
+    click_on 'Submit feedback'
+
+    expect(page).to have_content('Your feedback has been successfully submitted')
+  end
+end

--- a/spec/models/general_feedback_spec.rb
+++ b/spec/models/general_feedback_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe GeneralFeedback, type: :model do
   describe 'validations' do
     it { should validate_presence_of :visit_purpose }
     it { should validate_length_of(:visit_purpose_comment).is_at_most(1200) }
-    it { should validate_presence_of :rating }
     it { should validate_length_of(:comment).is_at_most(1200) }
   end
 


### PR DESCRIPTION
This is the first slice towards a redesign of the general feedback page.

## Screenshots of UI changes:

### Before

<img width="612" alt="Screenshot 2019-07-25 at 09 48 40" src="https://user-images.githubusercontent.com/32823756/61860722-51c0f780-aec2-11e9-99b8-75c3433881d6.png">

------------------------------------------------------------------------------------------------------

### After
<img width="739" alt="Screenshot 2019-07-24 at 16 02 58" src="https://user-images.githubusercontent.com/32823756/61807116-cfd4be00-ae30-11e9-986f-42d7867da2d5.png">
