### PR TITLE
Re-raise errors in dsi_api_response_to_spreadsheet usecase

### DIFF
--- a/lib/dsi_api_response_to_spreadsheet.rb
+++ b/lib/dsi_api_response_to_spreadsheet.rb
@@ -18,9 +18,11 @@ class DsiAPIResponseToSpreadsheet
 
     rescue StandardError => e
       Rails.logger.warn("DSI API #{endpoint} failed to respond at page #{page} with error: #{e.message}")
+      raise
     end
   rescue StandardError => e
     Rails.logger.warn("DSI API #{endpoint} failed to respond with error: #{e.message}")
+    raise
   end
 
   private


### PR DESCRIPTION
Handled exceptions don't show up in Rollbar. As suggested by Adrian Clay, leaving these exceptions unhandled would allow us to know when a scheduled job failed. This commit changes the behaviour of the use-case, when there is an error on a given page, the spreadsheet writer task will terminate on the page. 