### PR TITLE
Fix flakiness with AlertMailerSpec and location html

### DIFF
--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe AlertMailer, type: :mailer do
   include DateHelper
+  include ERB::Util
 
   let(:body) { mail.body.raw_source }
   let(:subscription) do
@@ -45,7 +46,7 @@ RSpec.describe AlertMailer, type: :mailer do
         )
         expect(body).to match(/---/)
         expect(body).to match(/#{Regexp.escape(vacancy_presenter.share_url(campaign_params))}/)
-        expect(body).to match(/#{vacancy_presenter.location}/)
+        expect(body).to match(/#{html_escape(vacancy_presenter.location)}/)
         expect(body).to match(/Salary: #{vacancy_presenter.salary_range}/)
 
         expect(body).to match(/#{vacancy_presenter.working_patterns}/)
@@ -72,14 +73,14 @@ RSpec.describe AlertMailer, type: :mailer do
 
         expect(body).to match(/\[#{first_vacancy_presenter.job_title}\]/)
         expect(body).to match(/#{Regexp.escape(first_vacancy_presenter.share_url(campaign_params))}/)
-        expect(body).to match(/#{first_vacancy_presenter.location}/)
+        expect(body).to match(/#{html_escape(first_vacancy_presenter.location)}/)
         expect(body).to match(/Salary: #{first_vacancy_presenter.salary_range}/)
         expect(body).to match(/#{first_vacancy_presenter.working_patterns}/)
         expect(body).to match(/#{format_date(first_vacancy_presenter.expires_on)}/)
 
         expect(body).to match(/\[#{second_vacancy_presenter.job_title}\]/)
         expect(body).to match(/#{Regexp.escape(second_vacancy_presenter.share_url(campaign_params))}/)
-        expect(body).to match(/#{second_vacancy_presenter.location}/)
+        expect(body).to match(/#{html_escape(second_vacancy_presenter.location)}/)
         expect(body).to match(/Salary: #{second_vacancy_presenter.salary_range}/)
         expect(body).to match(/#{second_vacancy_presenter.working_patterns}/)
         expect(body).to match(/#{format_date(second_vacancy_presenter.expires_on)}/)

--- a/spec/mailers/subscription_spec.rb
+++ b/spec/mailers/subscription_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SubscriptionMailer, type: :mailer do
+  include ERB::Util
+
   before(:each) do
     stub_const('NOTIFY_SUBSCRIPTION_CONFIRMATION_TEMPLATE', '')
     Timecop.travel('2019-01-01')
@@ -33,7 +35,7 @@ RSpec.describe SubscriptionMailer, type: :mailer do
     expect(mail.to).to eq([subscription.email])
     expect(body_lines[0]).to match(/# #{I18n.t('app.title')}/)
     expect(body_lines[1]).to match(
-      /#{escape_single_quotes(I18n.t('subscriptions.email.confirmation.heading', reference: subscription.reference))}/
+      /#{html_escape(I18n.t('subscriptions.email.confirmation.heading', reference: subscription.reference))}/
     )
     expect(body_lines[3]).to match(/#{I18n.t('subscriptions.email.confirmation.subheading', email: email)}/)
     expect(body_lines[5]).to match(/\* Subject: English/)
@@ -46,9 +48,5 @@ RSpec.describe SubscriptionMailer, type: :mailer do
   it 'has an unsubscribe link' do
     expect(body_lines[12]).to match(/#{I18n.t('subscriptions.email.unsubscribe_text_html')}/)
     expect(body_lines[14]).to match(%r{http:\/\/localhost:3000\/subscriptions\/#{subscription.token}\/unsubscribe})
-  end
-
-  def escape_single_quotes(unescaped_string)
-    ERB::Util.html_escape(unescaped_string)
   end
 end


### PR DESCRIPTION
When Faker generates a county with a quote, e.g. `O'Connellfort` then
the Mail contains the HTML escaped version `O&#39;Connellfort`.

We've seen this fail 2 times in CI now, so this fixes this flakiness.

#### Trello card
https://trello.com/c/GULLtaZZ