### PR TITLE
Add expiry time to vacancy schema

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,9 @@ Style/ClassAndModuleChildren:
 Metrics/ClassLength:
     Enabled: false
 
+Rails/TimeZone:
+    Enabled: false
+
 Metrics/MethodLength:
     Max: 50
     Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,9 +52,6 @@ Style/ClassAndModuleChildren:
 Metrics/ClassLength:
     Enabled: false
 
-Rails/TimeZone:
-    Enabled: false
-
 Metrics/MethodLength:
     Max: 50
     Exclude:

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -123,13 +123,27 @@ class Vacancy < ApplicationRecord
 
   acts_as_gov_uk_date :starts_on, :ends_on, :publish_on, :expires_on
 
-  scope :applicable, (-> { where('expires_on >= ?', Time.zone.today) })
+  scope :applicable, (-> { applicable_by_date.or(applicable_by_time) })
+  scope :applicable_by_time, (-> { where.not(expiry_time: nil).where('expiry_time >= ?', Time.zone.now) })
+  scope :applicable_by_date, (-> { where(expiry_time: nil).where('expires_on >= ?', Time.zone.today) })
   scope :active, (-> { where(status: %i[published draft]) })
   scope :listed, (-> { published.where('publish_on <= ?', Time.zone.today) })
   scope :published_on_count, (->(date) { published.where(publish_on: date.all_day).count })
   scope :pending, (-> { published.where('publish_on > ?', Time.zone.today) })
-  scope :expired, (-> { published.where('expires_on < ?', Time.zone.today) })
-  scope :live, (-> { published.where('publish_on <= ?', Time.zone.today).where('expires_on >= ?', Time.zone.today) })
+  scope :expired, (-> { expired_by_time.or(expired_by_date) })
+  scope :expired_by_time, (-> { published.where.not(expiry_time: nil).where('expiry_time < ?', Time.zone.now) })
+  scope :expired_by_date, (-> { published.where(expiry_time: nil).where('expires_on < ?', Time.zone.today) })
+  scope :live, (-> { live_by_date.or(live_by_time) })
+  scope :live_by_time, (lambda {
+                          published.where.not(expiry_time: nil)
+                            .where('publish_on <= ?', Time.zone.today)
+                            .where('expiry_time >= ?', Time.zone.now)
+                        })
+  scope :live_by_date, (lambda {
+                          published.where(expiry_time: nil)
+                            .where('publish_on <= ?', Time.zone.today)
+                            .where('expires_on >= ?', Time.zone.today)
+                        })
   scope :awaiting_feedback, (-> { expired.where(listed_elsewhere: nil, hired_status: nil) })
 
   paginates_per 10

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -57,7 +57,9 @@ class VacancyPresenter < BasePresenter
   end
 
   def expired?
-    model.expires_on < Time.zone.today
+    return model.expires_on < Time.zone.today if model.expiry_time.nil?
+
+    model.expiry_time < Time.zone.now
   end
 
   def school

--- a/db/migrate/20190819112757_add_expiry_time_to_vacancy.rb
+++ b/db/migrate/20190819112757_add_expiry_time_to_vacancy.rb
@@ -1,0 +1,5 @@
+class AddExpiryTimeToVacancy < ActiveRecord::Migration[5.2]
+  def change
+    add_column :vacancies, :expiry_time, :time
+  end
+end

--- a/db/migrate/20190819112757_add_expiry_time_to_vacancy.rb
+++ b/db/migrate/20190819112757_add_expiry_time_to_vacancy.rb
@@ -1,5 +1,5 @@
 class AddExpiryTimeToVacancy < ActiveRecord::Migration[5.2]
   def change
-    add_column :vacancies, :expiry_time, :time
+    add_column :vacancies, :expiry_time, :datetime
   end
 end

--- a/db/migrate/20190819112757_add_expiry_time_to_vacancy.rb
+++ b/db/migrate/20190819112757_add_expiry_time_to_vacancy.rb
@@ -1,5 +1,6 @@
 class AddExpiryTimeToVacancy < ActiveRecord::Migration[5.2]
   def change
     add_column :vacancies, :expiry_time, :datetime
+    
   end
 end

