### PR TITLE
Fix error messages on copy vacancy form

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -121,7 +121,8 @@ class Vacancy < ApplicationRecord
   delegate :name, to: :school, prefix: true, allow_nil: false
   delegate :geolocation, to: :school, prefix: true, allow_nil: true
 
-  acts_as_gov_uk_date :starts_on, :ends_on, :publish_on, :expires_on
+  acts_as_gov_uk_date :starts_on, :ends_on, :publish_on,
+                      :expires_on, error_clash_behaviour: :omit_gov_uk_date_field_error
 
   scope :applicable, (-> { applicable_by_date.or(applicable_by_time) })
   scope :applicable_by_time, (-> { where('expiry_time IS NOT NULL AND expiry_time >= ?', Time.zone.now) })

--- a/app/validators/date_format_validator.rb
+++ b/app/validators/date_format_validator.rb
@@ -1,12 +1,30 @@
 class DateFormatValidator < ActiveModel::Validator
   def validate(record)
     options[:fields].each do |field|
-      date = record.send(field)
-      next if date.blank?
-
-      match = date.strftime('%Y-%m-%d').match(/^(?<y>\d*)\-/)
-
-      record.errors.add(field, I18n.t('errors.messages.year_invalid')) if match[:y].length > 4
+      validate_date_fields(field, record)
     end
+  end
+
+  private
+
+  def validate_date_fields(field, record)
+    day = record.send(field.to_s + '_dd')
+    month = record.send(field.to_s + '_mm')
+    year = record.send(field.to_s + '_yyyy')
+    return if day.blank? || month.blank? || year.blank?
+    begin
+      Date.parse("#{day}-#{month}-#{year}")
+    rescue
+      record.errors.add(field, invalid_field_error(field))
+    end
+    record.errors.add(field, invalid_year_error(field)) if year.length > 4
+  end
+
+  def invalid_field_error(field)
+    I18n.t("activerecord.errors.models.vacancy.attributes.#{field}.invalid")
+  end
+
+  def invalid_year_error(field)
+    I18n.t("activerecord.errors.models.vacancy.attributes.#{field}.invalid_year")
   end
 end

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -60,22 +60,30 @@ en:
             contact_email:
               blank: can't be blank
             expires_on:
-              blank: can't be blank
-              before_publish_date: can't be before the publish date
+              blank: Enter the date the application is due
+              before_publish_date: Application cannot be due before the job has been listed
+              invalid: Enter an application due date in the correct format
+              invalid_year: Expires on on must include a 4-digit year
             expiry_time:
               blank: Enter the time the application is due
               wrong_format: Enter the time the application is due in the correct format
               must_be_am_pm: Enter am or pm
             publish_on:
-              blank: can't be blank
-              before_today: can't be before today
+              blank: Enter the date the role will be listed
+              before_today: Date role will be listed must be either today or a date in the future
+              invalid: Enter the date the role will be listed in the correct format
+              invalid_year: Publish on must include a 4-digit year
             starts_on:
               past: Start date must be in the future
               after_ends_on: Start date must be before end date
-              before_expires_on: must be after the closing date
+              before_expires_on: Start date must be after application deadline
+              invalid: Enter the start date in the correct format
+              invalid_year: Starts on must include a 4-digit year
             ends_on:
               past: End date must be in the future
-              before_expires_on: must be after the closing date
+              before_expires_on: End date must be after application deadline
+              invalid: Enter the end date in the correct format
+              invalid_year: Ends on must include a 4-digit year
             weekly_hours:
               negative: can't be negative
               invalid: must be a valid number

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -123,7 +123,7 @@ RSpec.feature 'Copying a vacancy' do
         click_on I18n.t('buttons.save_and_continue')
       end
 
-      expect(page).to have_content('Expires on Invalid date')
+      expect(page).to have_content('Enter an application due date in the correct format')
     end
   end
 
