### PR TITLE
Error quick fixes

### DIFF
--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -109,7 +109,8 @@
         %span.govuk-hint= t('jobs.form_hints.salary_range')
         = f.input :minimum_salary,
                   input_html: { class: 'govuk-input--width-10' },
-                  as: :currency
+                  as: :currency,
+                  wrapper_html: {id: 'minimum_salary'}
 
         = f.input :maximum_salary,
                   input_html: { class: 'govuk-input--width-10' },

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -108,7 +108,8 @@
         %span.govuk-hint= t('jobs.form_hints.salary_range')
         = f.input :minimum_salary,
                   input_html: { class: 'govuk-input--width-10' },
-                  as: :currency
+                  as: :currency,
+                  wrapper_html: {id: 'minimum_salary'}
 
         = f.input :maximum_salary,
                   input_html: { class: 'govuk-input--width-10' },

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -74,7 +74,7 @@ en:
               invalid: Enter an email address in the correct format, like name@example.com
             comment:
               blank: Enter your feedback
-              too_long: Feedback must not be more than %{count} characters
+              too_long: Feedback must not be more than 1,200 characters
         general_feedback:
           attributes:
             user_participation_response:
@@ -84,11 +84,11 @@ en:
               invalid: Enter an email address in the correct format, like name@example.com
             comment:
               blank: Enter your feedback
-              too_long: Feedback must not be more than %{count} characters
+              too_long: Feedback must not be more than 1,200 characters
             visit_purpose:
               blank: Enter the reason for your visit
             visit_purpose_comment:
-              too_long: Purpose of visit must not be more than %{count} characters
+              too_long: Purpose of visit must not be more than 1,200 characters
         transaction_auditor:
           attributes:
             task:


### PR DESCRIPTION
- This fixes the error anchor link for minimum salary
- This adds commas to the character limit error messages on the feedback forms.

Before:
<img width="441" alt="Screenshot 2019-11-01 at 12 29 41" src="https://user-images.githubusercontent.com/32823756/68024896-4c363300-fca3-11e9-8c4e-7a6874d48026.png">


After:
<img width="458" alt="Screenshot 2019-11-01 at 12 22 17" src="https://user-images.githubusercontent.com/32823756/68024803-0da07880-fca3-11e9-88b9-d91cbe4f79ac.png">
