### PR TITLE
(chore) upgrade puma to 4.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 
 gem 'rails', '~> 5.2.3'
 
-gem 'puma', '~> 3.12'
+gem 'puma', '~> 4.0'
 gem 'pg', '~> 1.1'
 gem 'elasticsearch-model'
 gem 'faraday_middleware-aws-signers-v4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,8 @@ GEM
       i18n (>= 0.5.0)
       railties (>= 3.0.0)
     public_suffix (3.1.1)
-    puma (3.12.0)
+    puma (4.3.0)
+      nio4r (~> 2.0)
     rack (2.0.7)
     rack-oauth2 (1.9.3)
       activesupport
@@ -550,7 +551,7 @@ DEPENDENCIES
   poltergeist
   pry
   public_activity
-  puma (~> 3.12)
+  puma (~> 4.0)
   rack_session_access
   rails (~> 5.2.3)
   rails-controller-testing (~> 1.0)


### PR DESCRIPTION
The recent upgrade to ruby 2.6.5 caused issues with the self signed
certificate that we're using on the https localhost for local dev work.
Upgrading puma to the latest version fixes this error.

- [ ] New development configuration to be shared - `bin/drebuild` required
