### PR TITLE
Add Dfe Sign-in API gateway

### DIFF
--- a/lib/dfe_sign_in_api.rb
+++ b/lib/dfe_sign_in_api.rb
@@ -1,4 +1,7 @@
 module DFESignIn
+  class ExternalServerError < StandardError; end
+  class ForbiddenRequestError < StandardError; end
+
   class API
     def users(page: 1)
       token = generate_jwt_token
@@ -6,7 +9,11 @@ module DFESignIn
         api_url(page),
         headers: { 'Authorization' => "Bearer #{token}" }
       )
-      JSON.parse(response)
+
+      raise ExternalServerError if response.code.eql?(500)
+      raise ForbiddenRequestError if response.code.eql?(403)
+
+      JSON.parse(response) if response.code.eql?(200)
     end
 
     private

--- a/lib/dfe_sign_in_api.rb
+++ b/lib/dfe_sign_in_api.rb
@@ -1,0 +1,35 @@
+module DFESignIn
+  class API
+    BASE_URL = DFE_SIGN_IN_URL
+
+    attr_accessor :dfe_sign_in_password
+
+    def initialize
+      self.dfe_sign_in_password = DFE_SIGN_IN_PASSWORD
+    end
+
+    def users(page: 1)
+      token = generate_jwt_token
+      response = HTTParty.get(
+        api_url(page),
+        headers: { 'Authorization' => "Bearer #{token}" }
+      )
+      JSON.parse(response)
+    end
+
+    private
+
+    def api_url(page = 1, records = 25)
+      "#{DFE_SIGN_IN_URL}/users?page=#{page}&pageSize=#{records}"
+    end
+
+    def generate_jwt_token
+      payload = {
+        iss: 'schooljobs',
+        exp: (Time.now.getlocal + 60).to_i,
+        aud: 'signin.education.gov.uk'
+      }
+      JWT.encode(payload, dfe_sign_in_password, 'HS256')
+    end
+  end
+end

--- a/lib/dfe_sign_in_api.rb
+++ b/lib/dfe_sign_in_api.rb
@@ -1,13 +1,5 @@
 module DFESignIn
   class API
-    BASE_URL = DFE_SIGN_IN_URL
-
-    attr_accessor :dfe_sign_in_password
-
-    def initialize
-      self.dfe_sign_in_password = DFE_SIGN_IN_PASSWORD
-    end
-
     def users(page: 1)
       token = generate_jwt_token
       response = HTTParty.get(
@@ -19,8 +11,8 @@ module DFESignIn
 
     private
 
-    def api_url(page = 1, records = 25)
-      "#{DFE_SIGN_IN_URL}/users?page=#{page}&pageSize=#{records}"
+    def api_url(page = 1)
+      "#{DFE_SIGN_IN_URL}/users?page=#{page}&pageSize=25"
     end
 
     def generate_jwt_token
@@ -29,7 +21,8 @@ module DFESignIn
         exp: (Time.now.getlocal + 60).to_i,
         aud: 'signin.education.gov.uk'
       }
-      JWT.encode(payload, dfe_sign_in_password, 'HS256')
+
+      JWT.encode(payload, DFE_SIGN_IN_PASSWORD, 'HS256')
     end
   end
 end

--- a/spec/fixtures/dfe_sign_in_service_users_response_page_1.json
+++ b/spec/fixtures/dfe_sign_in_service_users_response_page_1.json
@@ -1,0 +1,37 @@
+{
+  "users": [{
+    "approvedAt": "2019-06-19T15:09:58.683Z",
+    "updatedAt": "2019-06-19T15:09:58.683Z",
+    "organisation": {
+      "id": "13F20E54-79EA-4146-8E39-18197576F023",
+      "name": "Department for Education",
+      "Category": "002",
+      "Type": null,
+      "URN": null,
+      "UID": null,
+      "UKPRN": null,
+      "EstablishmentNumber": "001",
+      "Status": 1,
+      "ClosedOn": null,
+      "Address": null,
+      "phaseOfEducation": null,
+      "statutoryLowAge": null,
+      "statutoryHighAge": null,
+      "telephone": null,
+      "regionCode": null,
+      "legacyId": "1031237",
+      "companyRegistrationNumber": "1234567",
+      "createdAt": "2019-02-20T14:27:59.020Z",
+      "updatedAt": "2019-02-20T14:28:38.223Z"
+    },
+    "roleName": "Approver",
+    "roleId": 10000,
+    "userId": "AAA-111",
+    "email": "foo@example.com",
+    "familyName": "Johnson",
+    "givenName": "Roger"
+  }],
+  "numberOfRecords": 1,
+  "page": 1,
+  "numberOfPages": 2
+}

