### PR TITLE
Add specific headings for location category search result pages

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -8,6 +8,8 @@ module VacanciesHelper
     '£70,000' => 70000
   }.freeze
 
+  WORD_EXCEPTIONS = ['and', 'the', 'of', 'upon'].freeze
+
   def working_pattern_options
     Vacancy::WORKING_PATTERN_OPTIONS.map do |key, _value|
       [Vacancy.human_attribute_name("working_patterns.#{key}"), key]
@@ -82,5 +84,15 @@ module VacanciesHelper
 
   def nqt_suitable_checked?(newly_qualified_teacher)
     newly_qualified_teacher == 'true'
+  end
+
+  def format_location_name(location)
+    uncapitalize_words(location.titleize)
+  end
+
+  def uncapitalize_words(location_name)
+    array = location_name.split(' ')
+    array.map! { |word| WORD_EXCEPTIONS.include?(word.downcase) ? word.downcase : word }
+    array.join(' ')
   end
 end

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -38,6 +38,12 @@ class VacanciesPresenter < BasePresenter
     end
   end
 
+  def total_count_message_with_location(location)
+    return I18n.t('jobs.job_count_with_location_category', count: total_count, location: location) if total_count == 1
+    I18n.t('jobs.job_count_plural_with_location_category', \
+      count: number_with_delimiter(total_count), location: location)
+  end
+
   def apply_filters_button_text
     if @searched == true
       I18n.t('buttons.apply_filters_if_criteria')

--- a/app/views/vacancies/index.html+phone.haml
+++ b/app/views/vacancies/index.html+phone.haml
@@ -1,4 +1,7 @@
-- content_for :page_title_prefix, t('jobs.heading')
+- if @filters.location_category_search?
+  = content_for :page_title_prefix, t('jobs.location_search_heading', location: format_location_name(@filters.location))
+- else
+  = content_for :page_title_prefix, t('jobs.heading')
 = render partial: 'head_links'
 
 %h1.govuk-heading-xl
@@ -9,7 +12,7 @@
 
   .govuk-grid-column-two-thirds
     .govuk-grid-column-full.vacancies-count{class: @vacancies.user_search? ? 'search-made' : ''}
-      %p.govuk-heading-l.mb0= @vacancies.total_count_message
+      %p.govuk-heading-l.mb0= @filters.location_category_search? ? @vacancies.total_count_message_with_location(format_location_name(@filters.location)) : @vacancies.total_count_message
       - if @vacancies.user_search?
         %span.clear-search.nobreak= link_to t('jobs.filters.clear_filters'), root_path, class: 'govuk-link'
         = render(partial: 'subscribe_link', locals: { search_criteria: @filters.only_active_to_hash }) if EmailAlertsFeature.enabled?

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -1,4 +1,7 @@
-- content_for :page_title_prefix, t('jobs.heading')
+- if @filters.location_category_search?
+  = content_for :page_title_prefix, t('jobs.location_search_heading', location: format_location_name(@filters.location))
+- else
+  = content_for :page_title_prefix, t('jobs.heading')
 = render partial: 'head_links'
 
 %h1.govuk-heading-xl
@@ -8,7 +11,7 @@
     = render 'filters'
   .govuk-grid-column-two-thirds
     .govuk-grid-column-full.vacancies-count{class: @vacancies.user_search? ? 'search-made' : ''}
-      %p.govuk-heading-l.mt0.mb1.inline-block#vacancy-results= @vacancies.total_count_message
+      %p.govuk-heading-l.mt0.mb1.inline-block#vacancy-results= @filters.location_category_search? ? @vacancies.total_count_message_with_location(format_location_name(@filters.location)) : @vacancies.total_count_message
       - if @vacancies.user_search?
         %span.clear-search.nobreak= link_to t('jobs.filters.clear_filters'), root_path, class: 'govuk-link'
         = render(partial: 'subscribe_link', locals: { search_criteria: @filters.only_active_to_hash }) if EmailAlertsFeature.enabled?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,7 @@ en:
         expires_on: 'For example, 01 08 2020'
   jobs:
     heading: 'Find a job in teaching'
