### PR TITLE
(chore) remove Avon and West Midlands from list

### DIFF
--- a/app/models/location_category.rb
+++ b/app/models/location_category.rb
@@ -2,7 +2,7 @@ class LocationCategory
   class << self
     OUT_OF_SCOPE_REGIONS = ['Wales (pseudo)', 'Not Applicable']
     LONDON_REGION = 'London'
-    OUT_OF_SCOPE_COUNTIES = ['Powys', 'Blaenau Gwent']
+    OUT_OF_SCOPE_COUNTIES = ['Powys', 'Blaenau Gwent', 'Avon', 'West Midlands']
 
     def include?(location)
       ALL_LOCATION_CATEGORIES.include?(location.downcase)

--- a/lib/tasks/data/counties.yml
+++ b/lib/tasks/data/counties.yml
@@ -1,5 +1,4 @@
 ---
-- Avon
 - Bedfordshire
 - Berkshire
 - Bristol
@@ -48,7 +47,6 @@
 - Teesside
 - Tyne and Wear
 - Warwickshire
-- West Midlands
 - West Sussex
 - West Yorkshire
 - Wiltshire

--- a/spec/features/application_sitemap_spec.rb
+++ b/spec/features/application_sitemap_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Application sitemap', sitemap: true do
       document = Nokogiri::XML::Document.parse(body)
       nodes = document.search('url')
 
-      expect(nodes.count).to eq(106)
+      expect(nodes.count).to eq(104)
       expect(nodes.search("loc[text()='#{root_url(protocol: 'https')}']").text)
         .to eq(root_url(protocol: 'https'))
 


### PR DESCRIPTION
Avon is not a county and West Midlands is a region so these were not
valid counties for location category searches.