--- a/spec/fixtures/dfe_sign_in_service_users_response_page_2.json
+++ b/spec/fixtures/dfe_sign_in_service_users_response_page_2.json
@@ -1,0 +1,37 @@
+{
+  "users": [{
+    "approvedAt": "2019-06-19T15:09:58.683Z",
+    "updatedAt": "2019-06-19T15:09:58.683Z",
+    "organisation": {
+      "id": "13F20E54-79EA-4146-8E39-18197576F024",
+      "name": "Department for Education",
+      "Category": "002",
+      "Type": null,
+      "URN": null,
+      "UID": null,
+      "UKPRN": null,
+      "EstablishmentNumber": "001",
+      "Status": 1,
+      "ClosedOn": null,
+      "Address": null,
+      "phaseOfEducation": null,
+      "statutoryLowAge": null,
+      "statutoryHighAge": null,
+      "telephone": null,
+      "regionCode": null,
+      "legacyId": "1031237",
+      "companyRegistrationNumber": "1234567",
+      "createdAt": "2019-02-20T14:27:59.020Z",
+      "updatedAt": "2019-02-20T14:28:38.223Z"
+    },
+    "roleName": "Approver",
+    "roleId": 10000,
+    "userId": "BBB-222",
+    "email": "foo@example.com",
+    "familyName": "Johnson",
+    "givenName": "Roger"
+  }],
+  "numberOfRecords": 1,
+  "page": 2,
+  "numberOfPages": 2
+}

--- a/spec/lib/dfe_sign_in_api_spec.rb
+++ b/spec/lib/dfe_sign_in_api_spec.rb
@@ -3,40 +3,52 @@ require 'dfe_sign_in_api'
 
 RSpec.describe DFESignIn::API do
   describe '#users' do
-    it 'returns the users from the API ' do
-      stub_api_response_for_page(1)
-      response = described_class.new.users
+    context 'when the response code is 200' do
+      it 'returns the users from the API' do
+        stub_api_response_for_page(1)
+        response = described_class.new.users
 
-      expect(response).to eq(JSON.parse(response_file(1)))
-      expect(response['page']).to eq(1)
-      expect(response['numberOfPages']).to eq(2)
-    end
+        expect(response).to eq(JSON.parse(response_file(1)))
+        expect(response['page']).to eq(1)
+        expect(response['numberOfPages']).to eq(2)
+      end
 
-    it 'returns the users from the API for a given page ' do
-      stub_api_response_for_page(2)
-      response = described_class.new.users(page: 2)
-
-      expect(response).to eq(JSON.parse(response_file(2)))
-      expect(response['page']).to eq(2)
-      expect(response['numberOfPages']).to eq(2)
-    end
-
-    it 'sets a token in the header of the request' do
-      Timecop.freeze(Time.zone.now) do
-        payload = {
-          iss: 'schooljobs',
-          exp: (Time.now.getlocal + 60).to_i,
-          aud: 'signin.education.gov.uk'
-        }
-
-        expected_token = JWT.encode(payload, DFE_SIGN_IN_PASSWORD, 'HS256')
-
+      it 'returns the users from the API for a given page ' do
         stub_api_response_for_page(2)
-        described_class.new.users(page: 2)
+        response = described_class.new.users(page: 2)
 
-        expect(a_request(:get, "#{DFE_SIGN_IN_URL}/users?page=2&pageSize=25")
-          .with(headers: { 'Authorization' => "Bearer #{expected_token}" }))
-          .to have_been_made
+        expect(response).to eq(JSON.parse(response_file(2)))
+        expect(response['page']).to eq(2)
+        expect(response['numberOfPages']).to eq(2)
+      end
+
+      it 'sets a token in the header of the request' do
+        Timecop.freeze(Time.zone.now) do
+          expected_token = generate_jwt_token
+
+          stub_api_response_for_page(2)
+          described_class.new.users(page: 2)
+
+          expect(a_request(:get, "#{DFE_SIGN_IN_URL}/users?page=2&pageSize=25")
+            .with(headers: { 'Authorization' => "Bearer #{expected_token}" }))
+            .to have_been_made
+        end
+      end
+    end
+
+    context 'when the external response status is 500' do
+      before { stub_api_response_with_external_error(1) }
+
+      it 'raises an external server error' do
+        expect { described_class.new.users }.to raise_error(DFESignIn::ExternalServerError)
+      end
+    end
+
+    context 'when the response status is 403' do
+      before { stub_api_response_with_forbidden_error(1) }
+
+      it 'raises an forbidden request error' do
+        expect { described_class.new.users }.to raise_error(DFESignIn::ForbiddenRequestError)
       end
     end
 
