### PR TITLE
Edit error message for invalid application deadline

### DIFF
--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -24,7 +24,7 @@ en:
     expires_on:
       blank: Enter the date the application is due
       before_publish_date: Application cannot be due before the job has been listed
-      invalid: Use the correct format for the time the application is due
+      invalid: Use the correct format for the date the application is due
     publish_on:
       blank: Enter the date the role will be listed
       before_today: Date role will be listed must be either today or in the future
@@ -77,7 +77,7 @@ en:
               greater_than_minimum_salary: Maximum salary must be more than the minimum salary
             expiry_time:
               blank: Enter the time the application is due
-              wrong_format: Enter the time the application is due in the correct format
+              wrong_format: Use the correct format for the time the application is due
               must_be_am_pm: Select am or pm
             starts_on:
               past: Start date must be in the future

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -123,7 +123,7 @@ RSpec.feature 'Copying a vacancy' do
         click_on I18n.t('buttons.save_and_continue')
       end
 
-      expect(page).to have_content('Use the correct format for the time the application is due')
+      expect(page).to have_content('Use the correct format for the date the application is due')
     end
   end
 

--- a/spec/form_models/application_details_form_spec.rb
+++ b/spec/form_models/application_details_form_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe ApplicationDetailsForm, type: :model do
 
       validate_expiry_time_hours = [
         { value: nil, errors: ['Enter the time the application is due'] },
-        { value: 'not a number', errors: ['Enter the time the application is due in the correct format'] },
-        { value: '14', errors: ['Enter the time the application is due in the correct format'] },
-        { value: '0', errors: ['Enter the time the application is due in the correct format'] },
+        { value: 'not a number', errors: ['Use the correct format for the time the application is due'] },
+        { value: '14', errors: ['Use the correct format for the time the application is due'] },
+        { value: '0', errors: ['Use the correct format for the time the application is due'] },
       ]
 
       validate_expiry_time_hours.each do |h|
@@ -51,9 +51,9 @@ RSpec.describe ApplicationDetailsForm, type: :model do
 
       validate_expiry_time_minutes = [
         { value: nil, errors: ['Enter the time the application is due'] },
-        { value: 'not a number', errors: ['Enter the time the application is due in the correct format'] },
-        { value: '-6', errors: ['Enter the time the application is due in the correct format'] },
-        { value: '66', errors: ['Enter the time the application is due in the correct format'] },
+        { value: 'not a number', errors: ['Use the correct format for the time the application is due'] },
+        { value: '-6', errors: ['Use the correct format for the time the application is due'] },
+        { value: '66', errors: ['Use the correct format for the time the application is due'] },
       ]
 
       validate_expiry_time_minutes.each do |m|
@@ -83,7 +83,7 @@ RSpec.describe ApplicationDetailsForm, type: :model do
         subject.expiry_time_meridiem = nil
         subject.valid?
         expect(subject.errors.messages[:expiry_time]).to eq(
-          ['Enter the time the application is due in the correct format']
+          ['Use the correct format for the time the application is due']
         )
       end
 


### PR DESCRIPTION
The application DATE deadline and the application TIME deadline invalid error messages were raised in a content review.

This commit edits the invalid error messages specific to either the date or time for the application deadline as per the suggestion from the content review.

Jira ticket URL: https://dfedigital.atlassian.net/browse/TEVA-268?atlOrigin=eyJpIjoiZjk2YTE5MmQ1MzBiNDkzNGI5MTBhOWQ4YjI1NjlkM2EiLCJwIjoiaiJ9

## Changes in this PR:

### Screenshots of UI changes:

#### Before

**_Invalid Date_**

<img width="550" alt="Screenshot 2019-11-12 at 11 00 47" src="https://user-images.githubusercontent.com/32823756/68666377-ba98b200-053b-11ea-9136-f8e5cd705389.png">

**_Invalid Time_**

<img width="571" alt="Screenshot 2019-11-12 at 11 00 37" src="https://user-images.githubusercontent.com/32823756/68666386-bff5fc80-053b-11ea-8c8a-f6a5360407f4.png">

### After

**_Invalid Date_**

<img width="552" alt="Screenshot 2019-11-12 at 10 37 38" src="https://user-images.githubusercontent.com/32823756/68666464-e320ac00-053b-11ea-84fc-2fe6ca0e8e30.png">

**_Invalid Time_**

<img width="577" alt="Screenshot 2019-11-12 at 10 38 18" src="https://user-images.githubusercontent.com/32823756/68666481-e9af2380-053b-11ea-9586-f02524625be8.png">