### PR TITLE
(chore) display expiry time in vacancy list

### DIFF
--- a/app/views/vacancies/_vacancy.html.haml
+++ b/app/views/vacancies/_vacancy.html.haml
@@ -12,7 +12,7 @@
     - if vacancy.expiry_time.nil?
       %dd= format_date(vacancy.expires_on)
     - else 
-      %dd= format_date(vacancy.expires_on) + " at " + vacancy.expiry_time.strftime("%H:%M%P")
+      %dd= format_date(vacancy.expires_on) + " at " + vacancy.expiry_time.strftime('%-l:%M%P')
     %dt= t('jobs.starts_on')
     %dd= format_date(vacancy.starts_on)
     - if vacancy.working_patterns?

--- a/app/views/vacancies/_vacancy.html.haml
+++ b/app/views/vacancies/_vacancy.html.haml
@@ -9,7 +9,10 @@
     %dd.double
       = format_date(vacancy.publish_on)
     %dt= t('jobs.expires_on')
-    %dd= format_date(vacancy.expires_on)
+    - if vacancy.expiry_time.nil?
+      %dd= format_date(vacancy.expires_on)
+    - else 
+      %dd= format_date(vacancy.expires_on) + " at " + vacancy.expiry_time.strftime("%H:%M%P")
     %dt= t('jobs.starts_on')
     %dd= format_date(vacancy.starts_on)
     - if vacancy.working_patterns?

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -220,6 +220,16 @@ RSpec.feature 'Viewing vacancies' do
     end
   end
 
+  context 'when viewing vacancies created without expiry time' do
+    scenario 'Vacancies do not display an expiry time' do
+      vacancy = create(:vacancy, :with_no_expiry_time)
+      Vacancy.__elasticsearch__.client.indices.flush
+      visit jobs_path(vacancy)
+
+      verify_vacancy_list_page_details(VacancyPresenter.new(vacancy))
+    end
+  end
+
   context 'when the user is not on mobile' do
     scenario 'they should not see the \'refine your search\' link' do
       visit jobs_path

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -134,6 +134,12 @@ module VacancyHelpers
     expect(page.find('.vacancy')).to have_content(vacancy.publish_on)
     expect(page.find('.vacancy')).to have_content(vacancy.starts_on)
     expect(page.find('.vacancy')).to have_content(vacancy.working_patterns)
+
+    # rubocop:disable Style/GuardClause
+    unless vacancy.expiry_time.nil?
+      expect(page.find('.vacancy')).to have_content(vacancy.expiry_time.strftime('%H:%M%P'))
+    end
+    # rubocop:enable Style/GuardClause
   end
 
   def expect_schema_property_to_match_value(key, value)

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -137,7 +137,7 @@ module VacancyHelpers
 
     # rubocop:disable Style/GuardClause
     unless vacancy.expiry_time.nil?
-      expect(page.find('.vacancy')).to have_content(vacancy.expiry_time.strftime('%H:%M%P'))
+      expect(page.find('.vacancy')).to have_content(vacancy.expiry_time.strftime('%-l:%M%P'))
     end
     # rubocop:enable Style/GuardClause
   end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/uPDUKS9Q/1017-job-seekers-can-view-expiry-time-2

## Changes in this PR:
- Display vacancy expiry time in job listings view

## Screenshots of UI changes:

### Before
<img width="588" alt="Screenshot 2019-08-23 at 11 50 34" src="https://user-images.githubusercontent.com/47317567/63587656-76c98880-c59c-11e9-9c8e-60cd881e3100.png">

### After
<img width="585" alt="Screenshot 2019-08-23 at 11 50 40" src="https://user-images.githubusercontent.com/47317567/63587659-78934c00-c59c-11e9-9a7f-9ee6b35c71d1.png">