--- a/db/migrate/20190823081145_add_index_to_expiry_time.rb
+++ b/db/migrate/20190823081145_add_index_to_expiry_time.rb
@@ -1,0 +1,5 @@
+class AddIndexToExpiryTime < ActiveRecord::Migration[5.2]
+  def change
+    add_index :vacancies, :expiry_time
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -216,7 +216,7 @@ ActiveRecord::Schema.define(version: 2019_08_19_112757) do
     t.integer "hired_status"
     t.datetime "stats_updated_at"
     t.uuid "publisher_user_id"
-    t.time "expiry_time"
+    t.datetime "expiry_time"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"
     t.index ["leadership_id"], name: "index_vacancies_on_leadership_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_29_095306) do
+ActiveRecord::Schema.define(version: 2019_08_19_112757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -216,6 +216,7 @@ ActiveRecord::Schema.define(version: 2019_07_29_095306) do
     t.integer "hired_status"
     t.datetime "stats_updated_at"
     t.uuid "publisher_user_id"
+    t.time "expiry_time"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"
     t.index ["leadership_id"], name: "index_vacancies_on_leadership_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_19_112757) do
+ActiveRecord::Schema.define(version: 2019_08_23_081145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -218,6 +218,7 @@ ActiveRecord::Schema.define(version: 2019_08_19_112757) do
     t.uuid "publisher_user_id"
     t.datetime "expiry_time"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
+    t.index ["expiry_time"], name: "index_vacancies_on_expiry_time"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"
     t.index ["leadership_id"], name: "index_vacancies_on_leadership_id"
     t.index ["max_pay_scale_id"], name: "index_vacancies_on_max_pay_scale_id"

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -330,11 +330,11 @@ RSpec.describe Vacancy, type: :model do
       context 'when expiry time given' do
         it 'finds current vacancies' do
           expired_earlier_today = build(:vacancy, expires_on: Time.zone.today,
-                                                  expiry_time: DateTime.now - 1.hour)
+                                                  expiry_time: Time.zone.now - 1.hour)
           expired_earlier_today.send :set_slug
           expired_earlier_today.save(validate: false)
           expires_later_today = create(:vacancy, expires_on: Time.zone.today,
-                                                 expiry_time: DateTime.now + 1.hour)
+                                                 expiry_time: Time.zone.now + 1.hour)
 
           results = Vacancy.applicable
           expect(results).to include(expires_later_today)
@@ -396,7 +396,7 @@ RSpec.describe Vacancy, type: :model do
       context 'when expiry time given' do
         it 'retrieves vacancies that have a past expires_on date' do
           create_list(:vacancy, 5, :published)
-          expired = build(:vacancy, expiry_time: DateTime.now - 1.hour)
+          expired = build(:vacancy, expiry_time: Time.zone.now - 1.hour)
           expired.send :set_slug
           expired.save(validate: false)
 
@@ -430,10 +430,10 @@ RSpec.describe Vacancy, type: :model do
       context 'when expiry time given' do
         it 'includes vacancies till expiry time' do
           expired_earlier_today = create(:vacancy, status: :published,
-                                                   expiry_time: DateTime.now - 1.hour)
+                                                   expiry_time: Time.zone.now - 1.hour)
 
           expires_later_today = create(:vacancy, status: :published,
-                                                 expiry_time: DateTime.now + 1.hour)
+                                                 expiry_time: Time.zone.now + 1.hour)
 
           expect(Vacancy.live).to include(expires_later_today)
           expect(Vacancy.live).to_not include(expired_earlier_today)

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -311,6 +311,14 @@ RSpec.describe Vacancy, type: :model do
   end
 
   context 'scopes' do
+    let(:expired_earlier_today) do
+      build(:vacancy, expires_on: Time.zone.today,
+                      expiry_time: Time.zone.now - 1.hour)
+    end
+    let(:expires_later_today) do
+      create(:vacancy, status: :published,
+                       expiry_time: Time.zone.now + 1.hour)
+    end
     describe '#applicable' do
       context 'when expiry time not given' do
         it 'finds current vacancies' do
@@ -329,12 +337,8 @@ RSpec.describe Vacancy, type: :model do
 
       context 'when expiry time given' do
         it 'finds current vacancies' do
-          expired_earlier_today = build(:vacancy, expires_on: Time.zone.today,
-                                                  expiry_time: Time.zone.now - 1.hour)
           expired_earlier_today.send :set_slug
           expired_earlier_today.save(validate: false)
-          expires_later_today = create(:vacancy, expires_on: Time.zone.today,
-                                                 expiry_time: Time.zone.now + 1.hour)
 
           results = Vacancy.applicable
           expect(results).to include(expires_later_today)
