### PR TITLE
Add user participation request section to general feedback

### DIFF
--- a/app/controllers/general_feedback_controller.rb
+++ b/app/controllers/general_feedback_controller.rb
@@ -16,6 +16,7 @@ class GeneralFeedbackController < ApplicationController
   private
 
   def general_feedback_params
-    params.require(:general_feedback).permit(:visit_purpose, :visit_purpose_comment, :comment)
+    params.require(:general_feedback)
+          .permit(:visit_purpose, :visit_purpose_comment, :comment, :user_participation_response)
   end
 end

--- a/app/controllers/general_feedback_controller.rb
+++ b/app/controllers/general_feedback_controller.rb
@@ -17,6 +17,6 @@ class GeneralFeedbackController < ApplicationController
 
   def general_feedback_params
     params.require(:general_feedback)
-          .permit(:visit_purpose, :visit_purpose_comment, :comment, :user_participation_response)
+          .permit(:visit_purpose, :visit_purpose_comment, :comment, :user_participation_response, :email)
   end
 end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -12,11 +12,4 @@ module FeedbackHelper
      [t('feedback.rating2_option'), 2],
      [t('feedback.rating1_option'), 1]]
   end
-
-  def participation_options
-    [
-      [t('general_feedback.user_participation_options.interested'), :interested],
-      [t('general_feedback.user_participation_options.not_interested'), :not_interested]
-    ]
-  end
 end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -12,4 +12,11 @@ module FeedbackHelper
      [t('feedback.rating2_option'), 2],
      [t('feedback.rating1_option'), 1]]
   end
+
+  def participation_options
+    [
+      [t('general_feedback.user_participation_options.interested'), :interested],
+      [t('general_feedback.user_participation_options.not_interested'), :not_interested]
+    ]
+  end
 end

--- a/app/models/general_feedback.rb
+++ b/app/models/general_feedback.rb
@@ -23,7 +23,9 @@ class GeneralFeedback < ApplicationRecord
       visit_purpose_comment,
       rating,
       comment,
-      created_at.to_s
+      created_at.to_s,
+      user_participation_response,
+      email
     ]
   end
 end

--- a/app/models/general_feedback.rb
+++ b/app/models/general_feedback.rb
@@ -8,8 +8,13 @@ class GeneralFeedback < ApplicationRecord
   validates :visit_purpose_comment, length: { maximum: 1200 }, if: :visit_purpose_comment?
   validates :comment, length: { maximum: 1200 }, if: :comment?
   validates :user_participation_response, presence: true
+  validates :email, presence: true, if: :user_is_interested?
 
   scope :published_on, (->(date) { where(created_at: date.all_day) })
