### PR TITLE
Delete UrlValidator Class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'simple_form'
 gem 'rails-html-sanitizer', '~> 1.3.0' # Must be above this version due to CVE-2018-3741
 
 gem 'gov_uk_date_fields'
-
+gem 'validate_url', '~> 1.0.6'
 gem 'xml-sitemap'
 
 gem 'rollbar', '~> 2.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -576,6 +576,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  validate_url (~> 1.0.6)
   web-console (>= 3.3.0)
   webmock (~> 3.7)
   xml-sitemap

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,7 +1,0 @@
-class UrlValidator < ActiveModel::EachValidator
-  def validate_each(record, attribute, value)
-    URI.parse(value).is_a?(URI::HTTP)
-  rescue URI::InvalidURIError
-    record.errors[attribute] << I18n.t('errors.url.invalid')
-  end
-end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -459,8 +459,6 @@ en:
     sign_in:
       unauthorised: You are not authorised to act on behalf of this school
       failure: An unexpected error occured. We have been notified.
-    url:
-      invalid: is not a valid URL
     terms_and_conditions:
       errors_present: Please correct the following errors
     feedback:


### PR DESCRIPTION
- UrlValidator seems to be dead code. There is only one URL validation in the job listing journey which uses the `validates_url` [gem](https://github.com/perfectline/validates_url). The UrlValidator class is not being referenced or tested anywhere

- Add the `validates_url`gem to the gemfile, to make it an explicit dependency