@@ -429,12 +433,6 @@ RSpec.describe Vacancy, type: :model do
 
       context 'when expiry time given' do
         it 'includes vacancies till expiry time' do
-          expired_earlier_today = create(:vacancy, status: :published,
-                                                   expiry_time: Time.zone.now - 1.hour)
-
-          expires_later_today = create(:vacancy, status: :published,
-                                                 expiry_time: Time.zone.now + 1.hour)
-
           expect(Vacancy.live).to include(expires_later_today)
           expect(Vacancy.live).to_not include(expired_earlier_today)
         end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -312,17 +312,34 @@ RSpec.describe Vacancy, type: :model do
 
   context 'scopes' do
     describe '#applicable' do
-      it 'finds current vacancies' do
-        expired = build(:vacancy, :expired)
-        expired.send :set_slug
-        expired.save(validate: false)
-        expires_today = create(:vacancy, expires_on: Time.zone.today)
-        expires_future = create(:vacancy, expires_on: 3.months.from_now)
+      context 'when expiry time not given' do
+        it 'finds current vacancies' do
+          expired = build(:vacancy, :expired)
+          expired.send :set_slug
+          expired.save(validate: false)
+          expires_today = create(:vacancy, expires_on: Time.zone.today)
+          expires_future = create(:vacancy, expires_on: 3.months.from_now)
 
-        results = Vacancy.applicable
-        expect(results).to include(expires_today)
-        expect(results).to include(expires_future)
-        expect(results).to_not include(expired)
+          results = Vacancy.applicable
+          expect(results).to include(expires_today)
+          expect(results).to include(expires_future)
+          expect(results).to_not include(expired)
+        end
+      end
+
+      context 'when expiry time given' do
+        it 'finds current vacancies' do
+          expired_earlier_today = build(:vacancy, expires_on: Time.zone.today,
+                                                  expiry_time: DateTime.now - 1.hour)
+          expired_earlier_today.send :set_slug
+          expired_earlier_today.save(validate: false)
+          expires_later_today = create(:vacancy, expires_on: Time.zone.today,
+                                                 expiry_time: DateTime.now + 1.hour)
+
+          results = Vacancy.applicable
+          expect(results).to include(expires_later_today)
+          expect(results).to_not include(expired_earlier_today)
+        end
       end
     end
 
@@ -365,34 +382,62 @@ RSpec.describe Vacancy, type: :model do
     end
 
     describe '#expired' do
-      it 'retrieves vacancies that have a past expires_on date' do
-        create_list(:vacancy, 5, :published)
-        expired = build(:vacancy, :expired)
-        expired.send :set_slug
-        expired.save(validate: false)
+      context 'when expiry time not given' do
+        it 'retrieves vacancies that have a past expires_on date' do
+          create_list(:vacancy, 5, :published)
+          expired = build(:vacancy, :expired)
+          expired.send :set_slug
+          expired.save(validate: false)
 
-        expect(Vacancy.expired.count).to eq(1)
+          expect(Vacancy.expired.count).to eq(1)
+        end
+      end
+
+      context 'when expiry time given' do
+        it 'retrieves vacancies that have a past expires_on date' do
+          create_list(:vacancy, 5, :published)
+          expired = build(:vacancy, expiry_time: DateTime.now - 1.hour)
+          expired.send :set_slug
+          expired.save(validate: false)
+
+          expect(Vacancy.expired.count).to eq(1)
+        end
       end
     end
 
     describe '#live' do
-      let!(:live) { create_list(:vacancy, 5, :published) }
+      context 'when expiry time not given' do
+        let!(:live) { create_list(:vacancy, 5, :published) }
 
-      it 'retrieves vacancies that have a status of :published, a past publish_on date & a future expires_on date' do
-        expired = build(:vacancy, :expired)
-        expired.send :set_slug
-        expired.save(validate: false)
-        create_list(:vacancy, 3, :future_publish)
-        create_list(:vacancy, 4, :trashed)
+        it 'retrieves vacancies that have a status of :published, a past publish_on date & a future expires_on date' do
+          expired = build(:vacancy, :expired)
+          expired.send :set_slug
+          expired.save(validate: false)
+          create_list(:vacancy, 3, :future_publish)
+          create_list(:vacancy, 4, :trashed)
 