@@ -153,7 +153,7 @@ RSpec.feature 'Copying a vacancy' do
       let(:new_attributes) { { publish_on: nil } }
 
       it 'shows an error' do
-        expect(page).to have_content("Publish on can't be blank")
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.blank'))
       end
     end
 
@@ -161,7 +161,7 @@ RSpec.feature 'Copying a vacancy' do
       let(:new_attributes) { { publish_on: 1.day.ago } }
 
       it 'shows an error' do
-        expect(page).to have_content("Publish on can't be before today")
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.before_today'))
       end
     end
 
@@ -169,7 +169,7 @@ RSpec.feature 'Copying a vacancy' do
       let(:new_attributes) { { expires_on: nil } }
 
       it 'shows an error' do
-        expect(page).to have_content("Expires on can't be blank")
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.blank'))
       end
     end
 
@@ -177,7 +177,7 @@ RSpec.feature 'Copying a vacancy' do
       let(:new_attributes) { { job_title: nil } }
 
       it 'shows an error' do
-        expect(page).to have_content('Enter a job title')
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.job_title.blank'))
       end
     end
   end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Creating a vacancy' do
         end
 
         within_row_for(text: I18n.t('jobs.job_title')) do
-          expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.job_title.blank'))
+          expect(page).to have_content((I18n.t('activerecord.errors.models.vacancy.attributes.job_title.blank')))
         end
 
         within_row_for(text: I18n.t('jobs.description')) do
@@ -152,7 +152,7 @@ RSpec.feature 'Creating a vacancy' do
         end
 
         within_row_for(element: 'legend', text: I18n.t('jobs.deadline_date')) do
-          expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.blank'))
+          expect(page).to have_content(I18n.t('errors.messages.blank'))
         end
 
         within_row_for(element: 'legend', text: strip_tags(I18n.t('jobs.deadline_time_html'))) do
@@ -160,7 +160,7 @@ RSpec.feature 'Creating a vacancy' do
         end
 
         within_row_for(element: 'legend', text: I18n.t('jobs.publication_date')) do
-          expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.blank'))
+          expect(page).to have_content(I18n.t('errors.messages.blank'))
         end
       end
 

--- a/spec/form_models/application_details_form_spec.rb
+++ b/spec/form_models/application_details_form_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe ApplicationDetailsForm, type: :model do
       it 'the expiry date must be greater than the publish date' do
         expect(application_details.valid?).to be false
         expect(application_details.errors.messages[:expires_on][0])
