### PR TITLE
Add accessibility statement to the site.

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -13,6 +13,7 @@ class SitemapController < ApplicationController
       m.add page_path('privacy-policy', protocol: 'https'), period: 'weekly'
       m.add page_path('terms-and-conditions', protocol: 'https'), period: 'weekly'
       m.add page_path('cookies', protocol: 'https'), period: 'weekly'
+      m.add page_path('accessibility', protocol: 'https'), period: 'weekly'
     end
 
     expires_in 3.hours

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,7 +18,7 @@
     %link{href: asset_path("govuk-apple-touch-icon-152x152.png"), rel: "apple-touch-icon", sizes: "152x152"}/
     %link{href: asset_path("govuk-apple-touch-icon.png"), rel: "apple-touch-icon"}/
     - if content_for? :head_links
-      = yield(:head_links) 
+      = yield(:head_links)
     /[if !IE 8]
     = stylesheet_link_tag 'application', media: 'all'
     /[if lte IE 8]
@@ -48,7 +48,7 @@
           %button.govuk-header__menu-button.js-header-toggle{type: "button", role: "button", "aria-controls": "navigation", "aria-label": "Show or hide Top Level Navigation"}
             Menu
           = render partial: 'shared/navigation'
-          
+
     .govuk-width-container
       .govuk-phase-banner
         %p.govuk-phase-banner__content
@@ -69,15 +69,15 @@
         .govuk-footer__meta
           .govuk-footer__meta-item.govuk-footer__meta-item--grow
             %div.govuk-grid-row
-              %div.govuk-grid-column-one-third    
-                %h2.govuk-heading-m 
+              %div.govuk-grid-column-one-third
+                %h2.govuk-heading-m
                   = I18n.t('footer.for_job_seekers')
                 %ul.govuk-footer__inline-list
                   %li.govuk-footer__inline-list-item
                     =link_to I18n.t('footer.search_teaching_vacancies'), root_url, class: 'govuk-footer__link'
-              
+
               %div.govuk-grid-column-one-third
-                %h2.govuk-heading-m 
+                %h2.govuk-heading-m
                   = I18n.t('footer.for_schools')
                 %ul.govuk-footer__inline-list
                   %li.govuk-footer__inline-list-item
@@ -87,7 +87,7 @@
                 %h2.govuk-heading-m
                   = I18n.t('footer.service_support')
                 %ul.govuk-footer__inline-list.hide-bullet-points
-                  %li.govuk-footer-list-item 
+                  %li.govuk-footer-list-item
                     = mail_to I18n.t('help.email'), I18n.t('footer.request_support'), class: 'govuk-footer__link'
                   %li.govuk-footer-list-item
                     = link_to I18n.t('footer.provide_feedback'), new_feedback_path, class: 'govuk-footer__link'
@@ -97,6 +97,8 @@
                     =link_to 'Privacy policy', page_path('privacy-policy'), class: 'govuk-footer__link'
                   %li.govuk-footer-list-item
                     =link_to 'Terms and Conditions', page_path('terms-and-conditions'), class: 'govuk-footer__link'
+                  %li.govuk-footer-list-item
+                    =link_to 'Accessibility', page_path('accessibility'), class: 'govuk-footer__link'
 
             %svg.govuk-footer__licence-logo{focusable: "false", height: "17", role: "presentation", viewbox: "0 0 483.2 195.7", width: "41", xmlns: "http://www.w3.org/2000/svg"}
               %path{d: "M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145", fill: "currentColor"}

