### PR TITLE
Restrict dependabot to security updates, run daily

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,8 +3,14 @@ version: 1
 update_configs:
   - package_manager: "ruby:bundler"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "daily"
+    allowed_updates:
+      - match:
+          update_type: "security"
 
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "daily"
+    allowed_updates:
+      - match:
+          update_type: "security"


### PR DESCRIPTION
This is generating a lot of PRs and we don't have a good strategy for keeping up with them.
After we know what the load from security updates is like, we can consider putting in rules for other updates. 