### PR TITLE
(feature) On mobile make only the location search visible at the top

### DIFF
--- a/app/assets/javascripts/details.js
+++ b/app/assets/javascripts/details.js
@@ -1,0 +1,25 @@
+
+function addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(detailsElement) {
+    var expandedText = detailsElement.getAttribute('data-summary-expanded');
+    var collapsedText = detailsElement.getAttribute('data-summary-collapsed');
+    var summaryTextElement = detailsElement.getElementsByClassName('govuk-details__summary-text').item(0);
+
+    if(summaryTextElement && collapsedText && expandedText) {
+        summaryTextElement.textContent = collapsedText;
+
+        detailsElement.addEventListener('toggle', function () {
+            if (detailsElement.open) {
+                summaryTextElement.textContent = expandedText;
+            } else {
+                summaryTextElement.textContent = collapsedText;
+            }
+        });
+    }
+}
+
+
+$( document ).on('turbolinks:load', function() {
+    $('details').each(function(_, details) {
+        addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(details);
+    });
+});

--- a/app/assets/javascripts/details.js
+++ b/app/assets/javascripts/details.js
@@ -3,8 +3,9 @@ function addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(detailsElement) 
     var expandedText = detailsElement.getAttribute('data-summary-expanded');
     var collapsedText = detailsElement.getAttribute('data-summary-collapsed');
     var summaryTextElement = detailsElement.getElementsByClassName('govuk-details__summary-text').item(0);
+    var hasAllPropertiesToBeDynamic = summaryTextElement && collapsedText && expandedText;
 
