### PR TITLE
Fix the display of email errors on the subscription page

### DIFF
--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -18,7 +18,10 @@
           = t('errors.feedback.errors_present')
         %ul.govuk-list.govuk-error-summary__list
           - @subscription.errors.each do |attribute, error|
-            %li= @subscription.errors.full_message(attribute, error)
+            - if attribute == :email
+              %li= error
+            - else
+              %li= @subscription.errors.full_message(attribute, error)
 
 .govuk-grid-row
   .govuk-grid-column-one-half


### PR DESCRIPTION
As part of the error content changes done on the feedback forms (PR #1105), the Email validator class was edited.
The subscription model also uses this validator class.

This commit changes how any email related errors are displayed on the page.

## Screenshots of UI changes on the Subscriptions Page:

### Before
<img width="1066" alt="Screenshot 2019-10-31 at 16 26 20" src="https://user-images.githubusercontent.com/32823756/67966926-a4fec080-fbfc-11e9-8b73-793c639d65ff.png">


### After
<img width="1060" alt="Screenshot 2019-10-31 at 16 27 42" src="https://user-images.githubusercontent.com/32823756/67966936-a92ade00-fbfc-11e9-8a40-4237aa1ff746.png">