### PR TITLE
(fix) Link from doucmentation folder to terraform docs

### DIFF
--- a/documentation/terraform.md
+++ b/documentation/terraform.md
@@ -1,0 +1,1 @@
+The full documentation can be found at [/terraform/README.md](/terraform/README.md).


### PR DESCRIPTION
Keeps the documentation folder useful as a library of docs, while keeping the terraform docs close to what it documents.