### PR TITLE
(Chore) Refactor enums in codebase into hash enums.

### DIFF
--- a/app/models/alert_run.rb
+++ b/app/models/alert_run.rb
@@ -1,4 +1,4 @@
 class AlertRun < ApplicationRecord
-  enum status: %i[pending sent]
+  enum status: { pending: 0, sent: 1 }
   belongs_to :subscription
 end

--- a/app/models/audit_data.rb
+++ b/app/models/audit_data.rb
@@ -1,14 +1,14 @@
 class AuditData < ApplicationRecord
   self.table_name = 'audit_data'
 
-  enum category: %i[
-    vacancies
-    sign_in_events
-    interest_expression
-    search_event
-    toc_acceptance
-    subscription_creation
-  ]
+  enum category: {
+    vacancies: 0,
+    sign_in_events: 1,
+    interest_expression: 2,
+    search_event: 3,
+    toc_acceptance: 4,
+    subscription_creation: 5
+  }
 
   def to_row
     data.values.unshift(Time.zone.now.to_s)

--- a/app/models/general_feedback.rb
+++ b/app/models/general_feedback.rb
@@ -1,8 +1,8 @@
 class GeneralFeedback < ApplicationRecord
   include Auditor::Model
 
-  enum visit_purpose: %i[other_purpose find_teaching_job list_teaching_job]
-  enum user_participation_response: %i[interested not_interested]
+  enum visit_purpose: { other_purpose: 0, find_teaching_job: 1, list_teaching_job: 2 }
+  enum user_participation_response: { interested: 0, not_interested: 1 }
 
   validates :visit_purpose, presence: true
   validates :visit_purpose_comment, length: { maximum: 1200 }, if: :visit_purpose_comment?

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,7 +1,7 @@
 class Subscription < ApplicationRecord
   include Auditor::Model
 
-  enum frequency: %i[daily]
+  enum frequency: { daily: 0 }
 
   has_many :alert_runs
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -88,7 +88,7 @@ class Vacancy < ApplicationRecord
 
   friendly_id :slug_candidates, use: %w[slugged history]
 
-  enum status: %i[published draft trashed]
+  enum status: { published: 0, draft: 1, trashed: 2 }
   array_enum working_patterns: WORKING_PATTERN_OPTIONS
   enum listed_elsewhere: {
     listed_paid: 0,


### PR DESCRIPTION
This change is a clean up across the codebase.
Based on a comment on a PR: "It is best practice to add a specific integer value for each enum value." (View comment here: https://github.com/DFE-Digital/teacher-vacancy-service/pull/984#discussion_r309727484)

Not all the enums declared in the codebase are following this best practice and this could lead to more enums being created (especially in a copy & paste scenario) that don't follow this practice.

This change was done to encourage good code practices as mentioned above.