### PR TITLE
(hotfix) don't clear cache on smoke tests

### DIFF
--- a/spec/browser_test_helper.rb
+++ b/spec/browser_test_helper.rb
@@ -7,7 +7,7 @@ end
 Capybara.javascript_driver = :poltergeist
 
 RSpec.configure do |config|
-  config.before(:each, js: true) do
+  config.before(:each, js: true, :type => lambda {|v| v != :smoke_test}) do
     page.driver.clear_memory_cache
   end
 end

--- a/spec/browser_test_helper.rb
+++ b/spec/browser_test_helper.rb
@@ -7,7 +7,7 @@ end
 Capybara.javascript_driver = :poltergeist
 
 RSpec.configure do |config|
-  config.before(:each, js: true, :type => lambda {|v| v != :smoke_test}) do
+  config.before(:each, js: true, type: ->(v) { v != :smoke_test }) do
     page.driver.clear_memory_cache
   end
 end


### PR DESCRIPTION
Hotfix issue with cache clearing causing smoke tests to fail introduced  by latest production release