### PR TITLE
(chore) add link to feedback nudge email

### DIFF
--- a/app/views/feedback_prompt_mailer/prompt_for_feedback.text.haml
+++ b/app/views/feedback_prompt_mailer/prompt_for_feedback.text.haml
@@ -6,9 +6,10 @@ We’re constantly working to improve #{t('app.title')}. You can help us do so b
 
 - @vacancies.each do |vacancy|
   = "* #{vacancy.job_title}"
-
 \
-It should only take a minute or 2 of your time. Just sign into your Teaching Vacancies account and select the ‘Jobs awaiting feedback’ tab.
+It should only take a minute or 2 of your time. Just #{notify_link(new_identifications_url(:protocol => 'https'), "sign into your Teaching Vacancies account")} and select the ‘Jobs awaiting feedback’ tab.
+\
+If you are already signed in to your Teaching Vacancies account you can access the expired jobs awaiting your feedback by clicking #{notify_link(jobs_with_type_school_url(:type=>'awaiting_feedback' , :protocol => 'https') , "here")}.
 \
 Insights from schools like yours are essential if we’re to make Teaching Vacancies the preferred resource for getting schools the teachers they need while saving them money on recruitment costs.
 \

--- a/app/views/feedback_prompt_mailer/prompt_for_feedback.text.haml
+++ b/app/views/feedback_prompt_mailer/prompt_for_feedback.text.haml
@@ -11,7 +11,7 @@ It should only take a minute or 2 of your time. Just #{notify_link(new_identific
 \
 If you are already signed in to your Teaching Vacancies account you can access the expired jobs awaiting your feedback by clicking #{notify_link(jobs_with_type_school_url(:type=>'awaiting_feedback' , :protocol => 'https') , "here")}.
 \
-Insights from schools like yours are essential if we’re to make Teaching Vacancies the preferred resource for getting schools the teachers they need while saving them money on recruitment costs.
+Insights from schools like yours are essential to our efforts to improve Teaching Vacancies. With your help we can make it the resource schools prefer to use when looking for teachers, leading to even bigger savings on recruitment costs.
 \
 So thanks for your feedback!
 \


### PR DESCRIPTION
## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-234?atlOrigin=eyJpIjoiMzI0MjY2YzIwYmVlNGQ4YmFhZDI4NzA4N2E1NmQ2ZTAiLCJwIjoiaiJ9

## Changes in this PR:
- Add link in expired vacancy feedback nudge email

## Screenshots

### Before
<img width="469" alt="Screenshot 2019-11-19 at 13 45 05" src="https://user-images.githubusercontent.com/47317567/69151703-0b2b8480-0ad3-11ea-88d5-5119e78eb127.png">

### After
<img width="462" alt="Screenshot 2019-11-19 at 13 45 38" src="https://user-images.githubusercontent.com/47317567/69151727-167eb000-0ad3-11ea-97e0-0e5295ea914b.png">

