### PR TITLE
Remove invalid year error from DateValidator

### DIFF
--- a/app/validators/date_format_validator.rb
+++ b/app/validators/date_format_validator.rb
@@ -15,16 +15,14 @@ class DateFormatValidator < ActiveModel::Validator
     begin
       Date.parse("#{day}-#{month}-#{year}")
     rescue
-      record.errors.add(field, invalid_field_error(field))
+      invalid_field_error(field, record)
     end
-    record.errors.add(field, invalid_year_error(field)) if year.length > 4
+    invalid_field_error(field, record) unless year.length == 4
   end
 
-  def invalid_field_error(field)
-    I18n.t("activerecord.errors.models.vacancy.attributes.#{field}.invalid")
-  end
-
-  def invalid_year_error(field)
-    I18n.t("activerecord.errors.models.vacancy.attributes.#{field}.invalid_year")
+  def invalid_field_error(field, record)
+    record.errors.add(field,
+      I18n.t("activerecord.errors.models.vacancy.attributes.#{field}.invalid")
+    )
   end
 end

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -26,12 +26,10 @@ en:
       blank: Enter the date the application is due
       before_publish_date: Application cannot be due before the job has been listed
       invalid: Use the correct format for the time the application is due
-      invalid_year: Expires on on must include a 4-digit year
     publish_on:
       blank: Enter the date the role will be listed
       before_today: Date role will be listed must be either today or in the future
       invalid: Enter the date the role will be listed in the correct format
-      invalid_year: Publish on must include a 4-digit year
   errors:
     format: "%{message}"
     title: "Please correct the following %{errors} in your listing:"
@@ -46,7 +44,6 @@ en:
       salary:
         invalid_format: "must be entered in one of the following formats: 25000, 25,000 or 25000.00"
         lower_than_minimum_payscale: must be at least %{minimum_salary}
-      year_invalid: must include a 4-digit year
       email:
         invalid: is not a valid email address
   activemodel:
@@ -100,12 +97,10 @@ en:
               after_ends_on: Start date must be before end date
               before_expires_on: Start date must be after application deadline
               invalid: Enter the start date in the correct format
-              invalid_year: Starts on must include a 4-digit year
             ends_on:
               past: End date must be in the future
               before_expires_on: End date must be after application deadline
               invalid: Enter the end date in the correct format
-              invalid_year: Ends on must include a 4-digit year
             weekly_hours:
               negative: can't be negative
               invalid: must be a valid number

--- a/spec/validators/date_format_validator_spec.rb
+++ b/spec/validators/date_format_validator_spec.rb
@@ -10,96 +10,72 @@ RSpec.describe DateFormatValidator do
       end
     end
 
