### PR TITLE
Fix bug when sorting after searching with education phase

### DIFF
--- a/app/views/vacancies/_sorting_options.html.haml
+++ b/app/views/vacancies/_sorting_options.html.haml
@@ -1,8 +1,11 @@
 .govuk-grid-row.sortable-links
   .govuk-grid-column-one-half
     = form_tag('', method: :get) do
-      - search_criteria.each do |filter, value|
-        = hidden_field_tag filter, value
+      - search_criteria.each do |filter, value|  
+        - if filter == :phases
+          = hidden_field_tag "phases[]", value
+        - else
+          = hidden_field_tag filter, value
       = label_tag 'jobs_sort', t('jobs.sort_by'), class: "govuk-label inline"
       = select_tag 'jobs_sort', options_for_select(job_sorting_options, selected_sorting_method(sort: sort)), class: 'govuk-select govuk-input--width-10'
       = submit_tag t('jobs.sort_submit'), class: 'govuk-button', id: 'submit_job_sort'


### PR DESCRIPTION
When redirecting with a sort order after choosing a phase the search
would error as the hidden field was converting the phases array to a
string so the new URL would contain phases=secondary rather than
phases[]=secondary. This would cause an error when the phases param was
JSON parsed. We fixed it thanks to this answer on Stack Overflow:

https://stackoverflow.com/questions/28139318/pass-an-array-of-ids-back-from-a-view-to-a-rails-controller

## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-306?atlOrigin=eyJpIjoiY2FkY2ZhNGU3NjZiNDU3ZWI0NjY1NTM3ZmUzMzljN2QiLCJwIjoiaiJ9