### PR TITLE
(chore) Add domains to the linker parameter

### DIFF
--- a/app/views/shared/_gtag.html.haml
+++ b/app/views/shared/_gtag.html.haml
@@ -4,4 +4,7 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', "#{ENV['GOOGLE_ANALYTICS']}", { 'anonymize_ip': true, 'linker': { 'accept_incoming': 'true' } });
+  gtag('config', "#{ENV['GOOGLE_ANALYTICS']}", { 'anonymize_ip': true, 'linker': {
+     'domains': ['gov.uk/find-teaching-job', 'gov.uk/guidance/list-a-teaching-job-at-your-school-on-teaching-vacancies'],
+    'accept_incoming': 'true' }
+  });


### PR DESCRIPTION
We want to be able to track user journey before they get onto
the TVS website, there are currently 2 other .gov.uk sites that are
related to TVS, the linker parameter should treat them as part of
TVS.