### PR TITLE
Email hiring staff to request feedback

### DIFF
--- a/app/jobs/send_expired_vacancy_feedback_email_job.rb
+++ b/app/jobs/send_expired_vacancy_feedback_email_job.rb
@@ -3,9 +3,8 @@ class SendExpiredVacancyFeedbackEmailJob < ApplicationJob
 
   def perform
     expired_vacancies.group_by(&:publisher_user).each do |user, users_vacancies|
-      FeedbackPromptMailer.prompt_for_feedback(user.email, users_vacancies).deliver_later unless user.email.nil?
-
       unless user.email.nil?
+        FeedbackPromptMailer.prompt_for_feedback(user.email, users_vacancies).deliver_later
         Rails.logger.info("Sidekiq: Sending feedback prompt emails for #{users_vacancies.count} vacancies")
       end
     end

--- a/app/jobs/send_expired_vacancy_feedback_email_job.rb
+++ b/app/jobs/send_expired_vacancy_feedback_email_job.rb
@@ -1,0 +1,16 @@
+class SendExpiredVacancyFeedbackEmailJob < ApplicationJob
+  queue_as :email_feedback_prompt
+
+  def perform
+    expired_vacancies.group_by(&:publisher_user).each do |user, users_vacancies|
+      FeedbackPromptMailer.prompt_for_feedback(user.email, users_vacancies).deliver_later unless user.email.nil?
+    end
+  end
+
+  private
+
+  def expired_vacancies
+    Vacancy.where(expires_on: Time.zone.now - 2.weeks, hired_status: nil)
+           .where.not(publisher_user: nil)
+  end
+end

--- a/app/jobs/send_expired_vacancy_feedback_email_job.rb
+++ b/app/jobs/send_expired_vacancy_feedback_email_job.rb
@@ -4,6 +4,7 @@ class SendExpiredVacancyFeedbackEmailJob < ApplicationJob
   def perform
     expired_vacancies.group_by(&:publisher_user).each do |user, users_vacancies|
       FeedbackPromptMailer.prompt_for_feedback(user.email, users_vacancies).deliver_later unless user.email.nil?
+      Rails.logger.info("Sidekiq: Sending feedback prompt emails for #{users_vacancies.count} vacancies") unless user.email.nil?
     end
   end
 

--- a/app/jobs/send_expired_vacancy_feedback_email_job.rb
+++ b/app/jobs/send_expired_vacancy_feedback_email_job.rb
@@ -4,7 +4,10 @@ class SendExpiredVacancyFeedbackEmailJob < ApplicationJob
   def perform
     expired_vacancies.group_by(&:publisher_user).each do |user, users_vacancies|
       FeedbackPromptMailer.prompt_for_feedback(user.email, users_vacancies).deliver_later unless user.email.nil?
-      Rails.logger.info("Sidekiq: Sending feedback prompt emails for #{users_vacancies.count} vacancies") unless user.email.nil?
+
+      unless user.email.nil?
+        Rails.logger.info("Sidekiq: Sending feedback prompt emails for #{users_vacancies.count} vacancies")
+      end
     end
   end
 

--- a/app/mailers/feedback_prompt_mailer.rb
+++ b/app/mailers/feedback_prompt_mailer.rb
@@ -1,0 +1,11 @@
+class FeedbackPromptMailer < ApplicationMailer
+  def prompt_for_feedback(email, vacancies)
+    @vacancies = vacancies
+
+    view_mail(
+      NOTIFY_PROMPT_FEEDBACK_FOR_EXPIRED_VACANCIES,
+      to: [email],
+      subject: 'Teaching Vacancies needs your feedback on expired job listings',
+    )
+  end
+end

--- a/app/views/feedback_prompt_mailer/prompt_for_feedback.text.haml
+++ b/app/views/feedback_prompt_mailer/prompt_for_feedback.text.haml
@@ -1,0 +1,19 @@
+\# #{t('app.title')}
+
+Dear vacancy publisher,
+\
+We’re constantly working to improve #{t('app.title')}. Our aim is to make the service the preferred resource for getting schools the teachers they need while saving them money on recruitment costs.
+\
+But to make effective improvements we need the insights of our users, including feedback from schools like yours on their expired job listings.
+\
+Please help us by answering a couple quick questions about the following expired listings:
+
+- @vacancies.each do |vacancy|
+  = "* #{vacancy.job_title}"
+
+\
+Just sign into your Teaching Vacancies account and select the ‘Jobs awaiting feedback’ tab. It will only take a minute and the data is essential to our efforts to improve Teaching Vacancies.
+\
+Kind regards,
+\
+#{t('app.title')}