-    if(summaryTextElement && collapsedText && expandedText) {
+    if(hasAllPropertiesToBeDynamic) {
         summaryTextElement.textContent = collapsedText;
 
         detailsElement.addEventListener('toggle', function () {

--- a/app/assets/stylesheets/components/filter_vacancies.scss
+++ b/app/assets/stylesheets/components/filter_vacancies.scss
@@ -11,9 +11,6 @@
   .form-control {
     border-color: govuk-colour("grey-1");
   }
-  .govuk-button {
-    margin-top: $govuk-gutter-half;
-  }
 
   @include govuk-media-query($until: tablet) {
     margin-bottom: $govuk-gutter;

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -44,10 +44,10 @@
       = label_tag 'location', t('jobs.filters.location'), class: 'govuk-label'
       = search_field_tag :location, location, class: 'govuk-input form-control form-control-block', placeholder: t('jobs.filters.location_hint')
     - if local_assigns.fetch :collapsible?, false
-      %details.govuk-details{"data-module": "govuk-details"}
+      %details.govuk-details{"data-module": "govuk-details", "data-summary-expanded": t('jobs.filters.summary_expanded'), "data-summary-collapsed": t('jobs.filters.summary_collapsed')}
         %summary.govuk-details__summary
           %span.govuk-details__summary-text
-            Show more filters
+            = t('jobs.filters.summary_nojs')
         %div
           = yield :advanced_filters
     - else

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -1,3 +1,40 @@
+- content_for :advanced_filters do
+  .govuk-form-group
+    = label_tag 'radius', t('jobs.filters.radius'), class: 'govuk-label'
+    = select_tag 'radius', options_for_select(radius_filter_options, radius), class: 'govuk-select form-control form-control-block'
+  .govuk-form-group
+    = label_tag 'subject', t('jobs.filters.subject'), class: 'govuk-label'
+    = search_field_tag :subject, subject, class: 'govuk-input form-control form-control-block', placeholder: t('jobs.filters.subject_hint')
+  .govuk-form-group
+    = label_tag 'job_title', t('jobs.filters.job_title'), class: 'govuk-label'
+    = search_field_tag :job_title, job_title, class: 'govuk-input form-control form-control-block', placeholder: t('jobs.filters.job_title_hint')
+  .govuk-form-group
+    = label_tag 'minimum_salary', t('jobs.filters.minimum_salary'), class: 'govuk-label'
+    = select_tag 'minimum_salary', options_for_select(VacanciesHelper::SALARY_OPTIONS, minimum_salary), class: 'govuk-select form-control form-control-block', include_blank: 'None'
+  .govuk-form-group
+    = label_tag 'working_pattern', t('jobs.filters.working_pattern'), class: 'govuk-label'
+    = select_tag 'working_pattern', options_for_select(working_pattern_options, working_pattern), class: 'govuk-select form-control form-control-block', include_blank: 'Any'
+  .govuk-form-group
+    %fieldset.govuk-fieldset
+      = label_tag 'phases', t('jobs.filters.education_phase'), class: 'govuk-label'
+      .govuk-checkboxes.checkbox-group{ class: ('checkbox-group--scrollable' unless specific_phases?) }
+        .govuk-checkboxes__item
+          = check_box_tag 'phases[]', '', !specific_phases?, id: 'phases_any', class: 'govuk-checkboxes__input'
+          = label_tag 'phases[]', 'Any', for: 'phases_any', class: 'govuk-label govuk-checkboxes__label'
+        .checkbox-group__divider
+          = t('jobs.filters.education_phase_divider')
+        - school_phase_options.each_with_index do |phase, i|
+          .govuk-checkboxes__item
+            = check_box_tag 'phases[]', phase[1], phase_checked?(phase[1]), id: 'phases_' + phase[1], class: 'govuk-checkboxes__input'
+            = label_tag 'phases[]', phase[0], for: 'phases_' + phase[1], class: 'govuk-label govuk-checkboxes__label'
+  .govuk-form-group
+    %fieldset.govuk-fieldset
+      .govuk-checkboxes
+        .govuk-checkboxes__item
+          = check_box_tag 'newly_qualified_teacher', 'true', nqt_suitable_checked?(newly_qualified_teacher), class: 'govuk-checkboxes__input'
+          = label_tag 'newly_qualified_teacher', t('jobs.filters.nqt_suitable'), class: 'govuk-label govuk-checkboxes__label'
+
+
 %aside.filter-vacancies
   %h2.govuk-heading-m
     =t('jobs.filters.title')
@@ -6,40 +43,15 @@
     .govuk-form-group
       = label_tag 'location', t('jobs.filters.location'), class: 'govuk-label'
       = search_field_tag :location, location, class: 'govuk-input form-control form-control-block', placeholder: t('jobs.filters.location_hint')
-    .govuk-form-group
-      = label_tag 'radius', t('jobs.filters.radius'), class: 'govuk-label'
-      = select_tag 'radius', options_for_select(radius_filter_options, radius), class: 'govuk-select form-control form-control-block'
-    .govuk-form-group
-      = label_tag 'subject', t('jobs.filters.subject'), class: 'govuk-label'
-      = search_field_tag :subject, subject, class: 'govuk-input form-control form-control-block', placeholder: t('jobs.filters.subject_hint')
-    .govuk-form-group
-      = label_tag 'job_title', t('jobs.filters.job_title'), class: 'govuk-label'
-      = search_field_tag :job_title, job_title, class: 'govuk-input form-control form-control-block', placeholder: t('jobs.filters.job_title_hint')
-    .govuk-form-group
-      = label_tag 'minimum_salary', t('jobs.filters.minimum_salary'), class: 'govuk-label'
-      = select_tag 'minimum_salary', options_for_select(VacanciesHelper::SALARY_OPTIONS, minimum_salary), class: 'govuk-select form-control form-control-block', include_blank: 'None'
-    .govuk-form-group
-      = label_tag 'working_pattern', t('jobs.filters.working_pattern'), class: 'govuk-label'
-      = select_tag 'working_pattern', options_for_select(working_pattern_options, working_pattern), class: 'govuk-select form-control form-control-block', include_blank: 'Any'
-    .govuk-form-group
-      %fieldset.govuk-fieldset
-        = label_tag 'phases', t('jobs.filters.education_phase'), class: 'govuk-label'
-        .govuk-checkboxes.checkbox-group{ class: ('checkbox-group--scrollable' unless specific_phases?) }
-          .govuk-checkboxes__item
-            = check_box_tag 'phases[]', '', !specific_phases?, id: 'phases_any', class: 'govuk-checkboxes__input'
-            = label_tag 'phases[]', 'Any', for: 'phases_any', class: 'govuk-label govuk-checkboxes__label'
-          .checkbox-group__divider
-            = t('jobs.filters.education_phase_divider')
-          - school_phase_options.each_with_index do |phase, i|
-            .govuk-checkboxes__item
-              = check_box_tag 'phases[]', phase[1], phase_checked?(phase[1]), id: 'phases_' + phase[1], class: 'govuk-checkboxes__input'
-              = label_tag 'phases[]', phase[0], for: 'phases_' + phase[1], class: 'govuk-label govuk-checkboxes__label'
-    .govuk-form-group
-      %fieldset.govuk-fieldset
-        .govuk-checkboxes
-          .govuk-checkboxes__item
-            = check_box_tag 'newly_qualified_teacher', 'true', nqt_suitable_checked?(newly_qualified_teacher), class: 'govuk-checkboxes__input'
-            = label_tag 'newly_qualified_teacher', t('jobs.filters.nqt_suitable'), class: 'govuk-label govuk-checkboxes__label'
+    - if local_assigns.fetch :collapsible?, false
+      %details.govuk-details{"data-module": "govuk-details"}
+        %summary.govuk-details__summary
+          %span.govuk-details__summary-text
+            Show more filters
+        %div
+          = yield :advanced_filters
+    - else
+      = yield :advanced_filters
 
     = hidden_field_tag :sort_column, sort_column
     = hidden_field_tag :sort_order, sort_order

--- a/app/views/vacancies/index.html+phone.haml
+++ b/app/views/vacancies/index.html+phone.haml
@@ -4,6 +4,8 @@
 %h1.govuk-heading-xl
   = t('jobs.heading')
 .govuk-grid-row
+  .govuk-grid-column-one-third
+    = render 'filters', collapsible?: true
 
   .govuk-grid-column-two-thirds
     .govuk-grid-column-full.vacancies-count{class: @vacancies.user_search? ? 'search-made' : ''}
@@ -11,8 +13,6 @@
       - if @vacancies.user_search?
         %span.clear-search.nobreak= link_to t('jobs.filters.clear_filters'), root_path, class: 'govuk-link'
         = render(partial: 'subscribe_link', locals: { search_criteria: @filters.only_active_to_hash }) if EmailAlertsFeature.enabled?
-    .mt1
-      = link_to 'Refine your search?', '#filters', class: 'govuk-link'
     - if @vacancies.any?
       %div.sortable-links
         = t('jobs.sort_by')
@@ -24,6 +24,3 @@
           = render partial: 'vacancy', locals: { vacancy: vacancy }
 
     = paginate @vacancies, window: 2
-
-  .govuk-grid-column-one-third#filters
-    = render 'filters'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -252,6 +252,9 @@ en:
       education_phase_divider: 'or'
       nqt_suitable: 'Suitable for NQTs'
       clear_filters: 'Reset search'
+      summary_expanded: 'Show fewer filters'
+      summary_collapsed: 'Show more filters'
+      summary_nojs: 'Advanced filters'
     feedback:
       listed_elsewhere:
         listed_paid: 'Yes, on one or more paid services'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -240,7 +240,7 @@ en:
     filters:
       title: 'Search job listings'
       location: 'Location'
-      location_hint: 'Postcode'
+      location_hint: 'Enter a city, town or postcode'
       radius: 'Radius'
       subject: 'Subject'
       subject_hint: 'e.g. Maths'

--- a/spec/browser_test_helper.rb
+++ b/spec/browser_test_helper.rb
@@ -5,3 +5,9 @@ Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, phantomjs_options: ['--load-images=false'])
 end
 Capybara.javascript_driver = :poltergeist
+
+RSpec.configure do |config|
+  config.before(:each, js: true) do
+    page.driver.clear_memory_cache
+  end
+end

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -227,11 +227,11 @@ RSpec.feature 'Viewing vacancies' do
     end
   end
 
-  context 'when the user is on mobile' do
+  context 'when the user is on mobile', js: true do
     scenario 'they should see the \'Show more filters\' link' do
-      page.driver.header('User-Agent', USER_AGENTS['MOBILE_CHROME'])
+      page.driver.add_header('User-Agent', USER_AGENTS['MOBILE_CHROME'])
       visit jobs_path
-      expect(page).to have_content('Show more filters')
+      expect(page).to have_content(I18n.t('jobs.filters.summary_collapsed'))
     end
   end
 end

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -228,10 +228,10 @@ RSpec.feature 'Viewing vacancies' do
   end
 
   context 'when the user is on mobile' do
-    scenario 'they should see the \'refine your search\' link' do
+    scenario 'they should see the \'Show more filters\' link' do
       page.driver.header('User-Agent', USER_AGENTS['MOBILE_CHROME'])
       visit jobs_path
-      expect(page).to have_content('Refine your search')
+      expect(page).to have_content('Show more filters')
     end
   end
 end

--- a/spec/javascripts/details_spec.js
+++ b/spec/javascripts/details_spec.js
@@ -1,0 +1,82 @@
+describe("Details element with custom summary text for expanded & collapsed states", function () {
+
+    it("Updates the summary text to be the collapsed value", function() {
+        fixture.set('<details data-summary-expanded="expanded-text" data-summary-collapsed="collapsed-text">'
+            + '<summary><span class="govuk-details__summary-text">Pre-text</span></summary>'
+            + '</details>');
+
+        addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(fixtureDetailsTag());
+
+        expect(summaryTextValue()).to.equal("collapsed-text");
+    });
+
+    it("Doesn't update summary text if no data-summary-expanded attribute", function() {
+        fixture.set('<details data-summary-collapsed="collapsed-text">'
+            + '<summary><span class="govuk-details__summary-text">Pre-text</span></summary>'
+            + '</details>');
+
+        addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(fixtureDetailsTag());
+
+        expect(summaryTextValue()).to.equal("Pre-text");
+    });
+
+    it("Doesn't update summary text if no data-summary-collapsed attribute", function() {
+        fixture.set('<details data-summary-expanded="expanded-text">'
+            + '<summary><span class="govuk-details__summary-text">Pre-text</span></summary>'
+            + '</details>');
+
+        addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(fixtureDetailsTag());
+
+        expect(summaryTextValue()).to.equal("Pre-text");
+    });
+
+    it("Doesn't update summary text if no govuk-details_summary-text element", function() {
+        fixture.set('<details data-summary-expanded="expanded-text" data-summary-collapsed="collapsed-text">'
+            + '<summary>Pre-text</summary>'
+            + '</details>');
+
+        addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(fixtureDetailsTag());
+
+        expect(fixture.el.textContent).to.equal("Pre-text");
+    });
+
+    describe("When details is expanded", function() {
+        // PhantomJS isn't respecting the `.open = true` and raising events.
+        // This test needs manual testing at the moment.
+        xit("displays the expanded text", function() {
+            fixture.set('<details data-summary-expanded="expanded-text" data-summary-collapsed="collapsed-text">'
+                + '<summary><span class="govuk-details__summary-text">-Pretext</span></summary>'
+                + '</details>');
+
+            addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(fixtureDetailsTag());
+            fixtureDetailsTag().open = true;
+
+            expect(summaryTextValue()).to.equal("expanded-text");
+        });
+    });
+
+    describe("When details is collapsed", function() {
+        // PhantomJS isn't respecting the `.open` calls and raising events.
+        // This test needs manual testing at the moment.
+        xit("displays the collapsed text", function() {
+            fixture.set('<details data-summary-expanded="expanded-text" data-summary-collapsed="collapsed-text">'
+                + '<summary><span class="govuk-details__summary-text">-Pretext</span></summary>'
+                + '</details>');
+
+            addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(fixtureDetailsTag());
+            fixtureDetailsTag().open = true;
+            fixtureDetailsTag().open = false;
+
+            expect(summaryTextValue()).to.equal("collapsed-text");
+        });
+    });
+
+    function summaryTextValue() {
+        return fixture.el.getElementsByClassName('govuk-details__summary-text')[0].textContent;
+    }
+
+    function fixtureDetailsTag() {
+        return fixture.el.getElementsByTagName('details')[0];
+    }
+
+});


### PR DESCRIPTION

## Trello card URL:
https://trello.com/c/Sx3ktjSy

## Changes in this PR:
Identified in research, users were having difficulty seeing search
results because all the filters take up so much of the initial
viewing space OR the filters were hidden at the bottom of the page
on mobile.
## Screenshots of UI changes:

### Before
![original-filters](https://user-images.githubusercontent.com/976274/62761855-a1d1b980-ba7f-11e9-922d-7defd04eac40.gif)

### After
![expanding-options](https://user-images.githubusercontent.com/976274/62759901-916b1000-ba7a-11e9-98de-7b4340ba907c.gif)
