### PR TITLE
Implement approvers endpoint for DfE Sign in

### DIFF
--- a/lib/dfe_sign_in_api.rb
+++ b/lib/dfe_sign_in_api.rb
@@ -1,6 +1,7 @@
 module DFESignIn
   class ExternalServerError < StandardError; end
   class ForbiddenRequestError < StandardError; end
+  class UnknownResponseError < StandardError; end
 
   class API
     def users(page: 1)
@@ -12,8 +13,9 @@ module DFESignIn
 
       raise ExternalServerError if response.code.eql?(500)
       raise ForbiddenRequestError if response.code.eql?(403)
+      raise UnknownResponseError unless response.code.eql?(200)
 
-      JSON.parse(response&.body) if response.code.eql?(200)
+      JSON.parse(response.body)
     end
 
     private

--- a/lib/dfe_sign_in_api.rb
+++ b/lib/dfe_sign_in_api.rb
@@ -5,9 +5,19 @@ module DFESignIn
 
   class API
     def users(page: 1)
+      perform_request('/users', page)
+    end
+
+    def approvers(page: 1)
+      perform_request('/users/approvers', page)
+    end
+
+    private
+
+    def perform_request(endpoint, page)
       token = generate_jwt_token
       response = HTTParty.get(
-        api_url(page),
+        "#{DFE_SIGN_IN_URL}#{endpoint}?page=#{page}&pageSize=25",
         headers: { 'Authorization' => "Bearer #{token}" }
       )
 
@@ -16,12 +26,6 @@ module DFESignIn
       raise UnknownResponseError unless response.code.eql?(200)
 
       JSON.parse(response.body)
-    end
-
-    private
-
-    def api_url(page = 1)
-      "#{DFE_SIGN_IN_URL}/users?page=#{page}&pageSize=25"
     end
 
     def generate_jwt_token

--- a/spec/fixtures/dfe_sign_in_service_approvers_response_page_1.json
+++ b/spec/fixtures/dfe_sign_in_service_approvers_response_page_1.json
@@ -1,0 +1,37 @@
+{
+  "users": [
+      {
+          "organisation": {
+              "id": "13F20E54-79EA-4146-8E39-18197576F023",
+              "name": "Department for Education",
+              "Category": "002",
+              "Type": null,
+              "URN": null,
+              "UID": null,
+              "UKPRN": null,
+              "EstablishmentNumber": "001",
+              "Status": 1,
+              "ClosedOn": null,
+              "Address": null,
+              "phaseOfEducation": null,
+              "statutoryLowAge": null,
+              "statutoryHighAge": null,
+              "telephone": null,
+              "regionCode": null,
+              "legacyId": "1031237",
+              "companyRegistrationNumber": "1234567",
+              "createdAt": "2019-02-20T14:27:59.020Z",
+              "updatedAt": "2019-02-20T14:28:38.223Z"
+          },
+          "roleName": "Approver",
+          "roleId": 10000,
+          "userId": "21D62132-6570-4E63-9DCB-137CC35E7543",
+          "email": "foo@example.com",
+          "familyName": "Johnson",
+          "givenName": "Roger"
+      }
+  ],
+  "numberOfRecords": 1,
+  "page": 1,
+  "numberOfPages": 1
+}

--- a/spec/fixtures/dfe_sign_in_service_approvers_response_page_2.json
+++ b/spec/fixtures/dfe_sign_in_service_approvers_response_page_2.json
@@ -1,0 +1,35 @@
+{
+  "users": [{
+    "organisation": {
+      "id": "13F20E54-79EA-4146-8E39-18197576F024",
+      "name": "Department for Education",
+      "Category": "002",
+      "Type": null,
+      "URN": null,
+      "UID": null,
+      "UKPRN": null,
+      "EstablishmentNumber": "001",
+      "Status": 1,
+      "ClosedOn": null,
+      "Address": null,
+      "phaseOfEducation": null,
+      "statutoryLowAge": null,
+      "statutoryHighAge": null,
+      "telephone": null,
+      "regionCode": null,
+      "legacyId": "1031237",
+      "companyRegistrationNumber": "1234567",
+      "createdAt": "2019-02-20T14:27:59.020Z",
+      "updatedAt": "2019-02-20T14:28:38.223Z"
+    },
+    "roleName": "Approver",
+    "roleId": 10000,
+    "userId": "BBB-222",
+    "email": "foo@example.com",
+    "familyName": "Johnson",
+    "givenName": "Roger"
+  }],
+  "numberOfRecords": 1,
+  "page": 2,
+  "numberOfPages": 2
+}