+
+  def user_is_interested?
+    return true if user_participation_response == 'interested'
+  end
 
   def to_row
     [

--- a/app/models/general_feedback.rb
+++ b/app/models/general_feedback.rb
@@ -8,7 +8,7 @@ class GeneralFeedback < ApplicationRecord
   validates :visit_purpose_comment, length: { maximum: 1200 }, if: :visit_purpose_comment?
   validates :comment, length: { maximum: 1200 }, if: :comment?
   validates :user_participation_response, presence: true
-  validates :email, presence: true, if: :user_is_interested?
+  validates :email, email_address: { presence: true }, if: :user_is_interested?
 
   scope :published_on, (->(date) { where(created_at: date.all_day) })
 

--- a/app/models/general_feedback.rb
+++ b/app/models/general_feedback.rb
@@ -2,10 +2,12 @@ class GeneralFeedback < ApplicationRecord
   include Auditor::Model
 
   enum visit_purpose: %i[other_purpose find_teaching_job list_teaching_job]
+  enum user_participation_response: %i[interested not_interested]
 
   validates :visit_purpose, presence: true
   validates :visit_purpose_comment, length: { maximum: 1200 }, if: :visit_purpose_comment?
   validates :comment, length: { maximum: 1200 }, if: :comment?
+  validates :user_participation_response, presence: true
 
   scope :published_on, (->(date) { where(created_at: date.all_day) })
 

--- a/app/views/general_feedback/new.html.haml
+++ b/app/views/general_feedback/new.html.haml
@@ -48,7 +48,7 @@
               = f.input :email, as: :email,
                   label: t('general_feedback.user_interested_email_heading'),
                   hint: t('general_feedback.user_interested_email_text'),
-                  wrapper_html: {id: 'email', class: "govuk-details__text"},
+                  wrapper_html: {id: 'email', class: "govuk-inset-text"},
                   required: true
 
             .govuk-radios__item

--- a/app/views/general_feedback/new.html.haml
+++ b/app/views/general_feedback/new.html.haml
@@ -45,6 +45,13 @@
               = f.radio_button(:user_participation_response, :interested, class: 'govuk-radios__input')
               = f.label(t('general_feedback.user_participation_options.interested'), class: "govuk-label govuk-radios__label", required: true)
 
+              = f.input :email,
+                label: t('jobs.contact_email'),
+                hint: t('jobs.form_hints.contact_email'),
+                as: :email,
+                wrapper_html: {id: 'contact_email'},
+                required: true
+
             .govuk-radios__item
               = f.radio_button(:user_participation_response, :not_interested, class: 'govuk-radios__input')
               = f.label(t('general_feedback.user_participation_options.not_interested'), class: "govuk-label govuk-radios__label", required: true)

--- a/app/views/general_feedback/new.html.haml
+++ b/app/views/general_feedback/new.html.haml
@@ -39,11 +39,15 @@
           %legend.govuk-fieldset__legend.govuk-fieldset__legend--m
             %h2.govuk-fieldset__heading
               = t('general_feedback.user_participation_legend')
-          = f.collection_radio_buttons :user_participation_response, participation_options, :last, :first,
-                                       collection_wrapper_tag: 'div',
-                                       collection_wrapper_class: 'govuk-radios',
-                                       item_wrapper_class: 'govuk-radios__item',
-                                       item_wrapper_tag: 'div' do |field|
-            = field.radio_button(class: 'govuk-radios__input') + field.label(:class => "govuk-label govuk-radios__label")
+
+          .govuk-radios
+            .govuk-radios__item
+              = f.radio_button(:user_participation_response, :interested, class: 'govuk-radios__input')
+              = f.label(t('general_feedback.user_participation_options.interested'), class: "govuk-label govuk-radios__label", required: true)
+
+            .govuk-radios__item
+              = f.radio_button(:user_participation_response, :not_interested, class: 'govuk-radios__input')
+              = f.label(t('general_feedback.user_participation_options.not_interested'), class: "govuk-label govuk-radios__label", required: true)
+
 
       = f.submit t('feedback.submit'), class: 'govuk-button'

--- a/app/views/general_feedback/new.html.haml
+++ b/app/views/general_feedback/new.html.haml
@@ -34,4 +34,16 @@
                     label: false,
                     input_html: { class: 'form-control form-control-4-4', rows: '5' }
 
+      .govuk-form-group.feedback-form-group
+        %fieldset.govuk-fieldset
+          %legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+            %h2.govuk-fieldset__heading
+              = t('general_feedback.user_participation_legend')
+          = f.collection_radio_buttons :user_participation_response, participation_options, :last, :first,
+                                       collection_wrapper_tag: 'div',
+                                       collection_wrapper_class: 'govuk-radios',
+                                       item_wrapper_class: 'govuk-radios__item',
+                                       item_wrapper_tag: 'div' do |field|
+            = field.radio_button(class: 'govuk-radios__input') + field.label(:class => "govuk-label govuk-radios__label")
+
       = f.submit t('feedback.submit'), class: 'govuk-button'

--- a/app/views/general_feedback/new.html.haml
+++ b/app/views/general_feedback/new.html.haml
@@ -45,12 +45,11 @@
               = f.radio_button(:user_participation_response, :interested, class: 'govuk-radios__input')
               = f.label(t('general_feedback.user_participation_options.interested'), class: "govuk-label govuk-radios__label", required: true)
 
-              = f.input :email,
-                label: t('jobs.contact_email'),
-                hint: t('jobs.form_hints.contact_email'),
-                as: :email,
-                wrapper_html: {id: 'contact_email'},
-                required: true
+              = f.input :email, as: :email,
+                  label: t('general_feedback.user_interested_email_heading'),
+                  hint: t('general_feedback.user_interested_email_text'),
+                  wrapper_html: {id: 'email', class: "govuk-details__text"},
+                  required: true
 
             .govuk-radios__item
               = f.radio_button(:user_participation_response, :not_interested, class: 'govuk-radios__input')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -259,6 +259,10 @@ en:
       find_teaching_job: Find a job in teaching
       list_teaching_job: List a teaching job on the service
       other_purpose: Something else (tell us in the box below)
+    user_participation_legend: 'Would you like to participate in our research?'
+    user_participation_options:
+      interested: 'Yes'
+      not_interested: 'No'
   schools:
     about: 'About'
     address: 'Address'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,6 +263,8 @@ en:
     user_participation_options:
       interested: 'Yes'
       not_interested: 'No'
+    user_interested_email_heading: 'What is your email address?'
+    user_interested_email_text: "We'll only use this to tell you about opportunities to take part in user research that helps us improve Department for Education services."
   schools:
     about: 'About'
     address: 'Address'

--- a/db/migrate/20190729094604_add_email_to_general_feedbacks.rb
+++ b/db/migrate/20190729094604_add_email_to_general_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddEmailToGeneralFeedbacks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :general_feedbacks, :email, :string
+  end
+end

--- a/db/migrate/20190729095306_add_user_research_participation_request_to_general_feedbacks.rb
+++ b/db/migrate/20190729095306_add_user_research_participation_request_to_general_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddUserResearchParticipationRequestToGeneralFeedbacks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :general_feedbacks, :user_participation_response, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_22_142115) do
+ActiveRecord::Schema.define(version: 2019_07_29_095306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -76,6 +76,8 @@ ActiveRecord::Schema.define(version: 2019_07_22_142115) do
     t.text "visit_purpose_comment"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "email"
+    t.integer "user_participation_response"
   end
 
   create_table "leaderships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/general_feedbacks.rb
+++ b/spec/factories/general_feedbacks.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :general_feedback do
     visit_purpose { :find_teaching_job }
     comment { 'Some feedback text' }
+    user_participation_response { :not_interested }
   end
 end

--- a/spec/factories/general_feedbacks.rb
+++ b/spec/factories/general_feedbacks.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     visit_purpose { :find_teaching_job }
     comment { 'Some feedback text' }
     user_participation_response { :not_interested }
+    email { nil }
   end
 end

--- a/spec/features/general_feedback_spec.rb
+++ b/spec/features/general_feedback_spec.rb
@@ -6,13 +6,33 @@ RSpec.feature 'Giving general feedback for the service' do
     expect(page).to have_content(I18n.t('feedback.heading'))
   end
 
-  scenario 'successfully submitting feedback for the service' do
-    choose 'Find a job in teaching'
+  context 'when submitting feedback on the service' do
+    scenario 'must have a visit purpose' do
+      fill_in 'general_feedback_comment', with: 'Keep going!'
+      choose 'No'
 
-    fill_in 'general_feedback_comment', with: 'Keep going!'
+      click_on 'Submit feedback'
 
-    click_on 'Submit feedback'
+      expect(page).to have_content('Visit purpose can\'t be blank')
+    end
 
-    expect(page).to have_content('Your feedback has been successfully submitted')
+    scenario 'must have a participation response' do
+      choose 'Find a job in teaching'
+      fill_in 'general_feedback_comment', with: 'Keep going!'
+
+      click_on 'Submit feedback'
+
+      expect(page).to have_content('User participation response can\'t be blank')
+    end
+
+    scenario 'successfully submitting feedback for the service' do
+      choose 'Find a job in teaching'
+      fill_in 'general_feedback_comment', with: 'Keep going!'
+      choose 'No'
+
+      click_on 'Submit feedback'
+
+      expect(page).to have_content('Your feedback has been successfully submitted')
+    end
   end
 end

--- a/spec/features/general_feedback_spec.rb
+++ b/spec/features/general_feedback_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Giving general feedback for the service' do
   context 'when submitting feedback on the service' do
     scenario 'must have a visit purpose' do
       fill_in 'general_feedback_comment', with: 'Keep going!'
-      choose 'No'
+      choose('general_feedback_user_participation_response_not_interested')
 
       click_on 'Submit feedback'
 
@@ -28,7 +28,7 @@ RSpec.feature 'Giving general feedback for the service' do
     scenario 'successfully submitting feedback for the service' do
       choose 'Find a job in teaching'
       fill_in 'general_feedback_comment', with: 'Keep going!'
-      choose 'No'
+      choose('general_feedback_user_participation_response_not_interested')
 
       click_on 'Submit feedback'
 

--- a/spec/features/general_feedback_spec.rb
+++ b/spec/features/general_feedback_spec.rb
@@ -7,9 +7,12 @@ RSpec.feature 'Giving general feedback for the service' do
   end
 
   context 'when submitting feedback on the service' do
+    let(:choose_yes_to_participation) { choose('general_feedback_user_participation_response_interested') }
+    let(:choose_no_to_participation) { choose('general_feedback_user_participation_response_not_interested') }
+
     scenario 'must have a visit purpose' do
       fill_in 'general_feedback_comment', with: 'Keep going!'
-      choose('general_feedback_user_participation_response_not_interested')
+      choose_no_to_participation
 
       click_on 'Submit feedback'
 
@@ -28,7 +31,7 @@ RSpec.feature 'Giving general feedback for the service' do
     scenario 'successfully submitting feedback for the service' do
       choose 'Find a job in teaching'
       fill_in 'general_feedback_comment', with: 'Keep going!'
-      choose('general_feedback_user_participation_response_not_interested')
+      choose_no_to_participation
 
       click_on 'Submit feedback'
 
@@ -38,7 +41,7 @@ RSpec.feature 'Giving general feedback for the service' do
     scenario 'must have an email when participation response is Yes' do
       choose 'Find a job in teaching'
       fill_in 'general_feedback_comment', with: 'Keep going!'
-      choose('general_feedback_user_participation_response_interested')
+      choose_yes_to_participation
 
       click_on 'Submit feedback'
 
@@ -49,7 +52,7 @@ RSpec.feature 'Giving general feedback for the service' do
       choose 'Find a job in teaching'
       fill_in 'general_feedback_comment', with: 'Keep going!'
 
-      choose('general_feedback_user_participation_response_interested')
+      choose_yes_to_participation
       fill_in 'email', with: 'test@test.com'
 
       click_on 'Submit feedback'

--- a/spec/features/general_feedback_spec.rb
+++ b/spec/features/general_feedback_spec.rb
@@ -34,5 +34,27 @@ RSpec.feature 'Giving general feedback for the service' do
 
       expect(page).to have_content('Your feedback has been successfully submitted')
     end
+
+    scenario 'must have an email when participation response is Yes' do
+      choose 'Find a job in teaching'
+      fill_in 'general_feedback_comment', with: 'Keep going!'
+      choose('general_feedback_user_participation_response_interested')
+
+      click_on 'Submit feedback'
+
+      expect(page).to have_content('Email can\'t be blank')
+    end
+
+    scenario 'successfully submitting feedback and interest in user research' do
+      choose 'Find a job in teaching'
+      fill_in 'general_feedback_comment', with: 'Keep going!'
+
+      choose('general_feedback_user_participation_response_interested')
+      fill_in 'email', with: 'test@test.com'
+
+      click_on 'Submit feedback'
+
+      expect(page).to have_content('Your feedback has been successfully submitted')
+    end
   end
 end

--- a/spec/models/general_feedback_spec.rb
+++ b/spec/models/general_feedback_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe GeneralFeedback, type: :model do
     it { should validate_presence_of :visit_purpose }
     it { should validate_length_of(:visit_purpose_comment).is_at_most(1200) }
     it { should validate_length_of(:comment).is_at_most(1200) }
+    it { should validate_presence_of :user_participation_response }
   end
 
   describe '#published_on(date)' do

--- a/spec/models/general_feedback_spec.rb
+++ b/spec/models/general_feedback_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe GeneralFeedback, type: :model do
     it { should validate_presence_of :user_participation_response }
   end
 
+  describe '#email' do
+    context 'when user is interested in research participation' do
+      before { allow(subject).to receive(:user_is_interested?).and_return(true) }
+      it { is_expected.to validate_presence_of(:email) }
+    end
+
+    context 'when user is NOT interested in research participation' do
+      before { allow(subject).to receive(:user_is_interested?).and_return(false) }
+      it { is_expected.not_to validate_presence_of(:email) }
+    end
+  end
+
   describe '#published_on(date)' do
     it 'retrieves feedback submitted on the given date' do
       feedback_today = create_list(:general_feedback, 3)

--- a/spec/models/general_feedback_spec.rb
+++ b/spec/models/general_feedback_spec.rb
@@ -55,12 +55,16 @@ RSpec.describe GeneralFeedback, type: :model do
     let(:visit_purpose) { :other_purpose }
     let(:visit_purpose_comment) { 'For reasons...' }
     let(:comment) { 'Great!' }
+    let(:user_participation_response) { :interested }
+    let(:email) { 'hello@research.com' }
 
     let(:feedback) do
       Timecop.freeze(created_at) do
         create(:general_feedback, visit_purpose: visit_purpose,
                                   visit_purpose_comment: visit_purpose_comment,
-                                  comment: comment)
+                                  comment: comment,
+                                  user_participation_response: user_participation_response,
+                                  email: email)
       end
     end
 
