### PR TITLE
Filter out web crawlers visits from tracking.

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -46,7 +46,7 @@ class VacanciesController < ApplicationController
 
     @vacancy = VacancyPresenter.new(vacancy)
 
-    VacancyPageView.new(vacancy).track unless authenticated? || smoke_test?
+    VacancyPageView.new(vacancy).track unless non_tracked_visit?
 
     expires_in 5.minutes, public: true
   end
@@ -167,5 +167,9 @@ class VacanciesController < ApplicationController
 
   def audit_row
     { total_count: @vacancies.total_count }.merge(@filters.audit_hash)
+  end
+
+  def non_tracked_visit?
+    authenticated? || smoke_test? || browser.bot?
   end
 end

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -197,6 +197,20 @@ RSpec.describe VacanciesController, type: :controller do
       end
     end
 
+    context 'when the vacancy is visited by a robot' do
+      before { request.env['HTTP_USER_AGENT'] = 'Googlebot' }
+
+      let(:vacancy) { create(:vacancy) }
+      let(:params) { { id: vacancy.slug } }
+      let(:vacancy_page_view) { instance_double(VacancyPageView) }
+
+      it 'should not call the track method' do
+        expect(VacancyPageView).not_to receive(:new).with(vacancy)
+
+        subject
+      end
+    end
+
     context 'when using cookies' do
       let(:vacancy) { create(:vacancy) }
       let(:params) { { id: vacancy.slug } }


### PR DESCRIPTION
There was a large discrepancy found between the total number of page views, in the database and GA, for vacancies published in Autumn 2019.
Investigating the case based on the hypothesis that the value in the database was incorrect led to the discovery that our application’s in-built tracker did not ignore visits by web crawlers.
Given the number of both good and bad web crawlers, this could have contributed to inflating the total number of page views in the database.

This commit adds another condition for the tracker to verify before attempting to log the visit as a page view.
Any suggestion or feedback would be appreciated.

Jira ticket URL: https://dfedigital.atlassian.net/browse/TEVA-381