### PR TITLE
Ignore public/assets and vendor/cache folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 
 /node_modules
 /yarn-error.log
+/public/assets
+/vendor/cache
 
 .byebug_history
 


### PR DESCRIPTION
These folders are used to deploy to GOV.UK PaaS and should be ignored.