### PR TITLE
Increase page size for users endpoint in DSI:API gateway

### DIFF
--- a/lib/dfe_sign_in_api.rb
+++ b/lib/dfe_sign_in_api.rb
@@ -4,7 +4,7 @@ module DFESignIn
   class UnknownResponseError < StandardError; end
 
   class API
-    USERS_PAGE_SIZE = 25
+    USERS_PAGE_SIZE = 100
     APPROVERS_PAGE_SIZE = 1000
 
     def users(page: 1)

--- a/lib/dsi_api_response_to_spreadsheet.rb
+++ b/lib/dsi_api_response_to_spreadsheet.rb
@@ -15,14 +15,10 @@ class DsiAPIResponseToSpreadsheet
 
       rows = response_to_rows(response)
       @worksheet.append_rows(rows)
-
-    rescue StandardError => e
-      Rails.logger.warn("DSI API #{endpoint} failed to respond at page #{page} with error: #{e.message}")
-      raise
     end
   rescue StandardError => e
     Rails.logger.warn("DSI API #{endpoint} failed to respond with error: #{e.message}")
-    raise
+    raise format_error(e, endpoint)
   end
 
   private
@@ -40,5 +36,9 @@ class DsiAPIResponseToSpreadsheet
 
   def error_message_for(response)
     response['message'] || 'failed request'
+  end
+
+  def format_error(error, endpoint)
+    "#{error.message}, while writing data from DSI #{endpoint} endpoint. Flag this to Steven + Comms team"
   end
 end

--- a/spec/support/shared_examples/dsi_api_response_to_spreadheet.rb
+++ b/spec/support/shared_examples/dsi_api_response_to_spreadheet.rb
@@ -96,7 +96,7 @@ RSpec.shared_examples 'a DFE API response to spreadsheet' do
         expect(dfe_sign_in_api).not_to receive(endpoint).with(page: 3)
 
         expect { subject.send("all_service_#{endpoint}".to_sym) }
-        .to raise_error(DFESignIn::ExternalServerError)
+        .to raise_error(RuntimeError, /DFESignIn::ExternalServerError, while writing data from DSI #{endpoint}/)
       end
 
       scenario 'when there is a error response, logs the error message and re-raises the error' do
@@ -105,14 +105,13 @@ RSpec.shared_examples 'a DFE API response to spreadsheet' do
         stub_dsi_api_response_error_for_page(2)
         stub_spreadsheet_writer
 
-        expect(Rails.logger).to receive(:warn).with("DSI API #{endpoint} failed to respond at page 2 " \
-        'with error: DFESignIn::ExternalServerError')
         expect(Rails.logger).to receive(:warn)
         .with("DSI API #{endpoint} failed to respond with error: DFESignIn::ExternalServerError")
 
         expect(worksheet).to receive(:append_rows).once
 
-        expect { subject.send("all_service_#{endpoint}".to_sym) }.to raise_error(DFESignIn::ExternalServerError)
+        expect { subject.send("all_service_#{endpoint}".to_sym) }
+        .to raise_error(RuntimeError, /DFESignIn::ExternalServerError, while writing data from DSI #{endpoint}/)
       end
 
       scenario 'when there is a missing key, it returns null for the field' do


### PR DESCRIPTION
With the current page size(25) it takes 4hours+ to complete the spreadsheet writer task. The endpoint has a limitation of maximum 100 records per page. Updating the page size will reduce the duration of `dsi_users_to_spreadsheet` task.