--- a/app/views/pages/accessibility.html.haml
+++ b/app/views/pages/accessibility.html.haml
@@ -1,0 +1,68 @@
+- content_for :page_title_prefix  do
+  =t('static_pages.accessibility.page_title')
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl=t('static_pages.accessibility.page_title')
+
+    %h2.govuk-heading-l=t('static_pages.accessibility.title')
+    %p.govuk-body
+      =t('static_pages.accessibility.mission.opening_text')
+      %ul.govuk-list.govuk-list--bullet
+        -t('static_pages.accessibility.mission.list').each do |li|
+          %li=li.html_safe
+    %p.govuk-body=t('static_pages.accessibility.mission.closing_text')
+
+    %h3.govuk-heading-m=t('static_pages.accessibility.how_accessible.title')
+    %p.govuk-body=t('static_pages.accessibility.how_accessible.text').html_safe
+
+    %h3.govuk-heading-m=t('static_pages.accessibility.reporting_accessibility_problems.title')
+    %p.govuk-body=t('static_pages.accessibility.reporting_accessibility_problems.text', help_email: t('help.email')).html_safe
+
+    %h3.govuk-heading-m=t('static_pages.accessibility.enforcement_procedure.title')
+    %p.govuk-body=t('static_pages.accessibility.enforcement_procedure.text').html_safe
+
+    %h2.govuk-heading-l=t('static_pages.accessibility.technical_information.title')
+    -t('static_pages.accessibility.technical_information.text').each do |p|
+      %p.govuk-body=p.html_safe
+
+    %h3.govuk-heading-m=t('static_pages.accessibility.non_accesssible.title')
+    %p.govuk-body=t('static_pages.accessibility.non_accesssible.text')
+
+    %h3.govuk-heading-m=t('static_pages.accessibility.non_compliance.title')
+    %p.govuk-body=t('static_pages.accessibility.non_compliance.text')
+
+    %h4.govuk-heading-s=t('static_pages.accessibility.non_compliance.perceivable.heading')
+    %p.govuk-body=t('static_pages.accessibility.non_compliance.perceivable.principle')
+    -t('static_pages.accessibility.non_compliance.perceivable.issue.text').each do |p|
+      %p.govuk-body=p.html_safe
+
+    %h4.govuk-heading-s=t('static_pages.accessibility.non_compliance.operable.heading')
+    %p.govuk-body=t('static_pages.accessibility.non_compliance.operable.principle')
+    -t('static_pages.accessibility.non_compliance.operable.issue.text').each do |p|
+      %p.govuk-body=p.html_safe
+
+    %h4.govuk-heading-s=t('static_pages.accessibility.non_compliance.robust.heading')
+    %p.govuk-body=t('static_pages.accessibility.non_compliance.robust.principle')
+    -t('static_pages.accessibility.non_compliance.robust.issue.text').each do |p|
+      %p.govuk-body=p.html_safe
+
+    %h4.govuk-heading-s=t('static_pages.accessibility.non_compliance.not_in_scope.heading')
+    %p.govuk-body=t('static_pages.accessibility.non_compliance.not_in_scope.text')
+    -t('static_pages.accessibility.non_compliance.not_in_scope.issue.text').each do |p|
+      %p.govuk-body=p.html_safe
+
+    %h3.govuk-heading-m=t('static_pages.accessibility.how_we_tested.title')
+    -t('static_pages.accessibility.how_we_tested.opening_text').each do |p|
+      %p.govuk-body=p.html_safe
+    %ul.govuk-list.govuk-list--bullet
+      -t('static_pages.accessibility.how_we_tested.list').each do |li|
+        %li=li.html_safe
+
+    %p.govuk-body
+      =t('static_pages.accessibility.how_we_tested.closing_text.text').html_safe
+      %ul.govuk-list.govuk-list--bullet
+        -t('static_pages.accessibility.how_we_tested.closing_text.list').each do |li|
+          %li=li.html_safe
+
+    %p.govuk-body=t('static_pages.accessibility.date_reviewed').html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -693,6 +693,80 @@ en:
           title: Terms and Conditions for API users
           line_1: "You are free to reuse job listing data under the terms of the <a href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/' target='_blank' class='govuk-link'>Open Government Licence</a> for public sector information with the following exception:"
           list: you may not charge a school any fee or commission for contacting, interviewing or hiring a respondent to your advertisement or listing if it is based on Teaching Vacancies data that you have reused.
