### PR TITLE
Re-enable radius when using current location link

### DIFF
--- a/app/assets/javascripts/fetch_location.js
+++ b/app/assets/javascripts/fetch_location.js
@@ -39,6 +39,7 @@ function postcodeFromPosition(position) {
     success: function(response) {
       if (response.result) {
         $('#location').val(response.result[0].postcode);
+        $("#radius").prop("disabled", false);
       }
     },
     error: function(xhr) {

--- a/spec/features/job_seekers_can_use_current_location_link_spec.rb
+++ b/spec/features/job_seekers_can_use_current_location_link_spec.rb
@@ -6,7 +6,11 @@ RSpec.feature 'Using the current location shortcut link', js: true do
   let(:dfe_lon) { -0.1323527 }
 
   before do
-    visit root_path
+    visit_path_with_simulated_location_api(root_path)
+  end
+
+  def visit_path_with_simulated_location_api(path)
+    visit path
     simulate_location
     page.execute_script "$('.js-location-finder').addClass('js-geolocation-supported');"
   end
@@ -44,6 +48,20 @@ RSpec.feature 'Using the current location shortcut link', js: true do
 
       find('#current-location').click
       expect(page).to have_field('location', with: 'SW1P 2LU')
+    end
+
+    context 'on location category page' do
+      before do
+        visit_path_with_simulated_location_api(location_category_path('camden'))
+      end
+
+      scenario 're-enables the radius field' do
+        mock_postcodes_io
+
+        expect(page).to have_field('radius', disabled: true)
+        find('#current-location').click
+        expect(page).to have_field('radius', disabled: false)
+      end
     end
   end
 


### PR DESCRIPTION
Previously users on a location category page were unable to
use the "Radius" field after clicking the "use your current location"
link as the field was disabled on the location catogory page load.

We want users to be able to select a non-default radius if they click
the link to use their current location.

## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-344

## Screenshots

### After fix

![radius_working](https://user-images.githubusercontent.com/47317567/71674439-167cfb80-2d73-11ea-88c7-3cd9d8d5dc15.gif)
