### PR TITLE
Make page titles more descriptive (accessibility fix)

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,7 +8,7 @@
     = render partial: 'shared/open_graph'
     = render partial: 'shared/meta'
     %meta{charset: "utf-8"}/
-    %title #{content_for :page_title_prefix} — #{t('app.title')}
+    %title #{content_for :page_title_prefix} — #{t('app.title')} #{t('app.govuk')}
     %meta{content: "width=device-width, initial-scale=1", name: "viewport"}/
     %meta{content: "blue", name: "theme-color"}/
     %link{href: asset_path("favicon.ico"), rel: "shortcut icon", type: "image/x-icon"}/

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
     title: 'Teaching Vacancies'
     menu: 'Menu'
     description: 'The free service for schools in England to list teaching roles and for jobseekers to find them.'
+    govuk: 'GOV.UK'
   nav:
     sign_in: 'List a teaching job at your school'
     sign_out: 'Sign out'


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/fEW99Kpc/184-make-page-titles-descriptive-1

## Changes in this PR:
- Add gov.uk to page titles of every page