### PR TITLE
(Fix) Insert Vacancies without a Subject

### DIFF
--- a/lib/export_vacancy_records_to_big_query.rb
+++ b/lib/export_vacancy_records_to_big_query.rb
@@ -106,6 +106,8 @@ class ExportVacancyRecordsToBigQuery
   end
 
   def subjects(vacancy)
+    return [] if vacancy.subject.nil?
+
     subjects = [vacancy.subject]
     subjects << vacancy.first_supporting_subject if vacancy.first_supporting_subject
     subjects << vacancy.second_supporting_subject if vacancy.second_supporting_subject

--- a/spec/lib/export_vacancy_records_to_big_query_spec.rb
+++ b/spec/lib/export_vacancy_records_to_big_query_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe ExportVacancyRecordsToBigQuery do
     let(:dataset_stub) { instance_double('Google::Cloud::Bigquery::Dataset') }
 
     context 'with one vacancy' do
-      let(:vacancy) { create(:vacancy).reload }
-
       let(:expected_table_data) do
         [
           {
@@ -55,7 +53,19 @@ RSpec.describe ExportVacancyRecordsToBigQuery do
       ]
       end
 
+      context 'with no subjects' do
+        let(:vacancy) { create(:vacancy, subject: nil).reload }
+        let(:subjects) { [] }
+
+        it 'inserts into big query with no subject' do
+          expect(dataset_stub).to receive(:insert).with('vacancies', expected_table_data, autocreate: true)
+
+          subject.run!
+        end
+      end
+
       context 'with only one subject' do
+        let(:vacancy) { create(:vacancy).reload }
         let(:subjects) { [vacancy.subject.name] }
 
         it 'inserts into big query with one subject' do


### PR DESCRIPTION
This change adds a return statement to the `subjects` method. This would return `[]` in the case of a vacancy without a subject.