### PR TITLE
Fix sorting bug after searching with multiple education phases

### DIFF
--- a/app/views/vacancies/_sorting_options.html.haml
+++ b/app/views/vacancies/_sorting_options.html.haml
@@ -1,9 +1,10 @@
 .govuk-grid-row.sortable-links
   .govuk-grid-column-one-half
     = form_tag('', method: :get) do
-      - search_criteria.each do |filter, value|  
+      - search_criteria.each do |filter, value|
         - if filter == :phases
-          = hidden_field_tag "phases[]", value
+          - phases.each do | phase |
+            = hidden_field_tag "phases[]", phase
         - else
           = hidden_field_tag filter, value
       = label_tag 'jobs_sort', t('jobs.sort_by'), class: "govuk-label inline"


### PR DESCRIPTION
This stemmed from a review done on PR #1161 after it was merged into develop.
The fix in that PR did not work when a search included multiple education phases in its search parameters.

This commit takes into account searches with multiple education phases as well as single-phase searches.

## Next steps:

- [ ] Check sort functionality & searching by phase(s) both work in Staging.