### PR TITLE
Add datalayer declaration to google optimize activate script

### DIFF
--- a/app/assets/javascripts/google_optimise.js
+++ b/app/assets/javascripts/google_optimise.js
@@ -1,4 +1,5 @@
 var google_optimize_activate = function() {
+  window.dataLayer = window.dataLayer || [];
   dataLayer.push({'event': 'optimize.activate'});
 };
 


### PR DESCRIPTION
## Changes in this PR:
Teaspoon was throwing an error:
"TypeError: undefined is not an object (evaluating 'dataLayer.push')"
because datalayer hasn't been defined before calling it.