### PR TITLE
Edit error content on the Job Specification form

### DIFF
--- a/app/validators/salary_validator.rb
+++ b/app/validators/salary_validator.rb
@@ -7,15 +7,16 @@ class SalaryValidator < ActiveModel::EachValidator
 
   SALARY_FORMAT = /^(\d+|\d{1,3}(,\d{3})*)(\.\d{2})?$/.freeze
   MIN_SALARY_ALLOWED = 0
-  MAX_SALARY_ALLOWED = 200000
+  MAX_SALARY_LIMIT = 200000
 
   def validate_each(record, attribute, value)
-    return error_message(record, attribute, cant_be_blank_message) if check_presence? && value.blank?
+    return error_message(record, attribute, blank_minimum_salary_message) if check_presence? && value.blank?
     return error_message(record, attribute, invalid_format_message) if value[SALARY_FORMAT].nil?
 
     salary = converted_salary(value)
     return error_message(record, attribute, must_be_higher_than_min_allowed_message) if less_than_min_allowed?(salary)
-    return error_message(record, attribute, must_be_less_than_max_salary_message) if salary > MAX_SALARY_ALLOWED
+    return error_message(record, attribute, must_be_less_than_max_salary_message(attribute)) \
+      if salary >= MAX_SALARY_LIMIT
   end
 
   private
@@ -32,13 +33,19 @@ class SalaryValidator < ActiveModel::EachValidator
     BigDecimal(value)
   end
 
+  def blank_minimum_salary_message
+    I18n.t('activemodel.errors.models.job_specification_form.attributes.minimum_salary.blank')
+  end
+
   def invalid_format_message
     I18n.t('errors.messages.salary.invalid_format')
   end
 
-  def must_be_less_than_max_salary_message
-    I18n.t('errors.messages.less_than_or_equal_to',
-           count: number_to_currency(MAX_SALARY_ALLOWED, delimiter: ''))
+  def must_be_less_than_max_salary_message(field_name)
+    I18n.t('activemodel.errors.models.job_specification_form.attributes.salary.more_than_maxiumum',
+           salary: Vacancy.human_attribute_name(field_name),
+           count: number_to_currency(MAX_SALARY_LIMIT, delimiter: ',')
+          )
   end
 
   def must_be_higher_than_min_allowed_message

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -1,5 +1,20 @@
 en:
+  vacancy_errors: &vacancy_errors_labels
+    job_title:
+      blank: Enter a job title
+      too_short: Job title must be at least %{count} characters
+      too_long: Job title must not be more than %{count} characters
+    job_description:
+      blank: Enter a job description
+      too_short: Job description must be at least %{count} characters
+      too_long: Job description must be at least %{count} characters
+    minimum_salary:
+      blank: Enter a minimum salary
+    working_patterns:
+      blank: Select a working pattern
   errors:
+    number:
+    # format: "%{message}"
     title: "Please correct the following %{errors} in your listing:"
     messages:
       too_short:
@@ -15,6 +30,14 @@ en:
       year_invalid: must include a 4-digit year
       email:
         invalid: is not a valid email address
+  activemodel:
+    errors:
+      models:
+        job_specification_form:
+          attributes:
+            <<: *vacancy_errors_labels
+            salary:
+              more_than_maxiumum: "%{salary} must be less than %{count}"
   activerecord:
     attributes:
       vacancy/expiry_time: Application deadline (time)
@@ -25,18 +48,9 @@ en:
       models:
         vacancy:
           attributes:
-            job_title:
-              blank: can't be blank
-            job_description:
-              blank: can't be blank
-            minimum_salary:
-              blank: can't be blank
+            <<: *vacancy_errors_labels
             maximum_salary:
-              greater_than_minimum_salary: must be higher than the minimum salary
-            working_pattern:
-              present: must be blank
-            working_patterns:
-              blank: can't be blank
+              greater_than_minimum_salary: Maximum salary must be more than the minimum salary
             experience:
               blank: can't be blank
             education:
@@ -56,11 +70,11 @@ en:
               blank: can't be blank
               before_today: can't be before today
             starts_on:
-              past: can't be in the past
-              after_ends_on: can't be after the end date
+              past: Start date must be in the future
+              after_ends_on: Start date must be before end date
               before_expires_on: must be after the closing date
             ends_on:
-              past: can't be in the past
+              past: End date must be in the future
               before_expires_on: must be after the closing date
             weekly_hours:
               negative: can't be negative

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     expiry_time { expires_on&.change(sec: 0) }
     publish_on { Time.zone.today }
     minimum_salary { SalaryValidator::MIN_SALARY_ALLOWED }