+    accessibility:
+      page_title: Accessibility
+      title: Accessibility statement for Teaching Vacancies
+      mission:
+        opening_text: "Teaching Vacancies is run by the Department for Education. We want as many people as possible to be able to use the service. For example, that means users should be able to:"
+        list:
+          - change colours, contrast levels and fonts
+          - zoom in up to 300% without the text spilling off the screen
+          - navigate most of the service using just a keyboard
+          - navigate most of the service using speech recognition software
+          - listen to most of the content on Teaching Vacancies using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+        closing_text: "We’ve also made the text on the service as simple as possible to understand."
+      how_accessible:
+        title: How accessible Teaching Vacancies is
+        text: "Teaching Vacancies is currently designated as 'partially accessible' according to the <a href='https://www.w3.org/TR/WCAG21/' target='_blank' class='govuk-link'>Web Content Accessibility Guidelines version (WCAG) 2.1</a> AA standard. All significant issues with accessibility are detailed in the Non-accessible content section, below."
+      reporting_accessibility_problems:
+        title: Reporting accessibility problems with Teaching Vacancies
+        text: "We’re always looking to improve the accessibility of this service. If you find any problems that aren’t listed on this page or think we’re not meeting accessibility requirements, please email <a href='mailto: %{help_email}' class='govuk-link'>%{help_email}</a> with 'Accessibility issues' in the subject line of the email."
+      enforcement_procedure:
+        title: Enforcement procedure
+        text: "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <a href='https://www.equalityadvisoryservice.com/' class='govuk-link'>contact the Equality Advisory and Support Service (EASS)</a>."
+      technical_information:
+        title: "Technical information about Teaching Vacancies' accessibility"
+        text:
+          - The Department for Education is committed to making its digital services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+          - "This website is at present partially compliant with the <a href='https://www.w3.org/TR/WCAG21/' target='_blank' class='govuk-link'>WCAG 2.1</a> AA standard, due to those non-compliance issues listed below that are marked with (A) or (AA)."
+      non_accesssible:
+        title: Non-accessible content
+        text: A number of issues related to the accessibility of Teaching Vacancies were raised in an accessibility audit conducted in May 2019. Most of these have been corrected but there are still a number of issues the Teaching Vacancies team is working to resolve. When these issues have been resolved we will update this statement and the compliance status of Teaching Vacancies.
+      non_compliance:
+        title: Non-compliance with the accessibility regulations
+        text: The following accessibility issues have been identified and are grouped here according to which principle of accessibility criteria they fall under in the WCAG 2.1 guidelines.
+        perceivable:
+          heading: "'Perceivable'"
+          principle: "Principle: Information and user interface components must be presentable to users in ways they can perceive."
+          issue:
+            text:
+            - "<strong class='strong'>Issue</strong>: Some images don’t have a text alternative, so the information in them isn’t available to people using a screen reader.<br /><strong class='strong'>Criterion failed</strong>: 1.1.1 Text Alternatives: Non-text content (AA)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
+            - "<strong class='strong'>Issue</strong>: The colour contrast ratio between text and its background colour on certain pages makes text difficult for visually impaired users to read. Increasing the text size will resolve this issue.<br /><strong class='strong'>Criterion failed</strong>: 1.4.3 Distinguishable: Contrast (Minimum) (AA)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
+        operable:
+          heading: "'Operable'"
+          principle: "Principle: User interface components and navigation must be operable."
+          issue:
+            text:
+              - "<strong class='strong'>Issue</strong>: The 'skip to content' link that allows users of assistive technology to skip navigation links and go straight to the main content isn't working in Internet Explorer.<br /><strong class='strong'>Criterion failed</strong>: 2.4.1 Navigable: Bypass Blocks (A)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
+              - "<strong class='strong'>Issue</strong>: Some hyperlinks on the service need more useful descriptions for users of screen readers, who require context for each link.<br /><strong class='strong'>Criterion failed</strong>: 2.4.9 Navigable: Link Purpose (Link Only) (AAA)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
+              - "<strong class='strong'>Issue</strong>: Header text on the page confirming to a user that they've signed up for a job alert skips a heading level (for example, jumping from an h2 level to an h4 level), which can cause confusion for users navigating pages with a screen reader.<br /><strong class='strong'>Criterion failed</strong>: 2.4.10 Navigable: Section headings (AAA)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
+        robust:
+          heading: "'Robust'"
+          principle: "Principle: Content must be robust enough that it can be interpreted by a wide variety of user agents, including assistive technologies."
+          issue:
+            text:
+              - "<strong class='strong'>Issue</strong>: Users of screen readers aren't reliably notified when a page is loading or when jobs have been sorted by date. This leads to the focus remaining stationary.<br /><strong class='strong'>Criterion failed</strong>:  4.1.3 Compatible: Status messages (AA)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
+        not_in_scope:
+          heading: "Content that’s not within the scope of the accessibility regulations"
+          text: The following accessibility issues have been identified but do not fall within the scope of the WCAG 2.1 guidelines for the reasons stated.
+          issue:
+            text:
+              - "<strong class='strong'>Issue</strong>: The colour used to indicate when an element such as a radio button has received focus does not meet the expected ratio.  This is a GDS Design System issue, however, so is not within our scope to correct. Note that a subtle movement effect also helps convey the focus state of a button, for example, so colour contrast is not the only tactic we use for improving distinguishability.<br /><strong class='strong'>Criterion failed</strong>:  1.4.11 Distinguishable: Non-text contrast"
+      how_we_tested:
+        title: How we tested this website
+        opening_text:
+          - This website was last tested on 28 May 2019. The test was carried out by the Digital Accessibility Centre (DAC).
+          - "DAC tested various combinations of the following for both desktop and mobile/tablet users:"
+        list:
+          - assistive technologies (eg Jaws 16, NVDA, VoiceOver, Dragon Voice Activation, Keyboard, System inverted colours, Screen Magnification, Colour blind checks, Resizing content)
+          - browser environments (IE11, Firefox, Safari, Chrome)
+          - accessibility user groups (Blind, Deaf, Mobility, Colour blind, Dyslexia, Low Vision, Aspergers, Cognitive Impaired/Panic/Anxiety)
+        closing_text:
+          text: "DAC tested:"
+          list:
+            - the hiring staff journey for listing a job on the service, available at <a href='https://teaching-vacancies.service.gov.uk/identifications/new' target='_blank' class='govuk-link'>https://teaching-vacancies.service.gov.uk/identifications/new</a>
+            - the jobseeker journey for searching for a teaching job and signing up for a job alert, available at <a href='https://teaching-vacancies.service.gov.uk/' target='_blank' class='govuk-link'>https://teaching-vacancies.service.gov.uk/</a>
+      date_reviewed: This statement was prepared on 12 September 2019. It was last updated on 12 September 2019.
   footer:
       request_support: "Report problems via email"
       provide_feedback: "Feedback about the service"

