### PR TITLE
Edit error content for fields on the Candidate Specification form

### DIFF
--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -1,4 +1,7 @@
 en:
+  number:
+    format:
+      delimiter: ","
   vacancy_errors: &vacancy_errors_labels
     job_title:
       blank: Enter a job title
@@ -30,7 +33,6 @@ en:
       invalid: Enter the date the role will be listed in the correct format
       invalid_year: Publish on must include a 4-digit year
   errors:
-    number:
     # format: "%{message}"
     title: "Please correct the following %{errors} in your listing:"
     messages:
@@ -58,6 +60,17 @@ en:
         application_details_form:
           attributes:
             <<: *application_details_errors
+        candidate_specification_form:
+          attributes:
+            education:
+              blank: Enter essential educational requirements
+              too_long: Education must not be more than %{count} characters
+            experience:
+              blank: Enter essential skills and experience
+              too_long: Skills and experience must not be more than %{count} characters
+            qualifications:
+              blank: Enter essential qualifications
+              too_long: Qualifications must not be more than %{count} characters
   activerecord:
     attributes:
       vacancy/expiry_time: Application deadline (time)
@@ -73,11 +86,16 @@ en:
             maximum_salary:
               greater_than_minimum_salary: Maximum salary must be more than the minimum salary
             experience:
-              blank: can't be blank
+              blank: Enter essential skills and experience
             education:
-              blank: can't be blank
+              blank: Enter essential educational requirements
             qualifications:
+              blank: Enter essential qualifications
+            contact_email:
               blank: can't be blank
+            expires_on:
+              blank: can't be blank
+              before_publish_date: can't be before the publish date
             expiry_time:
               blank: Enter the time the application is due
               wrong_format: Enter the time the application is due in the correct format

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         click_on 'Update job'
 
         within_row_for(text: I18n.t('jobs.experience')) do
-          expect(page).to have_content('can\'t be blank')
+          expect(page).to have_content('Enter essential skills and experience')
         end
       end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -407,7 +407,7 @@ RSpec.feature 'Creating a vacancy' do
           fill_in 'candidate_specification_form[education]', with: ''
           click_on 'Save and continue'
 
-          expect(page).to have_content('Education can\'t be blank')
+          expect(page).to have_content('Enter essential educational requirements')
 
           fill_in 'candidate_specification_form[education]', with: 'essential requirements'
           click_on 'Save and continue'

--- a/spec/form_models/candidate_specification_form_spec.rb
+++ b/spec/form_models/candidate_specification_form_spec.rb
@@ -3,8 +3,76 @@ RSpec.describe CandidateSpecificationForm, type: :model do
   subject { CandidateSpecificationForm.new({}) }
 
   describe 'validations' do
-    it { should validate_presence_of(:education) }
-    it { should validate_presence_of(:qualifications) }
-    it { should validate_presence_of(:experience) }
+    describe '#education' do
+      let(:candidate_specification_form) { CandidateSpecificationForm.new(education: education) }
+
+      context 'when education is blank' do
+        let(:education) { nil }
+
+        it 'requests an entry in the field' do
+          expect(candidate_specification_form.valid?).to be false
+          expect(candidate_specification_form.errors.messages[:education][0])
+            .to eq('Enter essential educational requirements')
+        end
+      end
+
+      context 'when education text is too long' do
+        let(:education) { 'short' * 1000 }
+
+        it 'validates the maximum length' do
+          expect(candidate_specification_form.valid?).to be false
+          expect(candidate_specification_form.errors.messages[:education][0])
+            .to eq('Education must not be more than 1000 characters')
+        end
+      end
+    end
+
+    describe '#experience' do
+      let(:candidate_specification_form) { CandidateSpecificationForm.new(experience: experience) }
+
+      context 'when experience is blank' do
+        let(:experience) { nil }
+
+        it 'requests an entry in the field' do
+          expect(candidate_specification_form.valid?).to be false
+          expect(candidate_specification_form.errors.messages[:experience][0])
+            .to eq('Enter essential skills and experience')
+        end
+      end
+
+      context 'when experience text is too long' do
+        let(:experience) { 'short' * 1000 }
+
+        it 'validates the maximum length' do
+          expect(candidate_specification_form.valid?).to be false
+          expect(candidate_specification_form.errors.messages[:experience][0])
+            .to eq('Skills and experience must not be more than 1000 characters')
+        end
+      end
+    end
+
+    describe '#qualifications' do
+      let(:candidate_specification_form) { CandidateSpecificationForm.new(qualifications: qualifications) }
+
+      context 'when qualifications is blank' do
+        let(:qualifications) { nil }
+
+        it 'requests an entry in the field' do
+          expect(candidate_specification_form.valid?).to be false
+          expect(candidate_specification_form.errors.messages[:qualifications][0])
+            .to eq('Enter essential qualifications')
+        end
+      end
+
+      context 'when qualifications text is too long' do
+        let(:qualifications) { 'short' * 1000 }
+
+        it 'validates the maximum length' do
+          expect(candidate_specification_form.valid?).to be false
+          expect(candidate_specification_form.errors.messages[:qualifications][0])
+            .to eq('Qualifications must not be more than 1000 characters')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR rephrases the previous validation errors. The update error content is based off of desired changes from a content review.
The only difference being, that the error messages do not have commas in them. This may be added in a later commit

### Jira ticket URL: 
https://dfedigital.atlassian.net/browse/TEVA-265?atlOrigin=eyJpIjoiZGFkODgwMWJiZWQ0NDQwZGFhM2ZlMjlhMGM3ODkzNjYiLCJwIjoiaiJ9

## Screenshots of UI changes:

_(Please note that these still have their attribute names. These will be removed when all the error content changes are ready to be merged into develop, for now, this PR would be merged into a feature branch)_

### Before
![Screenshot 2019-11-07 at 15 07 34](https://user-images.githubusercontent.com/32823756/68400736-6aeb6c80-0170-11ea-980b-cc4b4b7a7ef6.png)

![Screenshot 2019-11-07 at 15 08 02](https://user-images.githubusercontent.com/32823756/68400750-7048b700-0170-11ea-87b5-6115ee9c017d.png)

### After

![Screenshot 2019-11-07 at 14 18 04](https://user-images.githubusercontent.com/32823756/68400623-3d062800-0170-11ea-8a9d-717a043b9d5c.png)

![Screenshot 2019-11-07 at 14 18 56](https://user-images.githubusercontent.com/32823756/68400536-1d6eff80-0170-11ea-973c-f38464a40ad2.png)

### Next Steps
- [ ] Change the global formatting to use `format: "{message}"` (Separate PR)

**Any feedback would be appreciated**