### PR TITLE
Add format salary helper method to vacancy model

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -220,11 +220,11 @@ class Vacancy < ApplicationRecord
   end
 
   def minimum_salary=(salary)
-    self[:minimum_salary] = salary.to_s.strip
+    self[:minimum_salary] = format_salary(salary)
   end
 
   def maximum_salary=(salary)
-    self[:maximum_salary] = salary.to_s.strip
+    self[:maximum_salary] = format_salary(salary)
   end
 
   def weekly_hours?
@@ -288,5 +288,10 @@ class Vacancy < ApplicationRecord
     return unless listed_elsewhere_changed? && hired_status_changed?
 
     self.stats_updated_at = Time.zone.now
+  end
+
+  def format_salary(salary)
+    salary = salary.to_s[0..-2] if salary.to_s[-1] == '.'
+    salary.to_s.strip.delete(',')
   end
 end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -291,7 +291,9 @@ class Vacancy < ApplicationRecord
   end
 
   def format_salary(salary)
-    salary = salary.to_s[0..-2] if salary.to_s[-1] == '.'
-    salary.to_s.strip.delete(',')
+    salary = salary.to_s.strip
+    return salary.delete(',') if salary[SalaryValidator::SALARY_FORMAT]
+
+    salary
   end
 end

--- a/app/validators/salary_validator.rb
+++ b/app/validators/salary_validator.rb
@@ -5,7 +5,7 @@ class SalaryValidator < ActiveModel::EachValidator
 
   rescue_from ArgumentError, with: :invalid_format_message
 
-  SALARY_FORMAT = /^\d+\.{0,1}\d{2}{0,1}$/.freeze
+  SALARY_FORMAT = /^(\d+|\d{1,3}(,\d{3})*)(\.\d{2})?$/.freeze
   MIN_SALARY_ALLOWED = 0
   MAX_SALARY_ALLOWED = 200000
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,7 +228,7 @@ en:
       job_title: "For secondary school roles include subject and, if relevant, level of seniority ('Subject leader for science', for example)."
       description: 'Briefly describe the duties and responsibilities involved in the role (minimum 10 characters)'
       subject: 'What subject will the teacher focus on?'
-      salary_range: 'Enter annual pay before tax, without commas or decimal points (for example 30000)'
+      salary_range: 'Enter annual pay before tax'
       working_patterns: Select all working patterns you will consider for the role. Flexible working options may attract more candidates.
       flexible_working: Tick this box if flexible working options are available. Candidates will be asked to email for further information.
       newly_qualified_teacher: 'Tick this box if it is suitable for newly qualified teachers.'

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -186,6 +186,35 @@ RSpec.describe Vacancy, type: :model do
           .to eq(['must not be more than £200000'])
         expect(job.errors.messages[:maximum_salary]).to be_empty
       end
+
+      it 'can accept salary format with comma' do
+        job = build(:vacancy, minimum_salary: '20,000')
+
+        expect(job.valid?).to be true
+        expect(job.minimum_salary).to eq '20000'
+      end
+
+      it 'can tolerate salary format with decimal points at the end' do
+        job = build(:vacancy, minimum_salary: '20,000.')
+
+        expect(job.valid?).to be true
+        expect(job.minimum_salary).to eq '20000'
+      end
+
+      it 'can accept salary format with two decimal points' do
+        job = build(:vacancy, minimum_salary: '20,000.23')
+
+        expect(job.valid?).to be true
+        expect(job.minimum_salary).to eq '20000.23'
+      end
+
+      it 'can not accept salary format with more than two decimal points' do
+        job = build(:vacancy, minimum_salary: '20,000.2323232')
+
+        expect(job.valid?).to be false
+        expect(job.errors.messages[:minimum_salary])
+          .to eq(['must be entered in one of the following formats: 25000 or 25000.00'])
+      end
     end
 
     context 'a record saved with job spec and candidate spec details, ' \

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -194,11 +194,21 @@ RSpec.describe Vacancy, type: :model do
         expect(job.minimum_salary).to eq '20000'
       end
 
-      it 'can tolerate salary format with decimal points at the end' do
+      it 'rejects salary format with incorrect comma placement' do
+        incorrect_salary_format = ['20,,000', '200,00', ',200'].sample
+        job = build(:vacancy, minimum_salary: incorrect_salary_format)
+
+        expect(job.valid?).to be false
+        expect(job.errors.messages[:minimum_salary])
+          .to eq(['must be entered in one of the following formats: 25000 or 25000.00'])
+      end
+
+      it 'rejects salary format with decimal points at the end' do
         job = build(:vacancy, minimum_salary: '20,000.')
 
-        expect(job.valid?).to be true
-        expect(job.minimum_salary).to eq '20000'
+        expect(job.valid?).to be false
+        expect(job.errors.messages[:minimum_salary])
+          .to eq(['must be entered in one of the following formats: 25000 or 25000.00'])
       end
 
       it 'can accept salary format with two decimal points' do
@@ -206,6 +216,14 @@ RSpec.describe Vacancy, type: :model do
 
         expect(job.valid?).to be true
         expect(job.minimum_salary).to eq '20000.23'
+      end
+
+      it 'rejects salary format with one decimal point' do
+        job = build(:vacancy, minimum_salary: '20,000.2')
+
+        expect(job.valid?).to be false
+        expect(job.errors.messages[:minimum_salary])
+          .to eq(['must be entered in one of the following formats: 25000 or 25000.00'])
       end
 
       it 'can not accept salary format with more than two decimal points' do


### PR DESCRIPTION
## Jira ticket URL:
https://dfedigital.atlassian.net/secure/RapidBoard.jspa?rapidView=21&modal=detail&selectedIssue=TEVA-215

## Changes in this PR:
- Add `format_salary` helper method to vacancy model, to allow any correct salary formats, including comma and decimal point.
- Update hint text for salary field

## Screenshots of UI changes:
### Before
<img width="648" alt="Screenshot 2019-10-09 at 13 09 51" src="https://user-images.githubusercontent.com/22743709/66480580-e33e0f80-ea96-11e9-9810-cb422563dc23.png">

### After
<img width="379" alt="Screenshot 2019-10-09 at 13 09 27" src="https://user-images.githubusercontent.com/22743709/66480592-eb964a80-ea96-11e9-9643-790da66e2c37.png">

## Next steps:
- [ ] Content review