@@ -51,7 +63,29 @@ RSpec.describe DFESignIn::API do
     def stub_api_response_for_page(page)
       stub_request(:get,
                    "#{DFE_SIGN_IN_URL}/users?page=#{page}&pageSize=25")
-        .to_return(body: response_file(page))
+        .to_return(body: response_file(page), status: 200)
+    end
+
+    def stub_api_response_with_external_error(page)
+      stub_request(:get,
+                   "#{DFE_SIGN_IN_URL}/users?page=#{page}&pageSize=25")
+        .to_return(body: '', status: 500)
+    end
+
+    def stub_api_response_with_forbidden_error(page)
+      stub_request(:get,
+                   "#{DFE_SIGN_IN_URL}/users?page=#{page}&pageSize=25")
+        .to_return(body: '{"success":false,"message":"jwt expired"}', status: 403)
+    end
+
+    def generate_jwt_token
+      payload = {
+        iss: 'schooljobs',
+        exp: (Time.now.getlocal + 60).to_i,
+        aud: 'signin.education.gov.uk'
+      }
+
+      JWT.encode(payload, DFE_SIGN_IN_PASSWORD, 'HS256')
     end
   end
 end

--- a/spec/lib/dfe_sign_in_api_spec.rb
+++ b/spec/lib/dfe_sign_in_api_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+require 'dfe_sign_in_api'
+
+RSpec.describe DFESignIn::API do
+  describe '#users' do
+    it 'returns the users from the API ' do
+      stub_api_response_for_page(1)
+      response = described_class.new.users
+
+      expect(response).to eq(JSON.parse(response_file(1)))
+      expect(response['page']).to eq(1)
+      expect(response['numberOfPages']).to eq(2)
+    end
+
+    it 'returns the users from the API for a given page ' do
+      stub_api_response_for_page(2)
+      response = described_class.new.users(page: 2)
+
+      expect(response).to eq(JSON.parse(response_file(2)))
+      expect(response['page']).to eq(2)
+      expect(response['numberOfPages']).to eq(2)
+    end
+
+    it 'sets a token in the header of the request' do
+      jwt_token = double
+      expect(JWT).to receive(:encode).with(
+        {
+          iss: 'schooljobs',
+          exp: (Time.now.getlocal + 60).to_i,
+          aud: 'signin.education.gov.uk'
+        },
+        'test-password',
+        'HS256'
+      ).and_return(jwt_token)
+
+      stub_api_response_with_token(jwt_token)
+
+      expect(HTTParty).to receive(:get)
+        .with('https://test-url.local/users?page=1&pageSize=25',
+              headers: { 'Authorization' => "Bearer #{jwt_token}" })
+        .and_return(response_file(1))
+
+      described_class.new.users
+    end
+
+    def response_file(page)
+      File.read(Rails.root.join(
+                  'spec',
+                  'fixtures',
+                  "dfe_sign_in_service_users_response_page_#{page}.json"
+                ))
+    end
+
+    def stub_api_response_for_page(page)
+      stub_request(:get,
+                   "#{DFE_SIGN_IN_URL}/users?page=#{page}&pageSize=25")
+        .to_return(body: response_file(page))
+    end
+
+    def stub_api_response_with_token(token)
+      stub_request(:get,
+                   "#{DFE_SIGN_IN_URL}/users?page=1&pageSize=25")
+        .with(headers: {
+                'Authorization' => "Bearer #{token}]"
+              }).to_return(body: response_file(1))
+    end
+  end
+end


### PR DESCRIPTION
We want to get service users from the DSI API to synchronise user
data with a google sheet.

## Jira ticket URL:
https://dfedigital.atlassian.net/secure/RapidBoard.jspa?rapidView=21&modal=detail&selectedIssue=TEVA-47