### PR TITLE
(chore) set DSI users endpoint page size to 1000

### DIFF
--- a/lib/dfe_sign_in_api.rb
+++ b/lib/dfe_sign_in_api.rb
@@ -4,7 +4,7 @@ module DFESignIn
   class UnknownResponseError < StandardError; end
 
   class API
-    USERS_PAGE_SIZE = 100
+    USERS_PAGE_SIZE = 1000
     APPROVERS_PAGE_SIZE = 1000
 
     def users(page: 1)


### PR DESCRIPTION
The DSI team upgraded the users endpoint page size to 1000. We want to
process the data returned from the users endpoint faster so returning
more records per page was the fastest way to do this.
