### PR TITLE
(Fix) Remove smoke test from build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,6 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
-    jobs:
-      - run_smoke_test
   scheduled-smoke-tests:
     triggers:
       - schedule:


### PR DESCRIPTION
We don't want to run smoke tests with each build, these should be
only run by the scheduler on the master branch