### PR TITLE
Disable the exporting of "search_event" and "interest_expression" data.

### DIFF
--- a/lib/tasks/update_spreadsheets.rake
+++ b/lib/tasks/update_spreadsheets.rake
@@ -1,10 +1,12 @@
 namespace :spreadsheets do
   desc 'Updates Google spreadsheets with the latest audit data'
   task update: :environment do
+    # Note that the exporting of "interest_expression"s and "search_event"s
+    # have been intentionally disabled as they were causing Out Of Memory issues
+    # in production.
+
     AddVacanciesToSpreadsheetJob.perform_later
-    AddAuditDataToSpreadsheetJob.perform_later('interest_expression')
     AddAuditDataToSpreadsheetJob.perform_later('subscription_creation')
-    AddAuditDataToSpreadsheetJob.perform_later('search_event')
     AddVacancyPublishFeedbackToSpreadsheetJob.perform_later
     AddGeneralFeedbackToSpreadsheetJob.perform_later
   end

--- a/spec/lib/tasks/update_spreadsheets_rake_spec.rb
+++ b/spec/lib/tasks/update_spreadsheets_rake_spec.rb
@@ -9,16 +9,8 @@ RSpec.describe 'rake spreadsheets:update', type: :task do
     expect { task.execute }.to have_enqueued_job(AddVacanciesToSpreadsheetJob)
   end
 
-  it 'queues the interest expression job' do
-    expect { task.execute }.to have_enqueued_job(AddAuditDataToSpreadsheetJob).with('interest_expression')
-  end
-
   it 'queues the subscription creation job' do
     expect { task.execute }.to have_enqueued_job(AddAuditDataToSpreadsheetJob).with('subscription_creation')
-  end
-
-  it 'queues the search event job' do
-    expect { task.execute }.to have_enqueued_job(AddAuditDataToSpreadsheetJob).with('search_event')
   end
 
   it 'queues the vacancy creation feedback job' do


### PR DESCRIPTION
These exports have been failing for several months now, causing out
of memory errors in the container they are run on:

```
Nov 25 01:05:43 Production ecs-agent 2019-11-25T01:05:42Z
[INFO] process within container 18c8e417918716434c0fccd70e72074e9ee6d8daba95b49f93cf3cde500e624a
(name: "ecs-tvs2_production_worker-121-tvs2productionweb-92aaede1cfc2faf49001") died due to OOM
```

We have agreed to continue collecting this information as it may
be useful for future analysis, but in the short term there is no
need for fixing the exporter.  Instead we could look at fixing
this once we move over to an alternative to Google Sheets.