+    location_search_heading: 'Teaching jobs in %{location}'
     sort_by: 'Sort by:'
     sort_submit: 'Sort'
     key_info: 'Key information'
@@ -121,6 +122,8 @@ en:
     job_count_plural_without_search: 'There are %{count} jobs listed.'
     job_count: '%{count} job matches your search.'
     job_count_plural: '%{count} jobs match your search.'
+    job_count_with_location_category: '%{count} teaching job in %{location}.'
+    job_count_plural_with_location_category: '%{count} teaching jobs in %{location}.'
     no_jobs:
       - 'Expanding your search may give more results.'
       - 'There may be few jobs if this isn’t a busy period in the teacher recruitment cycle.'

--- a/spec/features/job_seekers_can_view_location_categories_landing_pages_spec.rb
+++ b/spec/features/job_seekers_can_view_location_categories_landing_pages_spec.rb
@@ -1,20 +1,46 @@
 require 'rails_helper'
 
-RSpec.feature 'Viewing a location category landing page' do
-  scenario 'search results can be filtered by the location category' do
-    allow(LocationCategory).to receive(:include?).with('camden').and_return(true)
-
-    london_region = Region.find_or_create_by(name: 'London')
-    camden_vacancy = create(:vacancy, :published,
+RSpec.feature 'Viewing a location category landing page', elasticsearch: true do
+  let!(:london_region) { Region.find_or_create_by(name: 'London') }
+  let!(:camden_vacancy) do
+    create(:vacancy, :published,
       school: build(:school, region: london_region, local_authority: 'Camden'))
-    victoria_vacancy = create(:vacancy, :published,
-      school: build(:school, region: london_region, local_authority: 'Victoria'))
+  end
+  let!(:kensington_vacancy_one) do
+    create(:vacancy, :published,
+      school: build(:school, region: london_region, local_authority: 'Kensington and Chelsea'))
+  end
 
+  let!(:kensington_vacancy_two) do
+    create(:vacancy, :published,
+      school: build(:school, region: london_region, local_authority: 'Kensington and Chelsea'))
+  end
+
+  before(:each) do
+    allow(LocationCategory).to receive(:include?).with('camden').and_return(true)
+    allow(LocationCategory).to receive(:include?).with('kensington and chelsea').and_return(true)
     Vacancy.__elasticsearch__.client.indices.flush
+  end
 
+  scenario 'only results that fall within the location category are displayed' do
     visit location_category_path('camden')
 
     expect(page).to have_content(camden_vacancy.job_title)
-    expect(page).to_not have_content(victoria_vacancy.job_title)
+    expect(page).to_not have_content(kensington_vacancy_one.job_title)
+    expect(page).to_not have_content(kensington_vacancy_two.job_title)
+  end
+
+  scenario 'a specific heading for the landing page is displayed' do
+    visit location_category_path('camden')
+    expect(page).to have_content('1 teaching job in Camden.')
+
+    visit location_category_path('kensington and chelsea')
+    expect(page).to have_content('2 teaching jobs in Kensington and Chelsea.')
+  end
+
+  scenario 'a specific page title for the landing page is displayed' do
+    visit location_category_path('camden')
+
+    expect(page).to have_title('Teaching jobs in Camden')
   end
 end


### PR DESCRIPTION
When a user searches by a location category, we want to display specific landing pages for specific location categories.
This commit edits the heading on the page to be specific as a step towards this.

## Screenshots of UI changes:

### Before
<img width="1005" alt="Screenshot 2019-11-27 at 18 42 33" src="https://user-images.githubusercontent.com/32823756/69750934-e758e600-1145-11ea-9023-c4d68aee870d.png">

### After
<img width="1047" alt="Screenshot 2019-11-27 at 18 35 56" src="https://user-images.githubusercontent.com/32823756/69750957-f50e6b80-1145-11ea-8755-ec3436d63d1f.png">

<img width="1002" alt="Screenshot 2019-11-27 at 18 35 41" src="https://user-images.githubusercontent.com/32823756/69750964-fc357980-1145-11ea-8e34-3faa7fc4524d.png">


## Next steps:

- [ ] Check on Staging