-    maximum_salary { SalaryValidator::MAX_SALARY_ALLOWED }
+    maximum_salary { SalaryValidator::MAX_SALARY_LIMIT - 100 }
     contact_email { Faker::Internet.email }
     application_link { Faker::Internet.url }
     benefits { Faker::Lorem.sentence }
@@ -40,17 +40,17 @@ FactoryBot.define do
       experience { Faker::Lorem.characters(1010) }
       education { Faker::Lorem.characters(1005) }
       qualifications { Faker::Lorem.characters(1002) }
-      minimum_salary { (SalaryValidator::MAX_SALARY_ALLOWED + 100) }
-      maximum_salary { SalaryValidator::MAX_SALARY_ALLOWED + 100 }
+      minimum_salary { (SalaryValidator::MAX_SALARY_LIMIT + 100) }
+      maximum_salary { SalaryValidator::MAX_SALARY_LIMIT + 100 }
     end
 
     trait :fail_minimum_salary_max_validation do
-      minimum_salary { SalaryValidator::MAX_SALARY_ALLOWED + 100 }
+      minimum_salary { SalaryValidator::MAX_SALARY_LIMIT + 100 }
     end
 
     trait :fail_maximum_salary_max_validation do
       minimum_salary { SalaryValidator::MIN_SALARY_ALLOWED }
-      maximum_salary { SalaryValidator::MAX_SALARY_ALLOWED + 100 }
+      maximum_salary { SalaryValidator::MAX_SALARY_LIMIT + 100 }
     end
 
     trait :complete do

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -177,7 +177,7 @@ RSpec.feature 'Copying a vacancy' do
       let(:new_attributes) { { job_title: nil } }
 
       it 'shows an error' do
-        expect(page).to have_content("Job title can't be blank")
+        expect(page).to have_content('Enter a job title')
       end
     end
   end

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         fill_in 'job_specification_form[job_title]', with: ''
         click_on 'Update job'
 
-        expect(page).to have_content('Job title can\'t be blank')
+        expect(page).to have_content('Enter a job title')
       end
 
       scenario 'can be successfully edited' do

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -355,7 +355,7 @@ RSpec.feature 'Creating a vacancy' do
           fill_in 'job_specification_form[job_title]', with: ''
           click_on 'Save and continue'
 
-          expect(page).to have_content('Job title can\'t be blank')
+          expect(page).to have_content('Enter a job title')
 
           fill_in 'job_specification_form[job_title]', with: 'A new job title'
           click_on 'Save and continue'

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -4,10 +4,99 @@ RSpec.describe JobSpecificationForm, type: :model do
   subject { JobSpecificationForm.new({}) }
 
   context 'validations' do
