### PR TITLE
Remove get more info click column

### DIFF
--- a/app/presenters/school_vacancy_presenter.rb
+++ b/app/presenters/school_vacancy_presenter.rb
@@ -6,12 +6,6 @@ class SchoolVacancyPresenter < BasePresenter
     model.total_pageviews || 0
   end
 
-  # rubocop:disable Naming/AccessorMethodName
-  def get_more_info_clicks
-    model.total_get_more_info_clicks || 0
-  end
-  # rubocop:enable Naming/AccessorMethodName
-
   def publish_on
     format_date(model.publish_on)
   end

--- a/app/views/hiring_staff/schools/_vacancies_expired.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_expired.html.haml
@@ -10,7 +10,6 @@
                     %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), 'expired', column: 'publish_on', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.expired_on'), 'expired', column: 'expires_on', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.page_views'), 'expired', column: 'total_pageviews', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.get_more_info_clicks'), 'expired', column: 'total_get_more_info_clicks', sort: @sort)
                     %th.govuk-table__header{ colspan: 2 }= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.vacancies.each do |vacancy|

--- a/app/views/hiring_staff/schools/_vacancies_published.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_published.html.haml
@@ -9,7 +9,6 @@
                     %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), 'published', column: 'publish_on', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.expires_on'), 'published', column: 'expires_on', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.page_views'), 'published', column: 'total_pageviews', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.get_more_info_clicks'), 'published', column: 'total_get_more_info_clicks', sort: @sort)
                     %th.govuk-table__header{ colspan: 3}= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.vacancies.each do |vacancy|

--- a/app/views/hiring_staff/schools/_vacancy_expired.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy_expired.html.haml
@@ -3,6 +3,5 @@
   %td.govuk-table__cell= vacancy.publish_on
   %td.govuk-table__cell= vacancy.expires_on
   %td.govuk-table__cell= vacancy.page_views
-  %td.govuk-table__cell= vacancy.get_more_info_clicks
   %td.govuk-table__cell= link_to t('jobs.copy_link'), vacancy.copy_path, class: 'govuk-link', method: :get
   %td.govuk-table__cell= link_to t('jobs.delete_link'), vacancy.delete_path, class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/app/views/hiring_staff/schools/_vacancy_published.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy_published.html.haml
@@ -3,7 +3,6 @@
   %td.govuk-table__cell= vacancy.publish_on
   %td.govuk-table__cell= vacancy.expires_on
   %td.govuk-table__cell= vacancy.page_views
-  %td.govuk-table__cell= vacancy.get_more_info_clicks
   %td.govuk-table__cell= link_to t('jobs.edit_link'), vacancy.edit_path, class: 'govuk-link'
   %td.govuk-table__cell= link_to t('jobs.copy_link'), vacancy.copy_path, class: 'govuk-link', method: :get
   %td.govuk-table__cell= link_to t('jobs.delete_link'), vacancy.delete_path, class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/spec/features/hiring_staff_can_see_vacancy_statistics_spec.rb
+++ b/spec/features/hiring_staff_can_see_vacancy_statistics_spec.rb
@@ -39,24 +39,6 @@ RSpec.feature 'Hiring staff can see vacancy statistics' do
         end
       end
     end
-
-    context 'get more info clicks are nil' do
-      scenario 'page views show zero' do
-        within("tr#school_vacancy_presenter_#{vacancy.id}") do
-          expect(page.find('td[5]')).to have_content('0')
-        end
-      end
-    end
-
-    context 'get more info clicks are present' do
-      let(:total_get_more_info_clicks) { 100 }
-
-      scenario 'page views show the page view count' do
-        within("tr#school_vacancy_presenter_#{vacancy.id}") do
-          expect(page.find('td[5]')).to have_content(total_get_more_info_clicks)
-        end
-      end
-    end
   end
 
   context 'when vacancy is expired' do
@@ -88,24 +70,6 @@ RSpec.feature 'Hiring staff can see vacancy statistics' do
       scenario 'page views show the page view count' do
         within("tr#school_vacancy_presenter_#{vacancy.id}") do
           expect(page.find('td[4]')).to have_content(total_pageviews)
-        end
-      end
-    end
-
-    context 'get more info clicks are nil' do
-      scenario 'page views show zero' do
-        within("tr#school_vacancy_presenter_#{vacancy.id}") do
-          expect(page.find('td[5]')).to have_content('0')
-        end
-      end
-    end
-
-    context 'get more info clicks are present' do
-      let(:total_get_more_info_clicks) { 100 }
-
-      scenario 'page views show the page view count' do
-        within("tr#school_vacancy_presenter_#{vacancy.id}") do
-          expect(page.find('td[5]')).to have_content(total_get_more_info_clicks)
         end
       end
     end

--- a/spec/presenters/school_vacancy_presenter_spec.rb
+++ b/spec/presenters/school_vacancy_presenter_spec.rb
@@ -23,26 +23,6 @@ RSpec.describe SchoolVacancyPresenter do
     end
   end
 
-  describe 'get_more_info_clicks' do
-    let(:vacancy) { create(:vacancy, total_get_more_info_clicks: get_more_info_clicks) }
-
-    context 'when get more info clicks are present' do
-      let(:get_more_info_clicks) { 100 }
-
-      it 'returns the number' do
-        expect(presenter.get_more_info_clicks).to eq(get_more_info_clicks)
-      end
-    end
-
-    context 'when get more info clicks are not present' do
-      let(:get_more_info_clicks) { nil }
-
-      it 'returns zero' do
-        expect(presenter.get_more_info_clicks).to eq(0)
-      end
-    end
-  end
-
   describe 'application_deadline' do
     let(:vacancy) { create(:vacancy, expires_on: deadline_date, expiry_time: deadline_time) }
     let(:deadline_date) { Time.zone.today + 5.days }


### PR DESCRIPTION
## Changes in this PR:

Remove get more info clicks column from hiring staff dashboard - request from Isabelle, add some context in commit message
