### PR TITLE
Give more guidance when there are no vacancies for a search

### DIFF
--- a/app/assets/stylesheets/components/vacancies-count.scss
+++ b/app/assets/stylesheets/components/vacancies-count.scss
@@ -1,20 +1,10 @@
 .vacancies-count {
   padding-left: 0;
 }
-.search-made {
-  padding: 15px;
-  margin-top: 0;
-  margin-bottom: 20px;
-  clear: both;
-  background-color: govuk-colour("light-grey");
-  border-left: 4px solid govuk-colour("light-grey");
-  p {
-    margin-bottom: 10px;
-  }
-  .job-seeker-alert-icon {
-    margin-right: 10px;
-    position: relative;
-    top: 2px;
-    left: 2px; 
-  }
+
+.job-seeker-alert-icon {
+  margin-right: 10px;
+  position: relative;
+  top: 2px;
+  left: 2px;
 }

--- a/app/views/vacancies/_subscribe_link.html.haml
+++ b/app/views/vacancies/_subscribe_link.html.haml
@@ -1,6 +1,7 @@
-%p.govuk-body
+.govuk-inset-text
   %span.job-seeker-alert-icon
     %svg{xmlns:"http://www.w3.org/2000/svg", width:"20", height:"16", viewBox:"0 0 20 16"}
       %path{d:"M18 0H2C.9 0 0 .9 0 2v12a2 2 0 0 0 2 2h16c1.1 0 2-.9 2-2V2a2 2 0 0 0-2-2zm-.4 4.25l-7.07 4.42c-.32.2-.74.2-1.06 0L2.4 4.25a.85.85 0 1 1 .9-1.44L10 7l6.7-4.19a.85.85 0 1 1 .9 1.44zm0 0", fill:"#0b0c0c"}
       %image{src: asset_path("job-seeker-alert-icon.png")}
-  = link_to t('subscriptions.button'), new_subscription_path(search_criteria: search_criteria), class: 'govuk-link'
+  = link_to t('subscriptions.link.text'), new_subscription_path(search_criteria: search_criteria), class: 'govuk-link'
+  = t('subscriptions.link.help_text')

--- a/app/views/vacancies/index.html+phone.haml
+++ b/app/views/vacancies/index.html+phone.haml
@@ -11,7 +11,7 @@
     = render 'filters', collapsible?: true
 
   .govuk-grid-column-two-thirds
-    .govuk-grid-column-full.vacancies-count{class: @vacancies.user_search? ? 'search-made' : ''}
+    .govuk-grid-column-full.vacancies-count
       %p.govuk-heading-l.mb0= @filters.location_category_search? ? @vacancies.total_count_message_with_location(format_location_name(@filters.location)) : @vacancies.total_count_message
       - if @vacancies.user_search?
         %span.clear-search.nobreak= link_to t('jobs.filters.clear_filters'), root_path, class: 'govuk-link'
@@ -22,5 +22,12 @@
       %ul.vacancies
         - @vacancies.each do |vacancy|
           = render partial: 'vacancy', locals: { vacancy: vacancy }
+
+    - elsif @vacancies.user_search?
+      %p
+        = t('jobs.no_jobs.intro')
+        %ul.govuk-list.govuk-list--bullet
+          - t('jobs.no_jobs.suggestions').each do |list_item|
+            %li= list_item
 
     = paginate @vacancies, window: 2

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -11,8 +11,8 @@
   .govuk-grid-column-one-third
     = render 'filters'
   .govuk-grid-column-two-thirds
-    .govuk-grid-column-full.vacancies-count{class: @vacancies.user_search? ? 'search-made' : ''}
-      %p.govuk-heading-l.mt0.mb1.inline-block#vacancy-results= location_category_content?(@filters) ? @vacancies.total_count_message_with_location(format_location_name(@filters.location)) : @vacancies.total_count_message
+    .govuk-grid-column-full.vacancies-count
+      %p.govuk-heading-l.mb0.inline-block#vacancy-results= location_category_content?(@filters) ? @vacancies.total_count_message_with_location(format_location_name(@filters.location)) : @vacancies.total_count_message
       - if @vacancies.user_search?
         %span.clear-search.nobreak= link_to t('jobs.filters.clear_filters'), root_path, class: 'govuk-link'
         = render(partial: 'subscribe_link', locals: { search_criteria: @filters.only_active_to_hash }) if EmailAlertsFeature.enabled?
@@ -24,9 +24,11 @@
           = render partial: 'vacancy', locals: { vacancy: vacancy }
 
     - elsif @vacancies.user_search?
-      %div.empty
-        - t('jobs.no_jobs').each do |list_item|
-          %p= list_item
+      %p
+        = t('jobs.no_jobs.intro')
+        %ul.govuk-list.govuk-list--bullet
+          - t('jobs.no_jobs.suggestions').each do |list_item|
+            %li= list_item
 
     - else
       %div.empty

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,8 +139,11 @@ en:
     job_count_with_location_category: '%{count} teaching job in %{location}.'
     job_count_plural_with_location_category: '%{count} teaching jobs in %{location}.'
     no_jobs:
-      - 'Expanding your search may give more results.'
-      - 'There may be few jobs if this isn’t a busy period in the teacher recruitment cycle.'
+      intro: 'You might find matching jobs by:'
+      suggestions:
+        - 'increasing the search radius'
+        - 'using less specific search terms'
+        - 'using fewer search terms or filters'
     none_listed:
       - 'This may be because this isn’t a busy period in the teacher recruitment cycle.'
       - 'Schools have listed %{count} jobs but they have since expired.'
@@ -383,7 +386,9 @@ en:
           - 'expected start date'
           - 'end date (for fixed-term jobs)'
   subscriptions:
-    button: 'Sign up for a job alert matching your search'
+    link:
+      text: 'Subscribe to a job alert.'
+      help_text: 'We’ll email you whenever a job matching this search is published.'
     intro: 'We’ll email you details of any new jobs that match the following search criteria:'
     new:
       page_description: Sign up for a job alert

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe VacanciesController, type: :controller do
 
         it 'shows the subscribe link' do
           get :index, params: { subject: 'English' }
-          expect(response.body).to match(I18n.t('subscriptions.button'))
+          expect(response.body).to match(I18n.t('subscriptions.link.text'))
         end
       end
 
@@ -161,7 +161,7 @@ RSpec.describe VacanciesController, type: :controller do
 
         it 'does not show the subscribe link' do
           get :index, params: { subject: 'English' }
-          expect(response.body).to_not match(I18n.t('subscriptions.button'))
+          expect(response.body).to_not match(I18n.t('subscriptions.link.text'))
         end
       end
     end

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
 
       expect(page).to have_content('3 jobs match your search')
 
-      click_on 'Sign up for a job alert matching your search'
+      click_on I18n.t('subscriptions.link.text')
 
       expect(page).to have_content(I18n.t('subscriptions.new.page_description'))
       expect(page).to have_content('Subject: English')

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -114,7 +114,7 @@ RSpec.feature 'Viewing vacancies' do
       click_on I18n.t('buttons.apply_filters')
     end
 
-    I18n.t('jobs.no_jobs').each do |sentence|
+    I18n.t('jobs.no_jobs.suggestions').each do |sentence|
       expect(page).to have_content(sentence)
     end
   end
@@ -125,7 +125,7 @@ RSpec.feature 'Viewing vacancies' do
     I18n.t('jobs.none_listed', count: Vacancy.listed.count).each do |sentence|
       expect(page).to have_content(sentence)
     end
-    expect(page).not_to have_content(I18n.t('jobs.no_jobs'))
+    expect(page).not_to have_content(I18n.t('jobs.no_jobs.suggestions'))
   end
 
   context 'when a page number is manually added to the URL which does not return results' do
@@ -163,7 +163,7 @@ RSpec.feature 'Viewing vacancies' do
       click_button('Search')
     end
 
-    I18n.t('jobs.no_jobs').each do |sentence|
+    I18n.t('jobs.no_jobs.suggestions').each do |sentence|
       expect(page).to have_content(sentence)
     end
 
@@ -173,7 +173,7 @@ RSpec.feature 'Viewing vacancies' do
 
     click_button('Refine search')
 
-    I18n.t('jobs.no_jobs').each do |sentence|
+    I18n.t('jobs.no_jobs.suggestions').each do |sentence|
       expect(page).to have_content(sentence)
     end
 

--- a/spec/smoke_test/job_seekers_can_view_homepage_spec.rb
+++ b/spec/smoke_test/job_seekers_can_view_homepage_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Page availability', js: true, smoke_test: true do
       page.fill_in I18n.t('jobs.filters.subject'), with: 'Maths', visible: false
       page.first('.govuk-button[type=submit]').click
 
-      expect(page).to have_content(I18n.t('subscriptions.button'))
+      expect(page).to have_content(I18n.t('subscriptions.link.text'))
 
       vacancy_page = page.first('.view-vacancy-link')
       unless vacancy_page.nil?


### PR DESCRIPTION
## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-143

## Changes in this PR:
The new guidance is more clear as to how a user could change their
search.

Also redesign the email subscription link, using an Inset text
element to give prominence to this action.  This was previously
a bit hidden with the custom styling we use.

## Screenshots of UI changes:

# Before
<img width="398" alt="Before, mobile no results" src="https://user-images.githubusercontent.com/976274/71897981-09d01d00-3150-11ea-8771-9e981bb0b8dc.png">

<img width="983" alt="Before, desktop no results" src="https://user-images.githubusercontent.com/976274/71898073-426ff680-3150-11ea-8b6e-50e7826fefbb.png">

<img width="997" alt="Before, desktop with results" src="https://user-images.githubusercontent.com/976274/71898130-70553b00-3150-11ea-9708-3f4c46e10d91.png">



# After
<img width="392" alt="After, mobile no results" src="https://user-images.githubusercontent.com/976274/71898020-21a7a100-3150-11ea-8701-2deeb1b551ca.png">

<img width="972" alt="After, desktop no results" src="https://user-images.githubusercontent.com/976274/71898093-54519980-3150-11ea-8743-d1908fb0a3bf.png">

<img width="986" alt="After, desktop with results" src="https://user-images.githubusercontent.com/976274/71898147-7e0ac080-3150-11ea-98c5-c90e2ccbf284.png">

