### PR TITLE
Fix 3 issues with ExportVacancyRecordsToBigQuery Class

### DIFF
--- a/lib/export_vacancy_records_to_big_query.rb
+++ b/lib/export_vacancy_records_to_big_query.rb
@@ -79,7 +79,7 @@ class ExportVacancyRecordsToBigQuery
         qualifications: v.qualifications,
         experience: v.experience,
         status: v.status,
-        expiry_time: format_date(v.expiry_time),
+        expiry_time: expiry_time(v),
         publish_on: format_date(v.publish_on),
         school: {
           urn: v.school.urn,
@@ -103,6 +103,10 @@ class ExportVacancyRecordsToBigQuery
 
   def format_date(date)
     date.strftime('%FT%T%:z')
+  end
+
+  def expiry_time(vacancy)
+    vacancy.expiry_time || format_date(vacancy.expires_on)
   end
 
   def subjects(vacancy)

--- a/lib/export_vacancy_records_to_big_query.rb
+++ b/lib/export_vacancy_records_to_big_query.rb
@@ -114,9 +114,9 @@ class ExportVacancyRecordsToBigQuery
   end
 
   def subjects(vacancy)
-    return [] if vacancy.subject.nil?
+    subjects = []
 
-    subjects = [vacancy.subject]
+    subjects << vacancy.subject if vacancy.subject
     subjects << vacancy.first_supporting_subject if vacancy.first_supporting_subject
     subjects << vacancy.second_supporting_subject if vacancy.second_supporting_subject
 

--- a/lib/export_vacancy_records_to_big_query.rb
+++ b/lib/export_vacancy_records_to_big_query.rb
@@ -69,8 +69,8 @@ class ExportVacancyRecordsToBigQuery
         job_title: v.job_title,
         minimum_salary: v.minimum_salary,
         maximum_salary: v.maximum_salary,
-        starts_on: v.starts_on,
-        ends_on: v.ends_on,
+        starts_on: format_as_date(v.starts_on),
+        ends_on: format_as_date(v.ends_on),
         subjects: subjects(v),
         min_pay_scale: v.min_pay_scale&.label,
         max_pay_scale: v.max_pay_scale&.label,
@@ -80,7 +80,7 @@ class ExportVacancyRecordsToBigQuery
         experience: v.experience,
         status: v.status,
         expiry_time: expiry_time(v),
-        publish_on: format_date(v.publish_on),
+        publish_on: format_as_timestamp(v.publish_on),
         school: {
           urn: v.school.urn,
           county: v.school.county,
@@ -101,12 +101,16 @@ class ExportVacancyRecordsToBigQuery
   end
   # rubocop:enable Metrics/AbcSize
 
-  def format_date(date)
-    date.strftime('%FT%T%:z')
+  def format_as_date(date)
+    date&.strftime('%F')
+  end
+
+  def format_as_timestamp(datetime)
+    datetime&.strftime('%FT%T%:z')
   end
 
   def expiry_time(vacancy)
-    vacancy.expiry_time || format_date(vacancy.expires_on)
+    vacancy.expiry_time || format_as_timestamp(vacancy.expires_on)
   end
 
   def subjects(vacancy)

--- a/spec/lib/export_vacancy_records_to_big_query_spec.rb
+++ b/spec/lib/export_vacancy_records_to_big_query_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 require 'export_vacancy_records_to_big_query'
 
+RSpec.shared_examples 'a successful Big Query export' do
+  it 'inserts into the dataset' do
+    expect(dataset_stub).to receive(:insert).with('vacancies', expected_table_data, autocreate: true)
+
+    subject.run!
+  end
+end
+
 RSpec.describe ExportVacancyRecordsToBigQuery do
   describe '#run!' do
     before do
@@ -59,15 +67,11 @@ RSpec.describe ExportVacancyRecordsToBigQuery do
       ]
       end
 
-      context 'when dealing with an old vacancy that has no expiry_time' do
+      context 'with no expiry_time' do
         let(:vacancy) { create(:vacancy, :with_no_expiry_time).reload }
         let(:expiry_time) { format_date_as_timestamp(vacancy.expires_on) }
 
-        it 'inserts into big query with the expires_on' do
-          expect(dataset_stub).to receive(:insert).with('vacancies', expected_table_data, autocreate: true)
-
-          subject.run!
-        end
+        it_behaves_like 'a successful Big Query export'
       end
 
       context 'when there is a starts_on and ends_on' do
@@ -75,43 +79,27 @@ RSpec.describe ExportVacancyRecordsToBigQuery do
         let(:starts_on) { vacancy.starts_on.strftime('%F') }
         let(:ends_on) { vacancy.ends_on.strftime('%F') }
 
-        it 'inserts into big query with the expires_on' do
-          expect(dataset_stub).to receive(:insert).with('vacancies', expected_table_data, autocreate: true)
-
-          subject.run!
-        end
+        it_behaves_like 'a successful Big Query export'
       end
 
       context 'when a vacancy has no publish_on date' do
         let(:vacancy) { create(:vacancy, publish_on: nil).reload }
         let(:publish_on) { nil }
 
-        it 'inserts into big query with publish_on set as nil' do
-          expect(dataset_stub).to receive(:insert).with('vacancies', expected_table_data, autocreate: true)
-
-          subject.run!
-        end
+        it_behaves_like 'a successful Big Query export'
       end
 
       context 'with no subjects' do
         let(:vacancy) { create(:vacancy, subject: nil).reload }
         let(:subjects) { [] }
 
-        it 'inserts into big query with no subject' do
-          expect(dataset_stub).to receive(:insert).with('vacancies', expected_table_data, autocreate: true)
-
-          subject.run!
-        end
+        it_behaves_like 'a successful Big Query export'
       end
 
       context 'with only one subject' do
         let(:vacancy) { create(:vacancy).reload }
 
-        it 'inserts into big query with one subject' do
-          expect(dataset_stub).to receive(:insert).with('vacancies', expected_table_data, autocreate: true)
-
-          subject.run!
-        end
+        it_behaves_like 'a successful Big Query export'
       end
 
       context 'with multiple subjects' do
@@ -120,11 +108,7 @@ RSpec.describe ExportVacancyRecordsToBigQuery do
           [vacancy.subject.name, vacancy.first_supporting_subject.name, vacancy.second_supporting_subject.name]
         end
 
-        it 'inserts into big query with multiple subjects' do
-          expect(dataset_stub).to receive(:insert).with('vacancies', expected_table_data, autocreate: true)
-
-          subject.run!
-        end
+        it_behaves_like 'a successful Big Query export'
       end
     end
 


### PR DESCRIPTION
These are changes to fix
* Vacancies without an expiry_time
* Vacancies without a publish_on
* Vacancies without a starts_on (or ends_on)

that were found whilst running `ExportVacancyRecordsToBigQuery` on staging data.