### PR TITLE
Add docs on authorising URL ownership for Indexing API access

### DIFF
--- a/documentation/bau-tasks.md
+++ b/documentation/bau-tasks.md
@@ -21,3 +21,12 @@ The audit sheet will take around 5 minutes to update once the task has been star
 You can also check Papertrail by searching for "AddAuditDataToSpreadsheetJob".
 
 [task_link]: https://eu-west-2.console.aws.amazon.com/ecs/home?region=eu-west-2#/taskDefinitions/tvs2_production_web_update_spreadsheets_task/status/ACTIVE
+
+### Fixing the "Permission denied. Failed to verify the URL ownership." error
+
+1. Visit [webmaster_central] and login using the "teachingjobs@digital.education.gov.uk" account details
+from the secrets repo.
+
+2. Click add an owner for: "analytics-prod@teacher-vacancy-service.iam.gserviceaccount.com"
+
+[webmaster_central]: https://www.google.com/webmasters/verification/details?hl=en&siteUrl=https://teaching-vacancies.service.gov.uk/&authuser=3&mesd=ACQ0Nr_qx9U2vbqOrgcxCOE4aFyfB_GW-g6bpYPCnkxgHBU_6VaQ_VuatrdgmiW5ABZQMpTHrtERgmvhOB04uji-_nAlH6WkBSaMlpKO2Jk5N1VU7L8DcIJHvokNamPH2rmTcnvHuK6mGBWYiMT35ED0FjbrgZHFrWwFgjpAVvnhaKAtoEmVL25dnyo2XQt05pJe1yN7guWswWfafEYIGoe5Q-k4WNsJtQ


### PR DESCRIPTION
We've had the following error crop up several times
"Google::Apis::ClientError: forbidden: Permission denied. Failed to verify the URL ownership."

We believe that ownership access was lost as part of the move from
Google Analytics to Google Tag Manager for the
"teachingjobs@digital.education.gov.uk" account.  Delegated access
for the API is removed if the delegator loses access.

These docs serve to simplify the process of fixing the error
if it crops up again.

Rollbar details:
https://rollbar.com/dfe/teacher-vacancies/items/219/