-          .to eq('can\'t be before the publish date')
+        .to eq(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.before_publish_date'))
       end
     end
 
@@ -140,7 +140,7 @@ RSpec.describe ApplicationDetailsForm, type: :model do
       it 'the publish date must be present' do
         expect(application_details.valid?).to be false
         expect(application_details.errors.messages[:publish_on][0])
-          .to eq('can\'t be before today')
+          .to eq(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.before_today'))
       end
     end
   end

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe JobSpecificationForm, type: :model do
 
       expect(job_specification_form).to have(1).errors_on(:starts_on)
       expect(job_specification_form.errors.messages[:starts_on][0])
-        .to eq('must be after the closing date')
+        .to eq('Start date must be after application deadline')
     end
   end
 
@@ -175,7 +175,7 @@ RSpec.describe JobSpecificationForm, type: :model do
 
       expect(job_specification_form).to have(1).errors_on(:ends_on)
       expect(job_specification_form.errors.messages[:ends_on][0])
-        .to eq('must be after the closing date')
+        .to eq('End date must be after application deadline')
     end
   end
 

--- a/spec/validators/date_format_validator_spec.rb
+++ b/spec/validators/date_format_validator_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe DateFormatValidator do
 
       it 'shows an invalid year error' do
         vacancy.valid?
-        expect(vacancy.errors[:starts_on]).to include(I18n.t('errors.messages.year_invalid'))
+        expect(vacancy.errors[:starts_on])
+        .to include(I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.invalid_year'))
       end
     end
 
@@ -24,7 +25,8 @@ RSpec.describe DateFormatValidator do
 
       it 'shows an invalid year error' do
         vacancy.valid?
-        expect(vacancy.errors[:ends_on]).to include(I18n.t('errors.messages.year_invalid'))
+        expect(vacancy.errors[:ends_on])
+        .to include(I18n.t('activerecord.errors.models.vacancy.attributes.ends_on.invalid_year'))
       end
     end
 
@@ -33,7 +35,8 @@ RSpec.describe DateFormatValidator do
 
       it 'shows an invalid year error' do
         vacancy.valid?
-        expect(vacancy.errors[:publish_on]).to include(I18n.t('errors.messages.year_invalid'))
+        expect(vacancy.errors[:publish_on])
+        .to include(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.invalid_year'))
       end
     end
 
@@ -42,7 +45,60 @@ RSpec.describe DateFormatValidator do
 
       it 'shows an invalid year error' do
         vacancy.valid?
-        expect(vacancy.errors[:expires_on]).to include(I18n.t('errors.messages.year_invalid'))
+        expect(vacancy.errors[:expires_on])
+        .to include(
+          I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.invalid_year'))
+      end
+    end
+  end
+
+  describe '#validate_date_fields(fields, record)' do
+    context 'a record with blank fields' do
+      let(:vacancies_with_missing_field) do
+        [
+          FactoryBot.build(:vacancy, publish_on_dd: ''),
+          FactoryBot.build(:vacancy, publish_on_mm: ''),
+          FactoryBot.build(:vacancy, publish_on_yyyy: ''),
+        ]
+      end
+      let(:vacancy) { vacancies_with_missing_field.sample }
+
+      it 'does not evaluate format when there are blank fields' do
+        vacancy.valid?
+        expect(vacancy.errors[:publish_on])
+        .not_to include('Enter the date the role will be listed in the correct format')
+      end
+    end
+
+    context 'a record with incorrect day' do
+      let(:vacancy) { FactoryBot.build(:vacancy, expires_on_dd: '66') }
+
+      it 'shows an invalid date error' do
+        vacancy.valid?
+        expect(vacancy.errors[:expires_on])
+          .to include(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.invalid'))
+      end
+    end
+
+    context 'a record with incorrect month' do
+      let(:vacancy) { FactoryBot.build(:vacancy, expires_on_mm: '66') }
+
+      it 'shows an invalid date error' do
+        vacancy.valid?
+
+        expect(vacancy.errors[:expires_on])
+          .to include(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.invalid'))
+      end
+    end
+
+    context 'a record with an impossible date' do
+      let(:vacancy) { FactoryBot.build(:vacancy, publish_on_dd: '31', publish_on_mm: '02', publish_on_yyyy: '2020') }
+
+      it 'shows an invalid date error' do
+        vacancy.valid?
+
+        expect(vacancy.errors[:publish_on])
+          .to include(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.invalid'))
       end
     end
   end


### PR DESCRIPTION
## Jira ticket URL:
https://dfedigital.atlassian.net/secure/RapidBoard.jspa?rapidView=21&modal=detail&selectedIssue=TEVA-268

## Changes in this PR:
- move date format validations out from the gov_uk_date_fields gem (it used it's on date validator method with hard coded strings, in the future, we would like to use more descriptive error messages)
- Switched off gov_uk_date_field_errors when using gov_uk_date_fields gem
- update localisation file with the new error messages
- update tests accordingly
- Update the translation path for blank errors in failing tests

## Screenshots of UI changes:
### After
![image](https://user-images.githubusercontent.com/22743709/68124239-c7e3ea00-ff06-11e9-9d54-670d5d2c8d61.png)

## Next steps:
- [ ] update error formatting in activerecords.yml using ` format: "%{message}"`
