### PR TITLE
Add `ExportVacancyRecordsToBigQuery` Job Class

### DIFF
--- a/app/jobs/export_vacancy_records_to_big_query_job.rb
+++ b/app/jobs/export_vacancy_records_to_big_query_job.rb
@@ -1,0 +1,9 @@
+require 'export_vacancy_records_to_big_query'
+
+class ExportVacancyRecordsToBigQueryJob < ApplicationJob
+  queue_as :export_vacancies
+
+  def perform
+    ExportVacancyRecordsToBigQuery.new.run!
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -18,6 +18,7 @@
   - [dsi_user_data, 1]
   - [dsi_approver_data, 1]
   - [seed_vacancies_from_api, 1]
+  - [export_vacancies, 1]
 update_vacancy_spreadsheet:
   :concurrency: 1
 audit_published_vacancy:
@@ -36,7 +37,7 @@ audit_subscription_creation:
   :concurrency: 1
 audit_spreadsheet:
   :concurrency: 1
-dsi_user_data: 
+dsi_user_data:
   :concurrency: 1
 dsi_approver_data:
   :concurrency: 1
@@ -44,3 +45,5 @@ mailers:
   :concurrency: 2
 seed_vacancies_from_api:
   :concurrency: 2
+export_vacancies:
+  :concurrency: 1

--- a/spec/jobs/export_vacancy_records_to_big_query_job_spec.rb
+++ b/spec/jobs/export_vacancy_records_to_big_query_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ExportVacancyRecordsToBigQueryJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the export_vacancies queue' do
+    expect(job.queue_name).to eq('export_vacancies')
+  end
+
+  it 'exports vacancy data to big query' do
+    export_vacancy_records_to_big_query = double(:export_vacancy_records_to_big_query)
+    expect(ExportVacancyRecordsToBigQuery).to receive(:new) { export_vacancy_records_to_big_query }
+    expect(export_vacancy_records_to_big_query).to receive(:run!)
+
+    perform_enqueued_jobs { job }
+  end
+end


### PR DESCRIPTION
We want to schedule when the vacancy records would be exported to Big Query.
As a first step, this commit introduces a job and adds it to the `sidekiq` configuration.