### PR TITLE
Make school county nullable in Big Query

### DIFF
--- a/lib/export_vacancy_records_to_big_query.rb
+++ b/lib/export_vacancy_records_to_big_query.rb
@@ -34,7 +34,7 @@ class ExportVacancyRecordsToBigQuery
 
         schema.record 'school', mode: :nullable do |school|
           school.string 'urn', mode: :required
-          school.string 'county', mode: :required
+          school.string 'county', mode: :nullable
         end
 
         schema.timestamp 'created_at', mode: :required


### PR DESCRIPTION
Some schools do not have a county associated with them.