### PR TITLE
(chore) add location category links to start page

### DIFF
--- a/app/views/pages/home/_location_categories.html.haml
+++ b/app/views/pages/home/_location_categories.html.haml
@@ -1,13 +1,13 @@
-%h1.govuk-heading-xl Explore teaching jobs by location
+%h1.govuk-heading-xl #{ t('.location_links_heading') }
 .govuk-grid-row
   .govuk-grid-column-one-half
-    %h2.govuk-heading-m English counties
+    %h2.govuk-heading-m #{ t('.counties') }
     %ul.govuk-list
       - LocationCategory.counties.each do | county |
         %li
           = link_to county, location_category_path(county), class: 'govuk-link'
   .govuk-grid-column-one-half 
-    %h2.govuk-heading-m London boroughs
+    %h2.govuk-heading-m #{ t('.boroughs') }
     %ul.govuk-list
       - LocationCategory.boroughs.each do | borough |
         %li

--- a/app/views/pages/home/_location_categories.html.haml
+++ b/app/views/pages/home/_location_categories.html.haml
@@ -1,4 +1,4 @@
-%h1.govuk-heading-xl #{ t('.location_links_heading') }
+%h1.govuk-heading-l #{ t('.location_links_heading') }
 .govuk-grid-row
   .govuk-grid-column-one-half
     %h2.govuk-heading-m #{ t('.counties') }

--- a/app/views/pages/home/_location_categories.html.haml
+++ b/app/views/pages/home/_location_categories.html.haml
@@ -1,1 +1,14 @@
-%h1.govuk-heading-xl Location Categories
+%h1.govuk-heading-xl Explore teaching jobs by location
+.govuk-grid-row
+  .govuk-grid-column-one-half
+    %h2.govuk-heading-m English counties
+    %ul.govuk-list
+      - LocationCategory.counties.each do | county |
+        %li
+          = link_to county, location_category_path(county), class: 'govuk-link'
+  .govuk-grid-column-one-half 
+    %h2.govuk-heading-m London boroughs
+    %ul.govuk-list
+      - LocationCategory.boroughs.each do | borough |
+        %li
+          = link_to borough, location_category_path(borough), class: 'govuk-link'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,11 @@ en:
       page_description: Find out what personal information Teaching Vacancies collects, how it is used, how long it is kept and what your data protection rights are.
     terms-and-conditions:
       page_description: Read Teaching Vacancies' terms of use for jobseekers and schools. You must agree to these to use the service.
+    home:
+      location_categories:
+        location_links_heading: Explore teaching jobs by location
+        counties: English counties
+        boroughs: London boroughs
   sign_in:
     title: 'Sign in to Teaching Vacancies'
     link: 'Sign in'


### PR DESCRIPTION
We want users of the service to land on the start page and be able to
easily search for jobs within a county or london borough. To achieve
this we added links to the start page via a partial.

## Screenshots of UI changes:

<img width="668" alt="Screenshot 2019-12-04 at 16 44 59" src="https://user-images.githubusercontent.com/47317567/70162374-766d7d00-16b5-11ea-9d23-d912d54ff874.png">
