### PR TITLE
Stop using forked version gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'roadie-rails'
 gem 'simple_form'
 gem 'rails-html-sanitizer', '~> 1.0.4', '>= 1.0.4' # Must be above this version due to CVE-2018-3741
 
-gem 'gov_uk_date_fields', git: 'https://github.com/DFE-Digital/gov_uk_date_fields.git'
+gem 'gov_uk_date_fields'
 
 gem 'xml-sitemap'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/DFE-Digital/gov_uk_date_fields.git
-  revision: 61bf06ee258c633f4d477781f65734cd9d54f3c0
-  specs:
-    gov_uk_date_fields (3.0.0)
-      rails (>= 5.0)
-
-GIT
   remote: https://github.com/dxw/geocoder.git
   revision: bc032c38c2e72645b04547c93b6f4e96415393f5
   branch: add-os-name-support
@@ -171,6 +164,8 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
+    gov_uk_date_fields (4.0.1)
+      rails (>= 5.0)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -520,7 +515,7 @@ DEPENDENCIES
   geocoder!
   google-api-client
   google_drive
-  gov_uk_date_fields!
+  gov_uk_date_fields
   haml-rails
   high_voltage (~> 3.1)
   httparty

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,7 +5,6 @@ $govuk-image-url-function: 'image-url';
 @import 'global/variables';
 @import 'base/mixins';
 @import 'base/utilities';
-@import 'govuk_date_fields';
 @import 'components/feedback_form';
 @import 'components/filter_vacancies';
 @import 'components/vacancies-count';

--- a/app/views/hiring_staff/vacancies/application_details/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/edit.html.haml
@@ -30,17 +30,10 @@
       - else
         %div.govuk-form-group#publish_on
           = f.gov_uk_date_field :publish_on,
-            legend_text: t('jobs.publication_date'),
-            legend_class: 'govuk-label',
-            form_hint_text: t('jobs.form_hints.publication_date',
-                            date: l(Date.today, format: :hinttext))
+                                legend_options: { page_heading: false, class: "govuk-label" }
 
       %div.govuk-form-group#deadline
         = f.gov_uk_date_field :expires_on,
-                              legend_text: t('jobs.deadline_date'),
-                              legend_class: 'govuk-label',
-                              form_hint_text: t('jobs.form_hints.deadline_date',
-                                                date: l(Date.today + 2.months, format: :hinttext))
-
+                              legend_options: { page_heading: false, class: "govuk-label" }
 
       = f.button :submit, t('buttons.update_job')

--- a/app/views/hiring_staff/vacancies/application_details/new.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/new.html.haml
@@ -26,16 +26,10 @@
 
       %div.govuk-form-group#publish_on
         = f.gov_uk_date_field :publish_on,
-                              legend_text: t('jobs.publication_date'),
-                              legend_class: 'govuk-label',
-                              form_hint_text: t('jobs.form_hints.publication_date',
-                                              date: l(Date.today, format: :hinttext))
+                              legend_options: { page_heading: false, class: "govuk-label" }
 
       %div.govuk-form-group#expires_on
         = f.gov_uk_date_field :expires_on,
-                              legend_text: t('jobs.deadline_date'),
-                              legend_class: 'govuk-label',
-                              form_hint_text: t('jobs.form_hints.deadline_date',
-                                                date: l(Date.today + 2.months, format: :hinttext))
+                              legend_options: { page_heading: false, class: "govuk-label" }
 
       = f.button :submit, t('buttons.save_and_continue')

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -21,31 +21,21 @@
 
       %div.govuk-form-group#starts_on
         = f.gov_uk_date_field :starts_on,
-                              legend_text: "#{t('jobs.starts_on')} (optional)",
-                              legend_class: 'govuk-label',
-                              form_hint_text: t('jobs.form_hints.start_date',
-                                                date: l(Date.today + 3.months, format: :hinttext))
+                              legend_options: { page_heading: false, class: "govuk-label" }
+
       %div.govuk-form-group#ends_on
         = f.gov_uk_date_field :ends_on,
-                              legend_text: "#{t('jobs.ends_on')} (optional)",
-                              legend_class: 'govuk-label',
-                              form_hint_text: t('jobs.form_hints.end_date',
-                                                date: l(Date.today + 6.months, format: :hinttext))
+                              legend_options: { page_heading: false, class: "govuk-label" }
+
       %h2.govuk-heading-m
         = t('jobs.application_details')
 
       %div.govuk-form-group#publish_on
         = f.gov_uk_date_field :publish_on,
