### PR TITLE
(chore) Update the content within the feedback prompt email

### DIFF
--- a/app/views/feedback_prompt_mailer/prompt_for_feedback.text.haml
+++ b/app/views/feedback_prompt_mailer/prompt_for_feedback.text.haml
@@ -2,18 +2,18 @@
 
 Dear vacancy publisher,
 \
-We’re constantly working to improve #{t('app.title')}. Our aim is to make the service the preferred resource for getting schools the teachers they need while saving them money on recruitment costs.
-\
-But to make effective improvements we need the insights of our users, including feedback from schools like yours on their expired job listings.
-\
-Please help us by answering a couple quick questions about the following expired listings:
+We’re constantly working to improve #{t('app.title')}. You can help us do so by answering a couple quick questions about the following expired job listings for your school:
 
 - @vacancies.each do |vacancy|
   = "* #{vacancy.job_title}"
 
 \
-Just sign into your Teaching Vacancies account and select the ‘Jobs awaiting feedback’ tab. It will only take a minute and the data is essential to our efforts to improve Teaching Vacancies.
+It should only take a minute or 2 of your time. Just sign into your Teaching Vacancies account and select the ‘Jobs awaiting feedback’ tab.
+\
+Insights from schools like yours are essential if we’re to make Teaching Vacancies the preferred resource for getting schools the teachers they need while saving them money on recruitment costs.
+\
+So thanks for your feedback!
 \
 Kind regards,
 \
-#{t('app.title')}
+The #{t('app.title')} team


### PR DESCRIPTION
This change edits the content of the email sent to users who published the vacancies that have been expired for 2 weeks.

### Trello card URL: https://trello.com/c/NgjSSTJd

### Changes in this PR:

### Screenshots of UI changes:

#### Before
![image](https://user-images.githubusercontent.com/32823756/62712150-355ca900-b9f2-11e9-9db3-da1c173f4f90.png)


#### After
<img width="1222" alt="Screenshot 2019-08-08 at 13 03 22" src="https://user-images.githubusercontent.com/32823756/62712265-65a44780-b9f2-11e9-95ee-81876a41d51f.png">

## Next steps:

- [ ] Run the job that sends the prompt email on Staging; check that the new content changes are present.
