### PR TITLE
fix loofah deprecation warnings when running test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'haml-rails'
 gem 'kaminari'
 gem 'roadie-rails'
 gem 'simple_form'
-gem 'rails-html-sanitizer', '~> 1.0.4', '>= 1.0.4' # Must be above this version due to CVE-2018-3741
+gem 'rails-html-sanitizer', '~> 1.3.0' # Must be above this version due to CVE-2018-3741
 
 gem 'gov_uk_date_fields'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,8 +339,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
-      loofah (~> 2.2, >= 2.2.2)
+    rails-html-sanitizer (1.3.0)
+      loofah (~> 2.3)
     railties (5.2.2.1)
       actionpack (= 5.2.2.1)
       activesupport (= 5.2.2.1)
@@ -549,7 +549,7 @@ DEPENDENCIES
   rack_session_access
   rails (~> 5.2.2)
   rails-controller-testing (~> 1.0)
-  rails-html-sanitizer (~> 1.0.4, >= 1.0.4)
+  rails-html-sanitizer (~> 1.3.0)
   redis
   redis-objects
   roadie-rails


### PR DESCRIPTION
## Changes in this PR:
- Update rails-html-sanitizer to 1.3.0

## Screenshots of changes:

### Before

<img width="1098" alt="Screenshot 2019-10-07 at 15 38 45" src="https://user-images.githubusercontent.com/47317567/66329285-2e84e080-e926-11e9-9625-a97fcc05c39d.png">

### After
![image](https://user-images.githubusercontent.com/47317567/66329346-46f4fb00-e926-11e9-9ae1-d3cf6d6397c1.png)

## Next steps:

- [ ] New development configuration to be shared - bin/drebuild needed
