### PR TITLE
Change search by minimum salary filter functionality

### DIFF
--- a/app/services/vacancy_alert_search_builder.rb
+++ b/app/services/vacancy_alert_search_builder.rb
@@ -45,12 +45,36 @@ class VacancyAlertSearchBuilder < VacancySearchBuilder
   end
 
   def salary_query
-    return if minimum_salary.blank? && maximum_salary.blank?
-    return greater_than(minimum_salary: minimum_salary.to_i) if maximum_salary.blank?
-    return less_than_minimum_and_maximum_match if minimum_salary.blank?
+    return if minimum_salary.blank?
 
-    [greater_than(minimum_salary: minimum_salary.to_i),
-     less_than_maximum_salary_or_no_match]
+    [
+      {
+        bool: {
+          should: [
+            {
+              bool: {
+                must: [
+                  range: {
+                    "maximum_salary": {
+                      gte: minimum_salary.to_i
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              bool: {
+                must_not: {
+                  exists: {
+                    field: 'maximum_salary'
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
   end
 
   def less_than_minimum_and_maximum_match

--- a/app/services/vacancy_alert_search_builder.rb
+++ b/app/services/vacancy_alert_search_builder.rb
@@ -1,6 +1,5 @@
 class VacancyAlertSearchBuilder < VacancySearchBuilder
-  attr_accessor :keyword,
-                :maximum_salary
+  attr_accessor :keyword
 
   def initialize(filters:, from:, to:)
     @from = from
@@ -8,7 +7,6 @@ class VacancyAlertSearchBuilder < VacancySearchBuilder
     sort = VacancySort.new.update(column: 'publish_on', order: 'desc')
 
     self.keyword = filters.keyword.to_s.strip
-    self.maximum_salary = filters.maximum_salary
 
     super(filters: filters, sort: sort, expired: false, status: :published)
   end
@@ -41,61 +39,6 @@ class VacancyAlertSearchBuilder < VacancySearchBuilder
           'lt': @to
         },
       },
-    }
-  end
-
-  def salary_query
-    return if minimum_salary.blank?
-
-    [
-      {
-        bool: {
-          should: [
-            {
-              bool: {
-                must: [
-                  range: {
-                    "maximum_salary": {
-                      gte: minimum_salary.to_i
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              bool: {
-                must_not: {
-                  exists: {
-                    field: 'maximum_salary'
-                  }
-                }
-              }
-            }
-          ]
-        }
-      }
-    ]
-  end
-
-  def less_than_minimum_and_maximum_match
-    [less_than(maximum_salary: maximum_salary.to_i),
-     less_than_maximum_salary_or_no_match]
-  end
-
-  def less_than_maximum_salary_or_no_match
-    {
-      bool: {
-        should: [
-          less_than(maximum_salary: maximum_salary.to_i),
-          bool: {
-            must_not: {
-              exists: {
-                field: 'maximum_salary'
-              }
-            }
-          }
-        ]
-      }
     }
   end
 end

--- a/app/services/vacancy_search_builder.rb
+++ b/app/services/vacancy_search_builder.rb
@@ -198,26 +198,8 @@ class VacancySearchBuilder
     {
       bool: {
         should: [
-          {
-            bool: {
-              must: [
-                range: {
-                  "maximum_salary": {
-                    gte: minimum_salary.to_i
-                  }
-                }
-              ]
-            }
-          },
-          {
-            bool: {
-              must_not: {
-                exists: {
-                  field: 'maximum_salary'
-                }
-              }
-            }
-          }
+          less_than_maximum_salary,
+          without_a_maximum_salary
         ]
       }
     }
@@ -227,34 +209,28 @@ class VacancySearchBuilder
     sort.present? ? [{ sort.column.to_sym => { order: sort.order.to_sym } }] : []
   end
 
-  def greater_than(field_value_hash)
+  def less_than_maximum_salary
     {
       bool: {
-        should: field_value_hash.map do |field, value|
-                  {
-                    range: {
-                      "#{field}": {
-                        gte: value
-                      }
-                    }
-                  }
-                end
+        must: [
+          range: {
+            "maximum_salary": {
+              gte: minimum_salary.to_i
+            }
+          }
+        ]
       }
     }
   end
 
-  def less_than(field_value_hash)
+  def without_a_maximum_salary
     {
       bool: {
-        should: field_value_hash.map do |field, value|
-                  {
-                    range: {
-                      "#{field}": {
-                        lte: value
-                      }
-                    }
-                  }
-                end
+        must_not: {
+          exists: {
+            field: 'maximum_salary'
+          }
+        }
       }
     }
   end

--- a/app/services/vacancy_search_builder.rb
+++ b/app/services/vacancy_search_builder.rb
@@ -195,7 +195,32 @@ class VacancySearchBuilder
   def salary_query
     return if minimum_salary.blank?
 
-    greater_than(minimum_salary: minimum_salary.to_i)
+    {
+      bool: {
+        should: [
+          {
+            bool: {
+              must: [
+                range: {
+                  "maximum_salary": {
+                    gte: minimum_salary.to_i
+                  }
+                }
+              ]
+            }
+          },
+          {
+            bool: {
+              must_not: {
+                exists: {
+                  field: 'maximum_salary'
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
   end
 
   def sort_query

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -147,20 +147,42 @@ RSpec.feature 'Filtering vacancies' do
     end
   end
 
-  scenario 'is filterable by minimum salary', elasticsearch: true do
-    low_paid_vacancy = create(:vacancy, :published, minimum_salary: 18000, maximum_salary: 20000)
-    high_paid_vacancy = create(:vacancy, :published, minimum_salary: 42000, maximum_salary: 45000)
+  context 'when filtering by minimum salary', elasticsearch: true do
+    scenario 'displays vacancies with a maximum salary that is higher than or equal to the filter value' do
+      low_paying_vacancy = create(:vacancy, :published, minimum_salary: 10000, maximum_salary: 29000)
+      medium_paying_vacancy = create(:vacancy, :published, minimum_salary: 18000, maximum_salary: 30000)
+      high_paying_vacancy = create(:vacancy, :published, minimum_salary: 20000, maximum_salary: 45000)
 
-    Vacancy.__elasticsearch__.client.indices.flush
-    visit jobs_path
+      Vacancy.__elasticsearch__.client.indices.flush
+      visit jobs_path
 
-    within '.filters-form' do
-      select '£30,000', from: 'minimum_salary'
-      page.find('.govuk-button[type=submit]').click
+      within '.filters-form' do
+        select '£30,000', from: 'minimum_salary'
+        page.find('.govuk-button[type=submit]').click
+      end
+
+      expect(page).to have_content(medium_paying_vacancy.job_title)
+      expect(page).to have_content(high_paying_vacancy.job_title)
+      expect(page).not_to have_content(low_paying_vacancy.job_title)
     end
 
-    expect(page).to have_content(high_paid_vacancy.job_title)
-    expect(page).not_to have_content(low_paid_vacancy.job_title)
+    scenario 'displays all vacancies that have no maximum salary, regardless of their minimum salary' do
+      vacancy_one = create(:vacancy, :published, minimum_salary: 19000, maximum_salary: nil)
+      vacancy_two = create(:vacancy, :published, minimum_salary: 30000, maximum_salary: nil)
+      vacancy_three = create(:vacancy, :published, minimum_salary: 40000, maximum_salary: nil)
+
+      Vacancy.__elasticsearch__.client.indices.flush
+      visit jobs_path
+
+      within '.filters-form' do
+        select '£30,000', from: 'minimum_salary'
+        page.find('.govuk-button[type=submit]').click
+      end
+
+      expect(page).to have_content(vacancy_one.job_title)
+      expect(page).to have_content(vacancy_two.job_title)
+      expect(page).to have_content(vacancy_three.job_title)
+    end
   end
 
   context 'when filtering by newly qualified teacher', elasticsearch: true do

--- a/spec/services/vacancy_alert_search_builder_spec.rb
+++ b/spec/services/vacancy_alert_search_builder_spec.rb
@@ -67,41 +67,4 @@ RSpec.describe VacancyAlertSearchBuilder do
 
     expect(builder[:search_sort]).to eq(expected_sort_query)
   end
-
-  it 'includes the minimum salary value when it is provided' do
-    filters = OpenStruct.new(minimum_salary: 20000)
-    builder = VacancyAlertSearchBuilder.new(filters: filters, from: from_date, to: to_date).call
-
-    expected_hash = [
-      {
-        bool: {
-          should: [
-            {
-              bool: {
-                must: [
-                  range: {
-                    maximum_salary: {
-                      gte: 20000
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              bool: {
-                must_not: {
-                  exists: {
-                    field: 'maximum_salary'
-                  }
-                }
-              }
-            }
-          ]
-        }
-      }
-    ]
-
-    expect(builder).to be_a(Hash)
-    expect(builder[:search_query][:bool][:must]).to include(expected_hash)
-  end
 end

--- a/spec/services/vacancy_alert_search_builder_spec.rb
+++ b/spec/services/vacancy_alert_search_builder_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe VacancyAlertSearchBuilder do
     expect(builder[:search_sort]).to eq(expected_sort_query)
   end
 
-  it 'includes both the minimum and maximum salary when both are provided' do
-    filters = OpenStruct.new(minimum_salary: 200, maximum_salary: 20000)
+  it 'includes the minimum salary value when it is provided' do
+    filters = OpenStruct.new(minimum_salary: 20000)
     builder = VacancyAlertSearchBuilder.new(filters: filters, from: from_date, to: to_date).call
 
     expected_hash = [
@@ -77,78 +77,11 @@ RSpec.describe VacancyAlertSearchBuilder do
         bool: {
           should: [
             {
-              range: {
-                minimum_salary: {
-                  gte: 200
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        bool: {
-          should: [
-            {
               bool: {
-                should: [
-                  {
-                    range: {
-                      maximum_salary: {
-                        lte: 20000
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              bool: {
-                must_not: {
-                  exists: {
-                    field: 'maximum_salary'
-                  }
-                }
-              }
-            }
-          ]
-        }
-      }
-    ]
-
-    expect(builder).to be_a(Hash)
-    expect(builder[:search_query][:bool][:must]).to include(expected_hash)
-  end
-
-  it 'includes only the maximum salary value when no minimum is provided' do
-    filters = OpenStruct.new(minimum_salary: nil, maximum_salary: 20000)
-    builder = VacancyAlertSearchBuilder.new(filters: filters, from: from_date, to: to_date).call
-
-    expected_hash = [
-      {
-        bool: {
-          should: [
-            {
-              range: {
-                maximum_salary: {
-                  lte: 20000
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        bool: {
-          should: [
-            {
-              bool: {
-                should: [
-                  {
-                    range: {
-                      maximum_salary: {
-                        lte: 20000
-                      }
+                must: [
+                  range: {
+                    maximum_salary: {
+                      gte: 20000
                     }
                   }
                 ]

--- a/spec/services/vacancy_search_builder_spec.rb
+++ b/spec/services/vacancy_search_builder_spec.rb
@@ -135,29 +135,40 @@ RSpec.describe VacancySearchBuilder do
       expect(builder[:search_query][:bool][:must]).to include(expected_hash)
     end
 
-    context 'salary query' do
-      it 'only includes the minimum salary' do
-        sort = OpenStruct.new(column: :expires_on, order: :desc)
-        filters = OpenStruct.new(minimum_salary: 20000)
-        builder = described_class.new(filters: filters, sort: sort).call
+    it 'builds a salary query when a minimum salary is provided' do
+      sort = OpenStruct.new(column: :expires_on, order: :desc)
+      filters = OpenStruct.new(minimum_salary: 20000)
+      builder = described_class.new(filters: filters, sort: sort).call
 
-        expected_hash = {
-          bool: {
-            should: [
-              {
-                range: {
-                  minimum_salary: {
-                    gte: 20000
+      expected_hash = {
+        bool: {
+          should: [
+            {
+              bool: {
+                must: [
+                  range: {
+                    maximum_salary: {
+                      gte: 20000
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              bool: {
+                must_not: {
+                  exists: {
+                    field: 'maximum_salary'
                   }
                 }
               }
-            ]
-          }
+            }
+          ]
         }
+      }
 
-        expect(builder).to be_a(Hash)
-        expect(builder[:search_query][:bool][:must]).to include(expected_hash)
-      end
+      expect(builder).to be_a(Hash)
+      expect(builder[:search_query][:bool][:must]).to include(expected_hash)
     end
 
     it 'builds a published status query by default' do


### PR DESCRIPTION
Jira ticket URL: https://dfedigital.atlassian.net/browse/TEVA-95?atlOrigin=eyJpIjoiMGQ2OTFlYmQ4ZDM1NDM1NmJlMDljNmVlOTFkODUwM2UiLCJwIjoiaiJ9

Vacancies with salary ranges where the minimum salary's lower than the search filter value but the maximum salary's higher than the search filter value are not displayed to the user on the site or in job alerts.

We want to display vacancies to the user:
- that have a maximum salary that is higher than the search value
- do **NOT** have a specified maximum salary, (regardless of its minimum salary value)

## Screenshots of UI changes:

_No Minimum Salary Filter selected_

<img width="546" alt="Screenshot 2019-11-17 at 19 16 19" src="https://user-images.githubusercontent.com/32823756/69012687-67c25e80-0970-11ea-8779-39714a2ea710.png">

### Before
_£40,000 Minimum Salary Filter selected_
<img width="497" alt="Screenshot 2019-11-17 at 19 15 58" src="https://user-images.githubusercontent.com/32823756/69012718-cc7db900-0970-11ea-8f2a-1caee99fd7e9.png">

### After
_£40,000 Minimum Salary Filter selected_
<img width="536" alt="Screenshot 2019-11-17 at 19 15 10" src="https://user-images.githubusercontent.com/32823756/69012730-e6b79700-0970-11ea-9ed6-70b79d3b0430.png">

### New Job Alerts
<img width="826" alt="Screenshot 2019-11-18 at 06 23 16" src="https://user-images.githubusercontent.com/32823756/69029445-d7fecd80-09cc-11ea-995b-5467a0e6f35b.png">

## Next steps:

- [ ] Check minimum salary search filters on Staging return vacancies as desired

- [ ] Check Job alerts on Staging return vacancies as desired