--- a/spec/features/application_sitemap_spec.rb
+++ b/spec/features/application_sitemap_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Application sitemap', sitemap: true do
       document = Nokogiri::XML::Document.parse(body)
       nodes = document.search('url')
 
-      expect(nodes.count).to eq(9)
+      expect(nodes.count).to eq(10)
       expect(nodes.search("loc[text()='#{root_url(protocol: 'https')}']").text)
         .to eq(root_url(protocol: 'https'))
 
@@ -25,6 +25,8 @@ RSpec.feature 'Application sitemap', sitemap: true do
         .to eq(page_url('cookies', protocol: 'https'))
       expect(nodes.search("loc:contains('#{page_url('privacy-policy', protocol: 'https')}')").text)
         .to eq(page_url('privacy-policy', protocol: 'https'))
+      expect(nodes.search("loc:contains('#{page_url('accessibility', protocol: 'https')}')").text)
+        .to eq(page_url('accessibility', protocol: 'https'))
     end
   end
 end

--- a/spec/features/support_links_spec.rb
+++ b/spec/features/support_links_spec.rb
@@ -26,4 +26,12 @@ RSpec.feature 'A visitor to the website can access the support links' do
 
     expect(page).to have_content(I18n.t('static_pages.terms_and_conditions.all_users.using_the_website.text').first)
   end
+
+  scenario 'the accessibility statement' do
+    visit root_path
+    click_on 'Accessibility'
+
+    expect(page).to have_content(I18n.t('static_pages.accessibility.page_title'))
+    expect(page).to have_content(I18n.t('static_pages.accessibility.mission.opening_text'))
+  end
 end


### PR DESCRIPTION
We are required to add an accessibility statement (based on our most recent accessibility audit) to the service's website.
We want our service users to be able to view this accessibility statement from the site footer.

### Further work
This does not include a link to download the complete report. Further work could be done around this if this becomes a necessary requirement. At the moment of writing, it is not.

## Next steps:

- [ ] Check that date of deployment to the live site matches the date that the document was published and updated _(check the last line of the accessibility statement)_  as this may need altering. 