--- a/spec/lib/dfe_sign_in_api_spec.rb
+++ b/spec/lib/dfe_sign_in_api_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe DFESignIn::API do
       end
     end
 
+    context 'when the response status is unknown' do
+      before do
+        stub_request(:get,
+          "#{DFE_SIGN_IN_URL}/users?page=1&pageSize=25")
+          .to_return(body: '', status: 499)
+      end
+      it 'raises an unknown response error' do
+        expect { described_class.new.users }.to raise_error(DFESignIn::UnknownResponseError)
+      end
+    end
+
     def response_file(page)
       File.read(Rails.root.join(
                   'spec',

--- a/spec/lib/dfe_sign_in_api_spec.rb
+++ b/spec/lib/dfe_sign_in_api_spec.rb
@@ -1,102 +1,116 @@
 require 'rails_helper'
 require 'dfe_sign_in_api'
 
+RSpec.shared_examples 'a DFE Sign In endpoint' do
+  context 'when the external response status is 500' do
+    before { stub_api_response_with_external_error(1) }
+
+    it 'raises an external server error' do
+      expect { subject.call }.to raise_error(DFESignIn::ExternalServerError)
+    end
+  end
+
+  context 'when the response status is 403' do
+    before { stub_api_response_with_forbidden_error(1) }
+
+    it 'raises an forbidden request error' do
+      expect { subject.call }.to raise_error(DFESignIn::ForbiddenRequestError)
+    end
+  end
+
+  context 'when the response status is unknown' do
+    before do
+      stub_request(:get,
+        "#{DFE_SIGN_IN_URL}#{api_path}?page=1&pageSize=25")
+        .to_return(body: '', status: 499)
+    end
+    it 'raises an unknown response error' do
+      expect { subject.call }.to raise_error(DFESignIn::UnknownResponseError)
+    end
+  end
+
+  context 'when the response code is 200' do
+    it 'returns the users from the API' do
+      stub_api_response_for_page(1)
+      response = subject.call
+
+      expect(response).to eq(JSON.parse(response_file(1)))
+    end
+
+    it 'returns the approvers from the API for a given page ' do
+      stub_api_response_for_page(2)
+      response = subject.call(page: 2)
+
+      expect(response).to eq(JSON.parse(response_file(2)))
+      expect(response['page']).to eq(2)
+      expect(response['numberOfPages']).to eq(2)
+    end
+
+    it 'sets a token in the header of the request' do
+      Timecop.freeze(Time.zone.now) do
+        expected_token = generate_jwt_token
+
+        stub_api_response_for_page(1)
+        subject.call
+
+        expect(a_request(:get, "#{DFE_SIGN_IN_URL}#{api_path}?page=1&pageSize=25")
+          .with(headers: { 'Authorization' => "Bearer #{expected_token}" }))
+          .to have_been_made
+      end
+    end
+  end
+
+  def response_file(page)
+    File.read(Rails.root.join(
+                'spec',
+                'fixtures',
+                "dfe_sign_in_service_#{fixture_filename}_response_page_#{page}.json"
+              ))
+  end
+
+  def stub_api_response_for_page(page)
+    stub_request(:get,
+                 "#{DFE_SIGN_IN_URL}#{api_path}?page=#{page}&pageSize=25")
+      .to_return(body: response_file(page), status: 200)
+  end
+
+  def stub_api_response_with_external_error(page)
+    stub_request(:get,
+                 "#{DFE_SIGN_IN_URL}#{api_path}?page=#{page}&pageSize=25")
+      .to_return(body: '', status: 500)
+  end
+
+  def stub_api_response_with_forbidden_error(page)
+    stub_request(:get,
+                 "#{DFE_SIGN_IN_URL}#{api_path}?page=#{page}&pageSize=25")
+      .to_return(body: '{"success":false,"message":"jwt expired"}', status: 403)
+  end
+
+  def generate_jwt_token
+    payload = {
+      iss: 'schooljobs',
+      exp: (Time.now.getlocal + 60).to_i,
+      aud: 'signin.education.gov.uk'
+    }
+
+    JWT.encode(payload, DFE_SIGN_IN_PASSWORD, 'HS256')
+  end
+end
+
 RSpec.describe DFESignIn::API do
   describe '#users' do
-    context 'when the response code is 200' do
-      it 'returns the users from the API' do
-        stub_api_response_for_page(1)
-        response = described_class.new.users
+    let(:api_path) { '/users' }
+    let(:fixture_filename) { 'users' }
+    subject { described_class.new.method(:users) }
 
-        expect(response).to eq(JSON.parse(response_file(1)))
-        expect(response['page']).to eq(1)
-        expect(response['numberOfPages']).to eq(2)
-      end
+    it_behaves_like 'a DFE Sign In endpoint'
+  end
 
-      it 'returns the users from the API for a given page ' do
-        stub_api_response_for_page(2)
-        response = described_class.new.users(page: 2)
+  describe '#approvers' do
+    let(:api_path) { '/users/approvers' }
+    let(:fixture_filename) { 'approvers' }
+    subject { described_class.new.method(:approvers) }
 
-        expect(response).to eq(JSON.parse(response_file(2)))
-        expect(response['page']).to eq(2)
-        expect(response['numberOfPages']).to eq(2)
-      end
-
-      it 'sets a token in the header of the request' do
-        Timecop.freeze(Time.zone.now) do
-          expected_token = generate_jwt_token
-
-          stub_api_response_for_page(2)
-          described_class.new.users(page: 2)
-
-          expect(a_request(:get, "#{DFE_SIGN_IN_URL}/users?page=2&pageSize=25")
-            .with(headers: { 'Authorization' => "Bearer #{expected_token}" }))
-            .to have_been_made
-        end
-      end
-    end
-
-    context 'when the external response status is 500' do
-      before { stub_api_response_with_external_error(1) }
-
-      it 'raises an external server error' do
-        expect { described_class.new.users }.to raise_error(DFESignIn::ExternalServerError)
-      end
-    end
-
-    context 'when the response status is 403' do
-      before { stub_api_response_with_forbidden_error(1) }
-
-      it 'raises an forbidden request error' do
-        expect { described_class.new.users }.to raise_error(DFESignIn::ForbiddenRequestError)
-      end
-    end
-
-    context 'when the response status is unknown' do
-      before do
-        stub_request(:get,
-          "#{DFE_SIGN_IN_URL}/users?page=1&pageSize=25")
-          .to_return(body: '', status: 499)
-      end
-      it 'raises an unknown response error' do
-        expect { described_class.new.users }.to raise_error(DFESignIn::UnknownResponseError)
-      end
-    end
-
-    def response_file(page)
-      File.read(Rails.root.join(
-                  'spec',
-                  'fixtures',
-                  "dfe_sign_in_service_users_response_page_#{page}.json"
-                ))
-    end
-
-    def stub_api_response_for_page(page)
-      stub_request(:get,
-                   "#{DFE_SIGN_IN_URL}/users?page=#{page}&pageSize=25")
-        .to_return(body: response_file(page), status: 200)
-    end
-
-    def stub_api_response_with_external_error(page)
-      stub_request(:get,
-                   "#{DFE_SIGN_IN_URL}/users?page=#{page}&pageSize=25")
-        .to_return(body: '', status: 500)
-    end
-
-    def stub_api_response_with_forbidden_error(page)
-      stub_request(:get,
-                   "#{DFE_SIGN_IN_URL}/users?page=#{page}&pageSize=25")
-        .to_return(body: '{"success":false,"message":"jwt expired"}', status: 403)
-    end
-
-    def generate_jwt_token
-      payload = {
-        iss: 'schooljobs',
-        exp: (Time.now.getlocal + 60).to_i,
-        aud: 'signin.education.gov.uk'
-      }
-
-      JWT.encode(payload, DFE_SIGN_IN_PASSWORD, 'HS256')
-    end
+    it_behaves_like 'a DFE Sign In endpoint'
   end
 end


### PR DESCRIPTION
## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-275

## Changes in this PR:
We need to query the approvers endpoint to get a list of approvers for
the TVS service from DSI. We need to know who can approve access to TVS
without necessarily been invited themselves.

This data will be used for analysis in a number of ways, such as
reporting on the proportion of schools which have signed up.

This data will be pushed into the DSI User Google Sheet as part of
a different commit.
