### PR TITLE
remove id duplication (accessibility fix)

### DIFF
--- a/app/views/hiring_staff/vacancies/_show.html.haml
+++ b/app/views/hiring_staff/vacancies/_show.html.haml
@@ -13,10 +13,10 @@
       .govuk-grid-column-one-half
         .share-url.mb1.display-none
           %h2.govuk-heading-m.mt0 Share this job
-          #{link_to t('jobs.view_public_link'), @vacancy.share_url, class: 'govuk-link', id: 'share-url', 'aria-label': t('jobs.view_public_link')}, or #{link_to t('jobs.copy_public_url'), '#', class: 'govuk-link copy-to-clipboard', 'data-clipboard-text': @vacancy.share_url, 'aria-label': t('jobs.copy_public_url')}
+          #{link_to t('jobs.view_public_link'), @vacancy.share_url, class: 'govuk-link', 'aria-label': t('jobs.view_public_link')}, or #{link_to t('jobs.copy_public_url'), '#', class: 'govuk-link copy-to-clipboard', 'data-clipboard-text': @vacancy.share_url, 'aria-label': t('jobs.copy_public_url')}
         .share-url-no-js.mb1
           %h2.govuk-heading-s.mt0 Share this job
-          #{link_to "#{t('jobs.view_public_link')} (#{@vacancy.share_url})", job_path(@vacancy), class: 'govuk-link', id: 'share-url'}
+          #{link_to "#{t('jobs.view_public_link')} (#{@vacancy.share_url})", job_path(@vacancy), class: 'govuk-link'}
         = render partial: '/shared/vacancy/share_buttons'
       .govuk-grid-column-one-half
         .og-preview


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/3s4j1pR9/971-fix-duplicate-id-attributes-found-on-some-pages-problematic-for-assistive-technologies-1

## Changes in this PR:
- amend duplicate id