@@ -71,6 +75,8 @@ RSpec.describe GeneralFeedback, type: :model do
       expect(feedback.to_row[3]).to eq(nil) # Rating column: we no longer take these as feedback
       expect(feedback.to_row[4]).to eq(comment)
       expect(feedback.to_row[5]).to eq(feedback.created_at.to_s)
+      expect(feedback.to_row[6]).to eq(user_participation_response.to_s)
+      expect(feedback.to_row[7]).to eq(email)
     end
   end
 end

--- a/spec/models/general_feedback_spec.rb
+++ b/spec/models/general_feedback_spec.rb
@@ -12,6 +12,22 @@ RSpec.describe GeneralFeedback, type: :model do
     context 'when user is interested in research participation' do
       before { allow(subject).to receive(:user_is_interested?).and_return(true) }
       it { is_expected.to validate_presence_of(:email) }
+
+      it 'ensures an email is set' do
+        feedback = build(:general_feedback, user_participation_response: :interested)
+        feedback.save
+
+        expect(feedback.valid?).to eq(false)
+        expect(feedback.errors.messages[:email]).to eq(['can\'t be blank'])
+      end
+
+      it 'ensures a valid email address is used' do
+        feedback = build(:general_feedback, user_participation_response: :interested, email: 'inv@al@.id.email.com')
+        feedback.save
+
+        expect(feedback.valid?).to eq(false)
+        expect(feedback.errors.messages[:email]).to eq(['is not a valid email address'])
+      end
     end
 
     context 'when user is NOT interested in research participation' do


### PR DESCRIPTION
### Trello card URL: https://trello.com/c/M0jnSKKx

### Changes in this PR:
This is the second slice of a feature to redesign the general feedback form for the service.
First slice: (#974)

## Screenshots of UI changes:

### Before
<img width="605" alt="Screenshot 2019-08-01 at 12 29 14" src="https://user-images.githubusercontent.com/32823756/62290072-4fc5de00-b458-11e9-9b61-421e0a493051.png">


### After
<img width="339" alt="Screenshot 2019-08-01 at 12 28 33" src="https://user-images.githubusercontent.com/32823756/62290084-59e7dc80-b458-11e9-8f36-07a591cf0d1a.png">

## Next steps:

- [ ] Check the new section works on staging? (Criteria: The user should be required to give a valid email address only when they select the **Yes** radio button.)

- [ ] Add new headers to the General Feedback worksheet in the Staging audit spreadsheet for the user response and email columns. (NOTE: Inform Business Analyst when adding these headers to the Production audit spreadsheet.)

- [ ] Check that running the update spreadsheet task on staging updates the Staging version of General feedback worksheet with user response data and email address data.