--- a/lib/tasks/send_feedback_prompt_email.rake
+++ b/lib/tasks/send_feedback_prompt_email.rake
@@ -1,5 +1,5 @@
 namespace :feedback_prompt_email do
   task send: :environment do
-    SendExpiredVacancyFeedbackEmailJob.perform_later
+    SendExpiredVacancyFeedbackEmailJob.perform_now
   end
 end

--- a/lib/tasks/send_feedback_prompt_email.rake
+++ b/lib/tasks/send_feedback_prompt_email.rake
@@ -1,0 +1,5 @@
+namespace :feedback_prompt_email do
+  task send: :environment do
+    SendExpiredVacancyFeedbackEmailJob.perform_later
+  end
+end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -115,5 +115,10 @@ FactoryBot.define do
       sequence(:slug) { |n| "slug-#{n}" }
       working_patterns { nil }
     end
+
+    trait :with_feedback do
+      listed_elsewhere { :listed_paid }
+      hired_status { :hired_tvs }
+    end
   end
 end

--- a/spec/features/hiring_staff_receive_email_prompt_for_expired_vacancy_feedback_spec.rb
+++ b/spec/features/hiring_staff_receive_email_prompt_for_expired_vacancy_feedback_spec.rb
@@ -5,12 +5,12 @@ RSpec.feature 'Creating a vacancy' do
   let(:session_id) { SecureRandom.uuid }
 
   before(:each) do
+    ActionMailer::Base.deliveries.clear
     stub_hiring_staff_auth(urn: school.urn, session_id: session_id, email: 'test@mail.com')
   end
 
   after(:each) do
     Timecop.return
-    ActionMailer::Base.deliveries.clear
   end
 
   context 'Hiring staff has expired vacancy that is not older than 2 weeks' do

--- a/spec/features/hiring_staff_receive_email_prompt_for_expired_vacancy_feedback_spec.rb
+++ b/spec/features/hiring_staff_receive_email_prompt_for_expired_vacancy_feedback_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+RSpec.feature 'Creating a vacancy' do
+  include ActiveJob::TestHelper
+  let(:school) { create(:school) }
+  let(:session_id) { SecureRandom.uuid }
+
+  before(:each) do
+    stub_hiring_staff_auth(urn: school.urn, session_id: session_id, email: 'test@mail.com')
+  end
+
+  after(:each) do
+    Timecop.return
+    ActionMailer::Base.deliveries.clear
+  end
+
+  context 'Hiring staff has expired vacancy that is not older than 2 weeks' do
+    scenario 'does not receive feedback prompt e-mail' do
+      current_user = User.find_by(oid: session_id)
+      create(
+        :vacancy,
+        :published,
+        school: school,
+        job_title: 'Vacancy',
+        publish_on: Time.zone.today,
+        expires_on: Time.zone.today + 1.week,
+        publisher_user_id: current_user.id
+      )
+
+      Timecop.freeze(Time.zone.now + 2.weeks)
+
+      perform_enqueued_jobs do
+        SendExpiredVacancyFeedbackEmailJob.new.perform
+      end
+
+      expect(ApplicationMailer.deliveries.count).to eq(0)
+    end
+  end
+
+  context 'Hiring staff has 2 expired vacancies that are older than 2 weeks' do
+    scenario 'receives feedback prompt email with 2 vacancies' do
+      current_user = User.find_by(oid: session_id)
+      create(
+        :vacancy,
+        :published,
+        school: school,
+        job_title: 'Job one',
+        publish_on: Time.zone.today,
+        expires_on: Time.zone.today,
+        publisher_user_id: current_user.id
+      )
+
+      create(
+        :vacancy,
+        :published,
+        school: school,
+        job_title: 'Job two',
+        publish_on: Time.zone.today,
+        expires_on: Time.zone.today,
+        publisher_user_id: current_user.id
+      )
+
+      create(
+        :vacancy,
+        :published,
+        school: school,
+        job_title: 'Job three',
+        publish_on: Time.zone.today,
+        expires_on: Time.zone.today + 2.weeks,
+        publisher_user_id: current_user.id
+      )
+
+      Timecop.freeze(Time.zone.now + 2.weeks)
+
+      perform_enqueued_jobs do
+        SendExpiredVacancyFeedbackEmailJob.new.perform
+      end
+
+      expect(ApplicationMailer.deliveries.first.to).to eq(['test@mail.com'])
+      expect(ApplicationMailer.deliveries.count).to eq(1)
+      expect(ApplicationMailer.deliveries.first.body).to have_content('Job one')
+      expect(ApplicationMailer.deliveries.first.body).to have_content('Job two')
+      expect(ApplicationMailer.deliveries.first.body).to_not have_content('Job three')
+    end
+  end
+
+  context 'Two expired vacancies for two users that are older than 2 weeks' do
+    scenario 'both receives feedback prompt emails' do
+      current_user = User.find_by(oid: session_id)
+      another_user = create(:user, email: 'another@user.com')
+      create(
+        :vacancy,
+        :published,
+        school: school,
+        job_title: 'Job one',
+        publish_on: Time.zone.today,
+        expires_on: Time.zone.today,
+        publisher_user_id: current_user.id
+      )
+
+      create(
+        :vacancy,
+        :published,
+        school: school,
+        job_title: 'Job two',
+        publish_on: Time.zone.today,
+        expires_on: Time.zone.today,
+        publisher_user_id: another_user.id
+      )
+
+      Timecop.freeze(Time.zone.now + 2.weeks)
+
+      perform_enqueued_jobs do
+        SendExpiredVacancyFeedbackEmailJob.new.perform
+      end
+
+      expect(ApplicationMailer.deliveries.map(&:to)).to match(
+        [['another@user.com'], ['test@mail.com']]
+      )
+      expect(ApplicationMailer.deliveries.count).to eq(2)
+    end
+  end
+end