-    context 'a record with a malformed starts_on year' do
-      let(:vacancy) { FactoryBot.build(:vacancy, starts_on: Date.parse('12-01-202018')) }
-
-      it 'shows an invalid year error' do
-        vacancy.valid?
-        expect(vacancy.errors[:starts_on])
-        .to include(I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.invalid_year'))
+    context 'a record with a malformed year' do
+      let(:records) do
+        {
+          starts_on: FactoryBot.build(:vacancy, starts_on: Date.parse('12-01-111')),
+          ends_on: FactoryBot.build(:vacancy, ends_on: Date.parse('12-01-12345')),
+          publish_on: FactoryBot.build(:vacancy, publish_on: Date.parse('12-01-202089')),
+          expires_on: FactoryBot.build(:vacancy, expires_on: Date.parse('12-01-20298982323'))
+        }
       end
-    end
 
-    context 'a record with a malformed ends_on year' do
-      let(:vacancy) { FactoryBot.build(:vacancy, ends_on: Date.parse('12-01-202018')) }
-
-      it 'shows an invalid year error' do
+      it 'shows an invalid date format error' do
+        tested_field = [:starts_on, :ends_on, :publish_on, :expires_on].sample
+        vacancy = records[tested_field]
         vacancy.valid?
-        expect(vacancy.errors[:ends_on])
-        .to include(I18n.t('activerecord.errors.models.vacancy.attributes.ends_on.invalid_year'))
-      end
-    end
-
-    context 'a record with a malformed publish_on year' do
-      let(:vacancy) { FactoryBot.build(:vacancy, publish_on: Date.parse('12-01-202018')) }
-
-      it 'shows an invalid year error' do
-        vacancy.valid?
-        expect(vacancy.errors[:publish_on])
-        .to include(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.invalid_year'))
-      end
-    end
-
-    context 'a record with a malformed expires_on year' do
-      let(:vacancy) { FactoryBot.build(:vacancy, expires_on: Date.parse('12-01-202018')) }
-
-      it 'shows an invalid year error' do
-        vacancy.valid?
-        expect(vacancy.errors[:expires_on])
-        .to include(
-          I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.invalid_year'))
+        expect(vacancy.errors[tested_field])
+        .to include(I18n.t("activerecord.errors.models.vacancy.attributes.#{tested_field}.invalid"))
       end
     end
   end
 
-  describe '#validate_date_fields(fields, record)' do
-    context 'a record with blank fields' do
-      let(:vacancies_with_missing_field) do
-        [
-          FactoryBot.build(:vacancy, publish_on_dd: ''),
-          FactoryBot.build(:vacancy, publish_on_mm: ''),
-          FactoryBot.build(:vacancy, publish_on_yyyy: ''),
-        ]
-      end
-      let(:vacancy) { vacancies_with_missing_field.sample }
-
-      it 'does not evaluate format when there are blank fields' do
-        vacancy.valid?
-        expect(vacancy.errors[:publish_on])
-        .not_to include('Enter the date the role will be listed in the correct format')
-      end
+  context 'a record with blank fields' do
+    let(:vacancies_with_missing_field) do
+      [
+        FactoryBot.build(:vacancy, publish_on_dd: ''),
+        FactoryBot.build(:vacancy, publish_on_mm: ''),
+        FactoryBot.build(:vacancy, publish_on_yyyy: ''),
+      ]
     end
+    let(:vacancy) { vacancies_with_missing_field.sample }
 
-    context 'a record with incorrect day' do
-      let(:vacancy) { FactoryBot.build(:vacancy, expires_on_dd: '66') }
-
-      it 'shows an invalid date error' do
-        vacancy.valid?
-        expect(vacancy.errors[:expires_on])
-          .to include(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.invalid'))
-      end
+    it 'does not evaluate format when there are blank fields' do
+      vacancy.valid?
+      expect(vacancy.errors[:publish_on])
+      .not_to include('Enter the date the role will be listed in the correct format')
     end
+  end
 
-    context 'a record with incorrect month' do
-      let(:vacancy) { FactoryBot.build(:vacancy, expires_on_mm: '66') }
+  context 'a record with incorrect day' do
+    let(:vacancy) { FactoryBot.build(:vacancy, expires_on_dd: '66') }
 
-      it 'shows an invalid date error' do
-        vacancy.valid?
-
-        expect(vacancy.errors[:expires_on])
-          .to include(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.invalid'))
-      end
+    it 'shows an invalid date error' do
+      vacancy.valid?
+      expect(vacancy.errors[:expires_on])
+        .to include(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.invalid'))
     end
+  end
 
-    context 'a record with an impossible date' do
-      let(:vacancy) { FactoryBot.build(:vacancy, publish_on_dd: '31', publish_on_mm: '02', publish_on_yyyy: '2020') }
+  context 'a record with incorrect month' do
+    let(:vacancy) { FactoryBot.build(:vacancy, expires_on_mm: '66') }
 
-      it 'shows an invalid date error' do
-        vacancy.valid?
+    it 'shows an invalid date error' do
+      vacancy.valid?
 
-        expect(vacancy.errors[:publish_on])
-          .to include(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.invalid'))
-      end
+      expect(vacancy.errors[:expires_on])
+        .to include(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.invalid'))
+    end
+  end
+
+  context 'a record with an impossible date' do
+    let(:vacancy) { FactoryBot.build(:vacancy, publish_on_dd: '31', publish_on_mm: '02', publish_on_yyyy: '2020') }
+
+    it 'shows an invalid date error' do
+      vacancy.valid?
+
+      expect(vacancy.errors[:publish_on])
+        .to include(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.invalid'))
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR:
Going forward we don't want to use confusing error messages. Michael Nottingham suggested removing the `date must include a 4-digit year` errors and use the generic invalid year errors instead. 
- Removed the error from DateValidator class
- Removed `invalid year` errors from the translation file
- Update specs accordingly