### PR TITLE
Disable/enable radius filter selection when searching by location

### DIFF
--- a/app/assets/javascripts/enableRadiusFilter.js
+++ b/app/assets/javascripts/enableRadiusFilter.js
@@ -1,0 +1,7 @@
+$(document).on("turbolinks:load", function() {
+  if ($("#radius").is(":disabled")) {
+    $("#location").click(function() {
+      $("#radius").prop("disabled", false);
+    });
+  }
+});

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -1,7 +1,7 @@
 - content_for :advanced_filters do
   .govuk-form-group
     = label_tag 'radius', t('jobs.filters.radius'), class: 'govuk-label'
-    = select_tag 'radius', options_for_select(radius_filter_options, radius), class: 'govuk-select govuk-!-width-full'
+    = select_tag 'radius', options_for_select(radius_filter_options, radius), disabled: @filters.location_category_search?, class: 'govuk-select govuk-!-width-full'
   .govuk-form-group
     = label_tag 'subject', t('jobs.filters.subject'), class: 'govuk-label'
     = search_field_tag :subject, subject, class: 'govuk-input', placeholder: t('jobs.filters.subject_hint')

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -14,11 +14,11 @@ RSpec.feature 'Filtering vacancies' do
       allow(LocationCategory).to receive(:include?).with('enfield').and_return(false)
       expect(Geocoder).to receive(:coordinates).with('enfield')
                                                .and_return([51.6622925, -0.1180655])
-      enfield_vacancy = create(:vacancy, :published,
+      camden_vacancy = create(:vacancy, :published,
                                school: build(:school, name: 'St James School',
                                                       town: 'Enfield',
                                                       geolocation: '(51.6580645, -0.0448643)'))
-      penzance_vacancy = create(:vacancy, :published, school: build(:school, name: 'St James School',
+      victoria_vacancy = create(:vacancy, :published, school: build(:school, name: 'St James School',
                                                                              town: 'Penzance'))
 
       Vacancy.__elasticsearch__.client.indices.flush
@@ -30,8 +30,8 @@ RSpec.feature 'Filtering vacancies' do
         page.find('.govuk-button[type=submit]').click
       end
 
-      expect(page).to have_content(enfield_vacancy.job_title)
-      expect(page).not_to have_content(penzance_vacancy.job_title)
+      expect(page).to have_content(camden_vacancy.job_title)
+      expect(page).not_to have_content(victoria_vacancy.job_title)
     end
   end
 

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -14,11 +14,11 @@ RSpec.feature 'Filtering vacancies' do
       allow(LocationCategory).to receive(:include?).with('enfield').and_return(false)
       expect(Geocoder).to receive(:coordinates).with('enfield')
                                                .and_return([51.6622925, -0.1180655])
-      camden_vacancy = create(:vacancy, :published,
+      enfield_vacancy = create(:vacancy, :published,
                                school: build(:school, name: 'St James School',
                                                       town: 'Enfield',
                                                       geolocation: '(51.6580645, -0.0448643)'))
-      victoria_vacancy = create(:vacancy, :published, school: build(:school, name: 'St James School',
+      penzance_vacancy = create(:vacancy, :published, school: build(:school, name: 'St James School',
                                                                              town: 'Penzance'))
 
       Vacancy.__elasticsearch__.client.indices.flush
@@ -30,28 +30,48 @@ RSpec.feature 'Filtering vacancies' do
         page.find('.govuk-button[type=submit]').click
       end
 
-      expect(page).to have_content(camden_vacancy.job_title)
-      expect(page).not_to have_content(victoria_vacancy.job_title)
+      expect(page).to have_content(enfield_vacancy.job_title)
+      expect(page).not_to have_content(penzance_vacancy.job_title)
     end
   end
 
-  scenario 'search results can be filtered by the location category' do
-    london_region = Region.find_or_create_by(name: 'London')
-    camden_vacancy = create(:vacancy, :published,
-      school: build(:school, region: london_region, local_authority: 'Camden'))
-    victoria_vacancy = create(:vacancy, :published,
-      school: build(:school, region: london_region, local_authority: 'Victoria'))
-
-    Vacancy.__elasticsearch__.client.indices.flush
-    visit jobs_path
-
-    within '.filters-form' do
-      fill_in 'location', with: 'camden'
-      page.find('.govuk-button[type=submit]').click
+  context 'when filtering by a Location Category' do
+    let!(:london_region) { Region.find_or_create_by(name: 'London') }
+    let!(:camden_vacancy) do
+      create(:vacancy, :published,
+        school: build(:school, region: london_region, local_authority: 'Camden'))
     end
 
-    expect(page).to have_content(camden_vacancy.job_title)
-    expect(page).not_to have_content(victoria_vacancy.job_title)
+    let!(:victoria_vacancy) do
+      create(:vacancy, :published,
+        school: build(:school, region: london_region, local_authority: 'Victoria'))
+    end
+
+    before do
+      Vacancy.__elasticsearch__.client.indices.flush
+      visit jobs_path
+
+      within '.filters-form' do
+        fill_in 'location', with: 'camden'
+        page.find('.govuk-button[type=submit]').click
+      end
+    end
+
+    scenario 'search results returned have been filtered by the location category' do
+      expect(page).to have_content(camden_vacancy.job_title)
+      expect(page).not_to have_content(victoria_vacancy.job_title)
+    end
+
+    scenario 'radius filter is disabled' do
+      expect(page).to have_field('radius', disabled: true)
+    end
+
+    scenario 'radius filter is re-enabled when the location field is clicked', js: true do
+      expect(page).to have_field('radius', disabled: true)
+      page.find('#location').click
+
+      expect(page).to have_field('radius', disabled: false)
+    end
   end
 
   context 'with jobs with various job titles and subjects', elasticsearch: true do


### PR DESCRIPTION
When a user has performed a location category search, we want to disable the radius filter as they would receive all vacancies that fall within a given category for their location.
If the user wants to redefine their search e.g use a postcode or different location, the radius filter would be re-enabled upon clicking the location text field in JS-enabled browsers.
For JS-Disabled browsers, the user would have to click on the search button, the new search results page would have the radius filter enabled.

Jira ticket URL: https://dfedigital.atlassian.net/browse/TEVA-322?atlOrigin=eyJpIjoiMDNiY2Y5ZTc0OGVjNGQ0YThiYTc1YmU4MWIxYTMwZGUiLCJwIjoiaiJ9

## Screenshots of UI changes:

### When a location Category Search is done _(Note disabled Radius Button)_:
<img width="327" alt="Screenshot 2019-11-27 at 12 47 09" src="https://user-images.githubusercontent.com/32823756/69724658-43a31200-1114-11ea-93af-d38aa772d82c.png">

### When a user clicks the location field afterwards _(JS-enabled browsers)_:
<img width="333" alt="Screenshot 2019-11-27 at 12 47 32" src="https://user-images.githubusercontent.com/32823756/69724746-6b927580-1114-11ea-8560-cc86b8de0eb2.png">

## Next steps:
- [ ] Add content change for location category results
- [ ] Check it works on the Staging environment