--- a/spec/jobs/send_expired_vacancy_feedback_email_prompts_job_spec.rb
+++ b/spec/jobs/send_expired_vacancy_feedback_email_prompts_job_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+RSpec.describe SendExpiredVacancyFeedbackEmailJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later }
+  let(:mail) { double('Mail::Message', deliver_later: true) }
+
+  before do
+    allow(FeedbackPromptMailer).to receive(:prompt_for_feedback) { mail }
+  end
+
+  context 'when adding job to the queue' do
+    it 'queues the job' do
+      expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+    end
+
+    it 'is in the email_feedback_prompt queue' do
+      expect(job.queue_name).to eq('email_feedback_prompt')
+    end
+  end
+
+  context 'for one hiring staff' do
+    let(:user) { create(:user, email: email_of_hiring_staff) }
+    let(:email_of_hiring_staff) { 'email@exmaple.com' }
+
+    context 'with one expired vacancy needing feedback' do
+      let!(:expired_vacancy) { create(:vacancy, :expired, publisher_user: user, expires_on: Time.zone.today) }
+
+      it 'sends an email' do
+        expect(FeedbackPromptMailer).to receive(:prompt_for_feedback).with(email_of_hiring_staff, [expired_vacancy])
+        expect(mail).to receive(:deliver_later)
+        send_expired_vacancy_feedback_emails
+      end
+
+      context 'but the hiring staff has no email address' do
+        let(:email_of_hiring_staff) { nil }
+
+        it 'does not send an email' do
+          expect(FeedbackPromptMailer).to_not receive(:prompt_for_feedback)
+          send_expired_vacancy_feedback_emails
+        end
+      end
+    end
+
+    context 'with one expired vacancy with feedback already completed' do
+      let!(:expired_vacancies) do
+        create(:vacancy, :expired, :with_feedback, expires_on: Time.zone.today, publisher_user: user)
+      end
+
+      it 'does not send an email' do
+        expect(FeedbackPromptMailer).to_not receive(:prompt_for_feedback)
+        send_expired_vacancy_feedback_emails
+      end
+    end
+
+    context 'with two expired vacancies needing feedback' do
+      let!(:expired_vacancies) do
+        [create(:vacancy, :expired, expires_on: Time.zone.today, publisher_user: user),
+         create(:vacancy, :expired, expires_on: Time.zone.today, publisher_user: user)]
+      end
+
+      it 'sends an email with both vacancies' do
+        expect(FeedbackPromptMailer).to receive(:prompt_for_feedback).with(
+          email_of_hiring_staff,
+          a_collection_containing_exactly(*expired_vacancies)
+        )
+        send_expired_vacancy_feedback_emails
+      end
+    end
+
+    context 'running the job before hiring staff have had 2 weeks opportunity to fill in feedback' do
+      let!(:expired_vacancy) do
+        create(:vacancy, :expired, expires_on: Time.zone.today, publisher_user: user)
+      end
+
+      it 'sends no emails' do
+        expect(FeedbackPromptMailer).to_not receive(:prompt_for_feedback)
+
+        send_expired_vacancy_feedback_emails 1.week
+      end
+    end
+  end
+
+  context 'for two hiring staff' do
+    let(:first_hiring_staff) { create(:user, email: 'first_hiring_staff@email.com') }
+    let(:second_hiring_staff) { create(:user, email: 'second_hiring_staff@email.com') }
+
+    context 'with one expired vacancy each' do
+      let(:first_expired_vacancy) do
+        create(:vacancy, :expired, expires_on: Time.zone.today, publisher_user: first_hiring_staff)
+      end
+
+      let(:second_expired_vacancy) do
+        create(:vacancy, :expired, expires_on: Time.zone.today, publisher_user: second_hiring_staff)
+      end
+
+      it 'sends one email for each hiring staff' do
+        expect(FeedbackPromptMailer).to receive(:prompt_for_feedback).with(
+          first_hiring_staff.email,
+          [first_expired_vacancy]
+        )
+        expect(FeedbackPromptMailer).to receive(:prompt_for_feedback).with(
+          second_hiring_staff.email,
+          [second_expired_vacancy]
+        )
+        send_expired_vacancy_feedback_emails
+      end
+    end
+  end
+
+  context 'without a publisher hiring staff' do
+    context 'with one expired vacancy needing feedback' do
+      let!(:expired_vacancy) { create(:vacancy, :expired, expires_on: Time.zone.today, publisher_user: nil) }
+
+      it 'does not send an email' do
+        expect(FeedbackPromptMailer).to_not receive(:prompt_for_feedback)
+        send_expired_vacancy_feedback_emails
+      end
+    end
+  end
+
+  def send_expired_vacancy_feedback_emails(after = 2.weeks)
+    Timecop.travel(Time.zone.now + after) do
+      perform_enqueued_jobs { job }
+    end
+  end
+end

