### PR TITLE
Fix Rubocop warnings "no department given"

### DIFF
--- a/spec/lib/update_school_data_spec.rb
+++ b/spec/lib/update_school_data_spec.rb
@@ -41,10 +41,9 @@ RSpec.describe UpdateSchoolData do
     end
 
     it 'should raise an HTTP error' do
-      # rubocop:disable AmbiguousBlockAssociation
-      expect { UpdateSchoolData.new.run }
-        .to raise_error { HTTParty::ResponseError.new('School CSV file not found.') }
-      # rubocop:enable AmbiguousBlockAssociation
+      expect { UpdateSchoolData.new.run }.to raise_error do
+        HTTParty::ResponseError.new('School CSV file not found.')
+      end
     end
   end
 
@@ -55,10 +54,9 @@ RSpec.describe UpdateSchoolData do
     end
 
     it 'should raise an HTTP error' do
-      # rubocop:disable AmbiguousBlockAssociation
-      expect { UpdateSchoolData.new.run }
-        .to raise_error { HTTParty::ResponseError.new('Unexpected problem downloading School CSV file.') }
-      # rubocop:enable AmbiguousBlockAssociation
+      expect { UpdateSchoolData.new.run }.to raise_error do
+        HTTParty::ResponseError.new('Unexpected problem downloading School CSV file.')
+      end
     end
   end
 


### PR DESCRIPTION
When deploying to production I noticed the following warning in the
logs.
```
/srv/dfe-tvs/spec/lib/update_school_data_spec.rb: Warning: no department given for AmbiguousBlockAssociation. Run `rubocop -a --only Migration/DepartmentName` to fix.
/srv/dfe-tvs/spec/lib/update_school_data_spec.rb: Warning: no department given for AmbiguousBlockAssociation. Run `rubocop -a --only Migration/DepartmentName` to fix.
/srv/dfe-tvs/spec/lib/update_school_data_spec.rb: Warning: no department given for AmbiguousBlockAssociation. Run `rubocop -a --only Migration/DepartmentName` to fix.
/srv/dfe-tvs/spec/lib/update_school_data_spec.rb: Warning: no department given for AmbiguousBlockAssociation. Run `rubocop -a --only Migration/DepartmentName` to fix.
```