-        expect(Vacancy.live.count).to eq(live.count)
-        expect(Vacancy.live).to_not include(expired)
+          expect(Vacancy.live.count).to eq(live.count)
+          expect(Vacancy.live).to_not include(expired)
+        end
+
+        it 'includes vacancies that expire today' do
+          expires_today = create(:vacancy, status: :published, expires_on: Time.zone.today)
+
+          expect(Vacancy.live).to include(expires_today)
+        end
       end
 
-      it 'includes vacancies that expire today' do
-        expires_today = create(:vacancy, status: :published, expires_on: Time.zone.today)
+      context 'when expiry time given' do
+        it 'includes vacancies till expiry time' do
+          expired_earlier_today = create(:vacancy, status: :published,
+                                                   expiry_time: DateTime.now - 1.hour)
 
-        expect(Vacancy.live).to include(expires_today)
+          expires_later_today = create(:vacancy, status: :published,
+                                                 expiry_time: DateTime.now + 1.hour)
+
+          expect(Vacancy.live).to include(expires_later_today)
+          expect(Vacancy.live).to_not include(expired_earlier_today)
+        end
       end
     end
 

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -35,19 +35,35 @@ RSpec.describe VacancyPresenter do
   end
 
   describe '#expired?' do
-    it 'returns true when the vacancy has expired' do
-      vacancy = VacancyPresenter.new(build(:vacancy, expires_on: 4.days.ago))
-      expect(vacancy).to be_expired
+    context 'when expiry time not given' do
+      it 'returns true when the vacancy has expired' do
+        vacancy = VacancyPresenter.new(build(:vacancy, expires_on: 4.days.ago))
+        expect(vacancy).to be_expired
+      end
+
+      it 'returns false when the vacancy expires today' do
+        vacancy = VacancyPresenter.new(build(:vacancy, expires_on: Time.zone.today))
+        expect(vacancy).not_to be_expired
+      end
+
+      it 'returns false when the vacancy has yet to expire' do
+        vacancy = VacancyPresenter.new(build(:vacancy, expires_on: 6.days.from_now))
+        expect(vacancy).not_to be_expired
+      end
     end
 
-    it 'returns false when the vacancy expires today' do
-      vacancy = VacancyPresenter.new(build(:vacancy, expires_on: Time.zone.today))
-      expect(vacancy).not_to be_expired
-    end
+    context 'when expiry time given' do
+      it 'returns true when the vacancy has expired by now' do
+        vacancy = VacancyPresenter.new(build(:vacancy, expiry_time: DateTime.now - 1.hour))
 
-    it 'returns false when the vacancy has yet to expire' do
-      vacancy = VacancyPresenter.new(build(:vacancy, expires_on: 6.days.from_now))
-      expect(vacancy).not_to be_expired
+        expect(vacancy).to be_expired
+      end
+
+      it 'returns false when the vacancy expires later today' do
+        vacancy = VacancyPresenter.new(build(:vacancy, expiry_time: DateTime.now + 1.hour))
+
+        expect(vacancy).not_to be_expired
+      end
     end
   end
 

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -54,13 +54,13 @@ RSpec.describe VacancyPresenter do
 
     context 'when expiry time given' do
       it 'returns true when the vacancy has expired by now' do
-        vacancy = VacancyPresenter.new(build(:vacancy, expiry_time: DateTime.now - 1.hour))
+        vacancy = VacancyPresenter.new(build(:vacancy, expiry_time: Time.zone.now - 1.hour))
 
         expect(vacancy).to be_expired
       end
 
       it 'returns false when the vacancy expires later today' do
-        vacancy = VacancyPresenter.new(build(:vacancy, expiry_time: DateTime.now + 1.hour))
+        vacancy = VacancyPresenter.new(build(:vacancy, expiry_time: Time.zone.now + 1.hour))
 
         expect(vacancy).not_to be_expired
       end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/nDuQJ51p/1010-add-time-to-vacancy-deadline-so-that-jobseekers-know-how-long-they-have-to-apply-and-dont-click-on-expired-jobs-sliced

## Changes in this PR:
- Changed the scope queries in the vacancy model, so that
expiry_time is used in queries when it's not nil, while
tolerates the absence of this value. So that existing vacancies
that have no expiry_time can be expired based on their expires_on date,
just like the old behaviour. Added tests accordingly.

- Changed the VacancyPresenter to used expiry_time when its 
not null.
