### PR TITLE
Add '&.' on values that could return nil

### DIFF
--- a/lib/export_vacancy_records_to_big_query.rb
+++ b/lib/export_vacancy_records_to_big_query.rb
@@ -72,14 +72,14 @@ class ExportVacancyRecordsToBigQuery
         starts_on: v.starts_on,
         ends_on: v.ends_on,
         subjects: subjects(v),
-        min_pay_scale: v.min_pay_scale.label,
-        max_pay_scale: v.max_pay_scale.label,
+        min_pay_scale: v.min_pay_scale&.label,
+        max_pay_scale: v.max_pay_scale&.label,
         leadership: v.leadership&.title,
         education: v.education,
         qualifications: v.qualifications,
         experience: v.experience,
         status: v.status,
-        expiry_time: format_date(v.expiry_time), # TODO: Combine 2 fields
+        expiry_time: format_date(v.expiry_time),
         publish_on: format_date(v.publish_on),
         school: {
           urn: v.school.urn,

--- a/spec/lib/export_vacancy_records_to_big_query_spec.rb
+++ b/spec/lib/export_vacancy_records_to_big_query_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe ExportVacancyRecordsToBigQuery do
           starts_on: vacancy.starts_on,
           ends_on: vacancy.ends_on,
           subjects: subjects,
-          min_pay_scale: vacancy.min_pay_scale.label,
-          max_pay_scale: vacancy.max_pay_scale.label,
+          min_pay_scale: vacancy.min_pay_scale&.label,
+          max_pay_scale: vacancy.max_pay_scale&.label,
           leadership: vacancy.leadership&.title,
           education: vacancy.education,
           qualifications: vacancy.qualifications,
           experience: vacancy.experience,
           status: vacancy.status,
-          expiry_time: format_date(vacancy.expiry_time), # TODO: Combine 2 fields
+          expiry_time: format_date(vacancy.expiry_time),
           publish_on: format_date(vacancy.publish_on),
           school: {
             urn: vacancy.school.urn,


### PR DESCRIPTION
`min_pay_scale` and `max_pay_scale` are attributes of vacancies. If they are present, we want to get the label e.g `max_pay_scale.label` but this errors if `max_pay_scale` is nil.
This commit adds the safe operator on `min_pay_scale` and `max_pay_scale` so that nil is returned rather than an error.