-                              legend_text: t('jobs.publication_date'),
-                              legend_class: 'govuk-label',
-                              form_hint_text: t('jobs.form_hints.publication_date',
-                                              date: l(Date.today, format: :hinttext))
+                              legend_options: { page_heading: false, class: "govuk-label" }
 
       %div.govuk-form-group#expires_on
         = f.gov_uk_date_field :expires_on,
-                              legend_text: t('jobs.deadline_date'),
-                              legend_class: 'govuk-label',
-                              form_hint_text: t('jobs.form_hints.deadline_date',
-                                                date: l(Date.today + 2.months, format: :hinttext))
+                              legend_options: { page_heading: false, class: "govuk-label" }
 
       = f.button :submit, t('buttons.save_and_continue')

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -136,17 +136,11 @@
 
       %div.govuk-form-group#starts_on
         = f.gov_uk_date_field :starts_on,
-          legend_text: "#{t('jobs.starts_on')} (optional)",
-          legend_class: 'govuk-label',
-          form_hint_text: t('jobs.form_hints.start_date',
-                            date: l(Date.today + 3.months, format: :hinttext))
+                              legend_options: { page_heading: false, class: "govuk-label" }
 
 
       %div.govuk-form-group#ends_on
         = f.gov_uk_date_field :ends_on,
-          legend_text: "#{t('jobs.ends_on')} (optional)",
-          legend_class: 'govuk-label',
-          form_hint_text: t('jobs.form_hints.end_date',
-                            date: l(Date.today + 6.months, format: :hinttext))
+                              legend_options: { page_heading: false, class: "govuk-label" }
 
       = f.button :submit, t('buttons.update_job')

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -136,14 +136,10 @@
 
       %div.govuk-form-group#starts_on
         = f.gov_uk_date_field :starts_on,
-                              legend_text: "#{t('jobs.starts_on')} (optional)",
-                              legend_class: 'govuk-label',
-                              form_hint_text: t('jobs.form_hints.start_date',
-                                                date: l(Date.today + 3.months, format: :hinttext))
+                              legend_options: { page_heading: false, class: "govuk-label" }
+
       %div.govuk-form-group#ends_on
         = f.gov_uk_date_field :ends_on,
-                              legend_text: "#{t('jobs.ends_on')} (optional)",
-                              legend_class: 'govuk-label',
-                              form_hint_text: t('jobs.form_hints.end_date',
-                                                date: l(Date.today + 6.months, format: :hinttext))
+                              legend_options: { page_heading: false, class: "govuk-label" }
+
       = f.button :submit, t('buttons.save_and_continue')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,31 @@ en:
       change: 'Change organisation'
   identification:
     find_school_information: Find your school's official area
+  helpers:
+    fieldset:
+      job_specification_form:
+        starts_on: 'Expected start date (optional)'
+        ends_on: 'End date (optional)'
+      application_details_form:
+        publish_on: 'Date role will be listed'
+        expires_on: 'Application deadline'
+      copy_vacancy_form:
+        starts_on: 'Expected start date (optional)'
+        ends_on: 'End date (optional)'
+        publish_on: 'Date role will be listed'
+        expires_on: 'Application deadline'
+    hint:
+      job_specification_form:
+        starts_on: 'For example, 01 01 2020'
+        ends_on: 'For example, 01 08 2020'
+      application_details_form:
+        publish_on: 'For example, 01 01 2020'
+        expires_on: 'For example, 01 08 2020'
+      copy_vacancy_form:
+        starts_on: 'For example, 01 01 2020'
+        ends_on: 'For example, 01 08 2020'
+        publish_on: 'For example, 01 01 2020'
+        expires_on: 'For example, 01 08 2020'
   jobs:
     heading: 'Find a job in teaching'
     sort_by: 'Sort by:'


### PR DESCRIPTION
From a maintenance standpoint, we stopped using the forked version gem and used the [original gem](https://github.com/ministryofjustice/gov_uk_date_fields).

### Next Steps
- [ ] Check all the forms where there are date fields are rendered properly.

#### Forms Checklist:
When creating a new vacancy:
- [ ] Job Specification
- [ ] Application Details

When editing a vacancy:
- [ ] Job Specification
- [ ] Application Details

When copying a vacancy:
- [ ] Job Specification
- [ ] Application Details