### PR TITLE
Reset the session[:vacancy_attributes] between edits

### DIFF
--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -25,13 +25,15 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
   def review
     return redirect_to school_job_path(@vacancy.id), notice: already_published_message if @vacancy.published?
 
+    reset_session_vacancy!
+    store_vacancy_attributes(@vacancy.attributes)
+
     unless @vacancy.valid?
       return redirect_to candidate_specification_school_job_path unless step_2_valid?
       return redirect_to application_details_school_job_path unless step_3_valid?
     end
 
     session[:current_step] = :review
-    store_vacancy_attributes(@vacancy.attributes)
     @vacancy = VacancyPresenter.new(@vacancy)
     @vacancy.valid? if params[:source]&.eql?('publish')
   end

--- a/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+RSpec.feature 'Hiring staff can edit a draft vacancy' do
+  let(:school) { create(:school) }
+  before do
+    stub_hiring_staff_auth(urn: school.urn)
+  end
+
+  context 'with job specification completed' do
+    let!(:vacancy) do
+      pay_scales = create_list(:pay_scale, 3)
+      VacancyPresenter.new(build(:vacancy, :complete,
+                                 job_title: 'Draft vacancy',
+                                 school: school,
+                                 min_pay_scale: pay_scales.sample,
+                                 max_pay_scale: pay_scales.sample,
+                                 working_patterns: ['full_time', 'part_time']))
+    end
+    let(:draft_vacancy) { Vacancy.find_by(job_title: vacancy.job_title) }
+
+    before do
+      visit new_school_job_path
+      fill_in_job_specification_form_fields(vacancy)
+      click_on I18n.t('buttons.save_and_continue')
+    end
+
+    scenario 'redirects to incomplete candidate specification step, with fields pre-populated' do
+      draft_vacancy.education = 'Teaching degree'
+      draft_vacancy.qualifications = 'New Teacher Qualification'
+      draft_vacancy.save(validate: false)
+
+      visit edit_school_job_path(id: draft_vacancy.id)
+
+      expect(page).to have_content('Step 2 of 3')
+      expect(page).to have_content(draft_vacancy.education)
+      expect(page).to have_content(draft_vacancy.qualifications)
+    end
+
+    context 'when editing a different vacancy' do
+      # We use the session to store vacancy attributes, make sure it doesn't leak between edits.
+      before do
+        edit_a_published_vacancy
+      end
+
+      scenario 'then editing the draft redirects to incomplete step' do
+        visit school_job_path(id: draft_vacancy.id)
+        expect(page).to have_content('Step 2 of 3')
+      end
+
+      def edit_a_published_vacancy
+        published_vacancy = create(:vacancy, :published, school: school)
+        visit edit_school_job_path(published_vacancy.id)
+        click_link_in_container_with_text(I18n.t('jobs.application_link'))
+
+        fill_in 'application_details_form[application_link]', with: 'https://example.com'
+        click_on I18n.t('buttons.update_job')
+
+        expect(page).to have_content(I18n.t('messages.jobs.updated'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Jira ticket URL:

https://dfedigital.atlassian.net/browse/TEVA-176

## Changes in this PR:

Previously this wasn't being cleared which caused:
  * Data from one Vacancy being shown when editing another vacancy
  * Data from a draft Vacancy not being loaded and shown to the user
    if the session was empty, resulting in the vacancy details
    having to be re-entered.

As far as I can tell this defect was introduced as part of 77badb7

In the long term it would be nicer if the session wasn't being used to
store Vacancy attributes, as it would avoid these issues.

## Screenshots of UI changes:

### Before

![draft_vacancy_broken_small](https://user-images.githubusercontent.com/976274/65717314-ed284180-e098-11e9-8214-bf316db59de3.gif)

### After

![draft_vacancy_small](https://user-images.githubusercontent.com/976274/65716592-60c94f00-e097-11e9-85ba-3d3f79a307af.gif)