-    it { should validate_presence_of(:job_title) }
-    it { should validate_presence_of(:job_description) }
-    it { should validate_presence_of(:working_patterns) }
-    it { should validate_presence_of(:minimum_salary) }
+    describe '#working_patterns' do
+      let(:job_specification) { JobSpecificationForm.new(working_patterns: nil) }
+
+      it 'requests an entry in the field' do
+        expect(job_specification.valid?).to be false
+        expect(job_specification.errors.messages[:working_patterns][0])
+          .to eq('Select a working pattern')
+      end
+    end
+
+    describe '#job_title' do
+      let(:job_specification) { JobSpecificationForm.new(job_title: job_title) }
+
+      context 'when title is blank' do
+        let(:job_title) { nil }
+
+        it 'requests an entry in the field' do
+          expect(job_specification.valid?).to be false
+          expect(job_specification.errors.messages[:job_title][0])
+            .to eq('Enter a job title')
+        end
+      end
+
+      context 'when title is too short' do
+        let(:job_title) { 'aa' }
+
+        it 'validates minimum length' do
+          expect(job_specification.valid?).to be false
+          expect(job_specification.errors.messages[:job_title][0])
+            .to eq(I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.too_short', count: 4))
+        end
+      end
+
+      context 'when title is too long' do
+        let(:job_title) { 'Long title' * 100 }
+
+        it 'validates max length' do
+          expect(job_specification.valid?).to be false
+          expect(job_specification.errors.messages[:job_title][0])
+            .to eq(I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.too_long', count: 100))
+        end
+      end
+    end
+
+    describe '#job_description' do
+      let(:job_specification) { JobSpecificationForm.new(job_description: job_description) }
+
+      context 'when description is blank' do
+        let(:job_description) { nil }
+
+        it 'requests an entry in the field' do
+          expect(job_specification.valid?).to be false
+          expect(job_specification.errors.messages[:job_description][0])
+            .to eq('Enter a job description')
+        end
+      end
+
+      context 'when description is too short' do
+        let(:job_description) { 'short' }
+
+        it 'validates minimum length' do
+          expect(job_specification.valid?).to be false
+          expect(job_specification.errors.messages[:job_description][0])
+            .to eq(
+              I18n.t('activemodel.errors.models.job_specification_form.attributes.job_description.too_short',
+                count: 10)
+              )
+        end
+      end
+
+      context 'when description is too long' do
+        let(:job_description) { 'Long text' * 10000 }
+
+        it 'validates max length' do
+          expect(job_specification.valid?).to be false
+          expect(job_specification.errors.messages[:job_description][0])
+            .to eq(
+              I18n.t('activemodel.errors.models.job_specification_form.attributes.job_description.too_long',
+                count: 50000)
+              )
+        end
+      end
+    end
+
+    describe '#minimum_salary' do
+      let(:job_specification) { JobSpecificationForm.new(minimum_salary: nil) }
+
+      it 'requests an entry in the field' do
+        expect(job_specification.valid?).to be false
+        expect(job_specification.errors.messages[:minimum_salary][0])
+          .to eq('Enter a minimum salary')
+      end
+    end
 
     describe '#maximum_salary' do
       let(:job_specification) do
@@ -19,7 +108,7 @@ RSpec.describe JobSpecificationForm, type: :model do
       it 'the maximum salary should be higher than the minimum salary' do
         expect(job_specification.valid?).to be false
         expect(job_specification.errors.messages[:maximum_salary][0])
-          .to eq('must be higher than the minimum salary')
+          .to eq('Maximum salary must be more than the minimum salary')
       end
     end
   end
@@ -38,7 +127,7 @@ RSpec.describe JobSpecificationForm, type: :model do
 
       expect(job_specification_form).to have(1).errors_on(:starts_on)
       expect(job_specification_form.errors.messages[:starts_on][0])
-        .to eq('can\'t be in the past')
+        .to eq('Start date must be in the future')
     end
 
     it 'must be before the ends_on date' do
@@ -48,7 +137,7 @@ RSpec.describe JobSpecificationForm, type: :model do
 
       expect(job_specification_form).to have(1).errors_on(:starts_on)
       expect(job_specification_form.errors.messages[:starts_on][0])
-        .to eq('can\'t be after the end date')
+        .to eq('Start date must be before end date')
     end
 
     it 'must be after the closing date' do
@@ -76,7 +165,7 @@ RSpec.describe JobSpecificationForm, type: :model do
 
       expect(job_specification_form).to have(1).errors_on(:ends_on)
       expect(job_specification_form.errors.messages[:ends_on][0])
-        .to eq('can\'t be in the past')
+        .to eq('End date must be in the future')
     end
 
     it 'must be after the closing date' do

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -51,12 +51,12 @@ RSpec.describe Vacancy, type: :model do
 
       it '#job_title' do
         expect(subject.errors.messages[:job_title].first)
-          .to eq(I18n.t('errors.messages.too_short.other', count: 4))
+          .to eq(I18n.t('activerecord.errors.models.vacancy.attributes.job_title.too_short', count: 4))
       end
 
       it '#job_description' do
         expect(subject.errors.messages[:job_description].first)
-          .to eq(I18n.t('errors.messages.too_short.other', count: 10))
+          .to eq(I18n.t('activerecord.errors.models.vacancy.attributes.job_description.too_short', count: 10))
       end
     end
 
@@ -68,7 +68,7 @@ RSpec.describe Vacancy, type: :model do
 
       it '#job_title' do
         expect(subject.errors.messages[:job_title].first)
-          .to eq(I18n.t('errors.messages.too_long.other', count: 100))
+          .to eq(I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.too_long', count: 100))
       end
     end
 
@@ -80,7 +80,8 @@ RSpec.describe Vacancy, type: :model do
 
       it '#job_description' do
         expect(subject.errors.messages[:job_description].first)
-          .to eq(I18n.t('errors.messages.too_long.other', count: 50_000))
+          .to eq(I18n.t('activemodel.errors.models.job_specification_form.attributes.job_description.too_long',
+            count: 50000))
       end
 
       it '#experience' do
@@ -112,7 +113,7 @@ RSpec.describe Vacancy, type: :model do
         job = build(:vacancy, minimum_salary: nil, maximum_salary: nil)
 
         expect(job.valid?).to be false
-        expect(job.errors.messages[:minimum_salary]).to eq(['can\'t be blank'])
+        expect(job.errors.messages[:minimum_salary]).to eq(['Enter a minimum salary'])
         expect(job.errors.messages[:maximum_salary]).to be_empty
       end
 
@@ -120,7 +121,7 @@ RSpec.describe Vacancy, type: :model do
         job = build(:vacancy, minimum_salary: nil, maximum_salary: 'not a number')
 
         expect(job.valid?).to be false
-        expect(job.errors.messages[:minimum_salary]).to eq(['can\'t be blank'])
+        expect(job.errors.messages[:minimum_salary]).to eq(['Enter a minimum salary'])
         expect(job.errors.messages[:maximum_salary]).to be_empty
       end
 
@@ -166,7 +167,7 @@ RSpec.describe Vacancy, type: :model do
         expect(job).to_not be_valid
         expect(job.errors.messages[:minimum_salary]).to be_empty
         expect(job.errors.messages[:maximum_salary])
-          .to eq(['must not be more than £200000'])
+          .to eq(['Maximum salary must be less than £200,000'])
       end
 
       it 'greater than allowed minimum_salary and greater than allowed maximum_salary' do
@@ -174,7 +175,7 @@ RSpec.describe Vacancy, type: :model do
 
         expect(job).to_not be_valid
         expect(job.errors.messages[:minimum_salary])
-          .to eq(['must not be more than £200000'])
+          .to eq(['Minimum salary must be less than £200,000'])
         expect(job.errors.messages[:maximum_salary]).to be_empty
       end
 
@@ -183,7 +184,7 @@ RSpec.describe Vacancy, type: :model do
 
         expect(job).to_not be_valid
         expect(job.errors.messages[:minimum_salary])
-          .to eq(['must not be more than £200000'])
+          .to eq(['Minimum salary must be less than £200,000'])
         expect(job.errors.messages[:maximum_salary]).to be_empty
       end
 
@@ -254,7 +255,7 @@ RSpec.describe Vacancy, type: :model do
         vacancy = build(:vacancy, minimum_salary: 20, maximum_salary: 10)
 
         expect(vacancy.valid?).to be false
-        expect(vacancy.errors.messages[:maximum_salary]).to eq(['must be higher than the minimum salary'])
+        expect(vacancy.errors.messages[:maximum_salary]).to eq(['Maximum salary must be more than the minimum salary'])
       end
     end
 

--- a/spec/validators/salary_validator_spec.rb
+++ b/spec/validators/salary_validator_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SalaryValidator do
         model.amount = '200000000000000'
 
         expect(model).to_not be_valid
-        expect(model.errors.messages[:amount]).to eq(['must not be more than £200000'])
+        expect(model.errors.messages[:amount]).to eq(['Amount must be less than £200,000'])
       end
     end
 


### PR DESCRIPTION
This introduces the desired changes for the errors on the job specification form. See the list of job specification changes [here](https://docs.google.com/spreadsheets/d/1-MeFAToarUINg-8Sif4K0ZTPudowE6FU_mf3Hhf_iOk/edit#gid=0&range=37:37).

Since a lot of the errors across the site are currently being rewritten to not use the field name, the current idea is to later add `format: "{message}"` to the `activerecord.yml` so that we wouldn't have to add a lot of logic to the HAML files to separate the errors from the attribute names (as suggested by @C-gyorfi ).

### UI Screenshots 

_(Please note that these still have their attribute names. These will be removed when all the error content changes are ready to be merged into develop, for now, this PR would be merged into a feature branch)_

![Screenshot 2019-11-06 at 17 06 40](https://user-images.githubusercontent.com/32823756/68320946-c22e0600-00b8-11ea-8296-684fdea92260.png)
![Screenshot 2019-11-06 at 17 09 07](https://user-images.githubusercontent.com/32823756/68320947-c22e0600-00b8-11ea-8799-0eb06f555adb.png)
![Screenshot 2019-11-06 at 17 09 29](https://user-images.githubusercontent.com/32823756/68320948-c22e0600-00b8-11ea-8a0f-466ec3c67c6b.png)
![Screenshot 2019-11-06 at 17 09 56](https://user-images.githubusercontent.com/32823756/68320949-c22e0600-00b8-11ea-982b-4b7049080396.png)


### Next Steps
- [ ] Change the global formatting to use `format: "{message}"` (Separate PR)

**Any feedback would be appreciated**