### PR TITLE
Change error content for date role is listed

### DIFF
--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -28,7 +28,7 @@ en:
     publish_on:
       blank: Enter the date the role will be listed
       before_today: Date role will be listed must be either today or in the future
-      invalid: Enter the date the role will be listed in the correct format
+      invalid: Use the correct format for the date the role will be listed
   candidate_specification_errors: &candidate_specification_errors
     education:
       blank: Enter essential educational requirements

--- a/spec/validators/date_format_validator_spec.rb
+++ b/spec/validators/date_format_validator_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe DateFormatValidator do
     it 'does not evaluate format when there are blank fields' do
       vacancy.valid?
       expect(vacancy.errors[:publish_on])
-      .not_to include('Enter the date the role will be listed in the correct format')
+      .not_to include('Use the correct format for the date the role will be listed')
     end
   end
 


### PR DESCRIPTION
Quick edit: Edit the invalid error message displayed for the date role is listed (as per content review)

## Screenshots of UI changes:

### Before
<img width="1230" alt="Screenshot 2019-11-12 at 12 47 50" src="https://user-images.githubusercontent.com/32823756/68672989-b1fba800-054a-11ea-9ae5-0996b227cfa0.png">

<img width="555" alt="Screenshot 2019-11-12 at 12 48 02" src="https://user-images.githubusercontent.com/32823756/68672998-b6c05c00-054a-11ea-903e-80d921043308.png">

### After
<img width="1225" alt="Screenshot 2019-11-12 at 12 42 07" src="https://user-images.githubusercontent.com/32823756/68672927-92fd1600-054a-11ea-88e1-d3d708dc9220.png">

<img width="554" alt="Screenshot 2019-11-12 at 12 42 13" src="https://user-images.githubusercontent.com/32823756/68672931-97293380-054a-11ea-94e1-25cdf428c212.png">