--- a/spec/mailers/feedback_prompt_mailer_spec.rb
+++ b/spec/mailers/feedback_prompt_mailer_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe FeedbackPromptMailer, type: :mailer do
+  include DateHelper
+
+  let(:body) { mail.body.raw_source }
+
+  describe 'prompt_for_feedback' do
+    before(:each) do
+      stub_const('NOTIFY_PROMPT_FEEDBACK_FOR_EXPIRED_VACANCIES', '')
+    end
+    let(:email_address) { 'dummy@dum.com' }
+    let(:mail) { described_class.prompt_for_feedback(email_address, vacancies) }
+    let(:vacancies) { create_list(:vacancy, 2, :published) }
+
+    context 'with two vacancies' do
+      it 'shows both vacancies' do
+        expect(mail.subject).to eq('Teaching Vacancies needs your feedback on expired job listings')
+        expect(mail.to).to eq([email_address])
+
+        expect(body).to match(/Dear vacancy publisher/)
+
+        expect(body).to match(/\* #{vacancies.first.job_title}/)
+        expect(body).to match(/\* #{vacancies.second.job_title}/)
+      end
+    end
+  end
+end

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -25,10 +25,10 @@ module AuthHelpers
     allow(fake_env).to receive(env_field_for_password.to_sym).and_return(env_value_for_password)
   end
 
-  def stub_hiring_staff_auth(urn:, session_id: 'session_id')
+  def stub_hiring_staff_auth(urn:, session_id: 'session_id', email: nil)
     page.set_rack_session(urn: urn)
     page.set_rack_session(session_id: session_id)
-    create(:user, oid: session_id)
+    create(:user, oid: session_id, email: email)
   end
 
   def stub_authentication_step(organisation_id: '939eac36-0777-48c2-9c2c-b87c948a9ee0',

--- a/terraform.tf
+++ b/terraform.tf
@@ -94,6 +94,9 @@ module "ecs" {
   send_job_alerts_daily_email_task_command  = "${var.send_job_alerts_daily_email_task_command}"
   send_job_alerts_daily_email_task_schedule = "${var.send_job_alerts_daily_email_task_schedule}"
 
+  send_feedback_prompt_email_task_command = "${var.send_feedback_prompt_email_task_command}"
+  send_feedback_prompt_email_task_schedule = "${var.send_feedback_prompt_email_task_schedule}"
+
   sessions_trim_task_command  = "${var.sessions_trim_task_command}"
   sessions_trim_task_schedule = "${var.sessions_trim_task_schedule}"
 

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -523,6 +523,23 @@ module "send_job_alerts_daily_email_task" {
   event_role_arn     = "${aws_iam_role.scheduled_task_role.arn}"
 }
 
+module "send_feedback_prompt_email_task" {
+  source = "../scheduled-ecs-task"
+
+  task_name        = "${var.ecs_service_web_task_name}_send_feedback_prompt_email"
+  task_description = "Send daily feedback prompt emails for expired vacancies"
+  task_command     = "${var.send_feedback_prompt_email_task_command}"
+  task_schedule    = "${var.send_feedback_prompt_email_task_schedule}"
+
+  container_definition_template = "${module.rake_container_definition.template}"
+
+  ecs_cluster_arn = "${aws_ecs_cluster.cluster.arn}"
+
+  execution_role_arn = "${aws_iam_role.ecs_execution_role.arn}"
+  task_role_arn      = "${aws_iam_role.ecs_execution_role.arn}"
+  event_role_arn     = "${aws_iam_role.scheduled_task_role.arn}"
+}
+
 module "import_schools_task" {
   source = "../scheduled-ecs-task"
 

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -114,6 +114,10 @@ variable "send_job_alerts_daily_email_task_command" {
   type = "list"
 }
 
+variable "send_feedback_prompt_email_task_command" {
+  type = "list"
+}
+
 variable "sessions_trim_task_command" {
   type = "list"
 }
@@ -144,6 +148,7 @@ variable "update_spreadsheets_task_command" {
 
 variable "update_spreadsheets_task_schedule" {}
 variable "send_job_alerts_daily_email_task_schedule" {}
+variable "send_feedback_prompt_email_task_schedule" {}
 
 variable "vacancies_statistics_refresh_cache_task_command" {
   type = "list"

--- a/variables.tf
+++ b/variables.tf
@@ -164,6 +164,17 @@ variable "send_job_alerts_daily_email_task_schedule" {
   default     = "cron(0 08 * * ? *)"
 }
 
+variable "send_feedback_prompt_email_task_command" {
+  description = "The Entrypoint for the send_feedback_prompt_email task"
+  default     = ["rake", "verbose", "feedback_prompt_email:send"]
+}
+
+variable "send_feedback_prompt_email_task_schedule" {
+  description = "send_feedback_prompt_email schedule expression - https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
+  default     = "cron(0 09 * * ? *)"
+}
+
+
 variable "import_schools_task_command" {
   description = "The Entrypoint for the import_schools task"
   default     = ["rake", "verbose", "data:schools:import"]

--- a/variables.tf
+++ b/variables.tf
@@ -174,7 +174,6 @@ variable "send_feedback_prompt_email_task_schedule" {
   default     = "cron(0 09 * * ? *)"
 }
 
-
 variable "import_schools_task_command" {
   description = "The Entrypoint for the import_schools task"
   default     = ["rake", "verbose", "data:schools:import"]


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/w6XuSGrN/970-e-mail-hiring-staff-2-weeks-after-a-vacancy-expires-to-ask-them-to-provide-feedback-8

## Changes in this PR:
- Add new mailer to prompt hiring staff for feedback on expired vacancies which are older than 2 weeks
- Create a new job for sending out feedback prompt emails
- Add rake task to schedule emails
- Add unit tests and end to end test accordingly

## Screenshots of UI changes:
<img width="1179" alt="Screenshot 2019-07-29 at 10 44 10" src="https://user-images.githubusercontent.com/22743709/62038558-df1b8900-b1ed-11e9-81ae-3d235dd25e91.png">

## Next steps:

- [ ] Terraform deployment required
- [ ] Check new cron job 
- [ ] Start recording user email on sign in