### PR TITLE
Add rake task to update DSI spreadsheets

### DIFF
--- a/lib/tasks/update_dsi_spreadsheets.rake
+++ b/lib/tasks/update_dsi_spreadsheets.rake
@@ -1,0 +1,7 @@
+namespace :dsi_spreadsheets do
+  desc 'Updates Google spreadsheets with DSI users data'
+  task update: :environment do
+    AddDSIUsersToSpreadsheetJob.perform_later
+    AddDSIApproversToSpreadsheetJob.perform_later
+  end
+end

--- a/lib/tasks/update_spreadsheets.rake
+++ b/lib/tasks/update_spreadsheets.rake
@@ -7,7 +7,5 @@ namespace :spreadsheets do
     AddAuditDataToSpreadsheetJob.perform_later('search_event')
     AddVacancyPublishFeedbackToSpreadsheetJob.perform_later
     AddGeneralFeedbackToSpreadsheetJob.perform_later
-    AddDSIUsersToSpreadsheetJob.perform_later
-    AddDSIApproversToSpreadsheetJob.perform_later
   end
 end

--- a/spec/lib/tasks/update_dsi_spreadsheets_rake_spec.rb
+++ b/spec/lib/tasks/update_dsi_spreadsheets_rake_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'rake dsi_spreadsheets:update', type: :task do
+  before do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  it 'queues the add dsi users to spreadsheet job' do
+    expect { task.execute }.to have_enqueued_job(AddDSIUsersToSpreadsheetJob)
+  end
+
+  it 'queues the add dsi approvers to spreadsheet job' do
+    expect { task.execute }.to have_enqueued_job(AddDSIApproversToSpreadsheetJob)
+  end
+end

--- a/spec/lib/tasks/update_spreadsheets_rake_spec.rb
+++ b/spec/lib/tasks/update_spreadsheets_rake_spec.rb
@@ -28,12 +28,4 @@ RSpec.describe 'rake spreadsheets:update', type: :task do
   it 'queues the general feedback job' do
     expect { task.execute }.to have_enqueued_job(AddGeneralFeedbackToSpreadsheetJob)
   end
-
-  it 'queues the add dsi users to spreadsheet job' do
-    expect { task.execute }.to have_enqueued_job(AddDSIUsersToSpreadsheetJob)
-  end
-
-  it 'queues the add dsi approvers to spreadsheet job' do
-    expect { task.execute }.to have_enqueued_job(AddDSIApproversToSpreadsheetJob)
-  end
 end

--- a/terraform.tf
+++ b/terraform.tf
@@ -91,6 +91,9 @@ module "ecs" {
   update_spreadsheets_task_command  = "${var.update_spreadsheets_task_command}"
   update_spreadsheets_task_schedule = "${var.update_spreadsheets_task_schedule}"
 
+  update_dsi_spreadsheets_task_command  = "${var.update_dsi_spreadsheets_task_command}"
+  update_dsi_spreadsheets_task_schedule = "${var.update_dsi_spreadsheets_task_schedule}"
+
   send_job_alerts_daily_email_task_command  = "${var.send_job_alerts_daily_email_task_command}"
   send_job_alerts_daily_email_task_schedule = "${var.send_job_alerts_daily_email_task_schedule}"
 

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -580,6 +580,23 @@ module "update_spreadsheets_task" {
   event_role_arn     = "${aws_iam_role.scheduled_task_role.arn}"
 }
 
+module "update_dsi_spreadsheets_task" {
+  source = "../scheduled-ecs-task"
+
+  task_name        = "${var.ecs_service_web_task_name}_update_dsi_spreadsheets"
+  task_description = "Update DSI spreadsheets"
+  task_command     = "${var.update_dsi_spreadsheets_task_command}"
+  task_schedule    = "${var.update_dsi_spreadsheets_task_schedule}"
+
+  container_definition_template = "${module.rake_container_definition.template}"
+
+  ecs_cluster_arn = "${aws_ecs_cluster.cluster.arn}"
+
+  execution_role_arn = "${aws_iam_role.ecs_execution_role.arn}"
+  task_role_arn      = "${aws_iam_role.ecs_execution_role.arn}"
+  event_role_arn     = "${aws_iam_role.scheduled_task_role.arn}"
+}
+
 module "performance_platform_submit_task" {
   source = "../scheduled-ecs-task"
 

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -153,7 +153,12 @@ variable "update_spreadsheets_task_command" {
   type = "list"
 }
 
+variable "update_dsi_spreadsheets_task_command" {
+  type = "list"
+}
+
 variable "update_spreadsheets_task_schedule" {}
+variable "update_dsi_spreadsheets_task_schedule" {}
 variable "send_job_alerts_daily_email_task_schedule" {}
 variable "send_feedback_prompt_email_task_schedule" {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -194,6 +194,16 @@ variable "update_spreadsheets_task_schedule" {
   default     = "cron(0 01 * * ? *)"
 }
 
+variable "update_dsi_spreadsheets_task_command" {
+  description = "The Entrypoint for the update_dsi_spreadsheets task"
+  default     = ["rake", "verbose", "dsi_spreadsheets:update"]
+}
+
+variable "update_dsi_spreadsheets_task_schedule" {
+  description = "update_dsi_spreadsheets schedule expression - https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
+  default     = "cron(0 02 * * ? *)"
+}
+
 variable "sessions_trim_task_command" {
   description = "The Entrypoint for trimming old sessions"
   default     = ["rake", "verbose", "db:sessions:trim"]


### PR DESCRIPTION
## Changes in this PR:
`AddDSIUSersToSpreadsheet` and `AddDSIApproversToSpreadsheet` jobs were scheduled along with other spreadsheet writer tasks. The execution failed, presumably because of the google sheets API rate limit. Move these job to a separate rake task so that we can schedule them separately.

## Next steps:
- [ ] Terraform deployment required?
 