### PR TITLE
fix for attribute of labels for month input fields (accessibility fix)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,7 @@ gem 'roadie-rails'
 gem 'simple_form'
 gem 'rails-html-sanitizer', '~> 1.0.4', '>= 1.0.4' # Must be above this version due to CVE-2018-3741
 
-gem 'gov_uk_date_fields', git: 'https://github.com/despo/gov_uk_date_fields.git',
-                          branch: 'trigger-iphone-numeric-keyboard-for-new-gov-uk-ds'
+gem 'gov_uk_date_fields', git: 'https://github.com/DFE-Digital/gov_uk_date_fields.git'
 
 gem 'xml-sitemap'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
-  remote: https://github.com/despo/gov_uk_date_fields.git
-  revision: 5098694990e8a730b328aa2f5db855f91ad20d17
-  branch: trigger-iphone-numeric-keyboard-for-new-gov-uk-ds
+  remote: https://github.com/DFE-Digital/gov_uk_date_fields.git
+  revision: 61bf06ee258c633f4d477781f65734cd9d54f3c0
   specs:
     gov_uk_date_fields (3.0.0)
       rails (>= 5.0)


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/YiYqRJyA/974-provide-descriptive-labels-to-form-elements-missing-them-2
## Changes in this PR:
- Change gemfile to use fixed version of gov-uk-date-fields gem 