### PR TITLE
Add rake script to update subscriptions to new working pattern

### DIFF
--- a/lib/tasks/task-documentation.md
+++ b/lib/tasks/task-documentation.md
@@ -1,0 +1,17 @@
+# Task Documentation
+
+## update_subscriptions.rake
+
+This task was created to convert any subscriptions in the database with the old working pattern format to the new working pattern format as the format in which the subscriptions were stored were changed by this [Pull Request](https://github.com/DFE-Digital/teacher-vacancy-service/pull/1268). This was necessary as users would fail to recieve daily alert emails if their subscription included a working pattern.
+
+The old format for subscriptions meant the the working pattern in the search criteria was stored in a string format:
+`{"subject"=>"english", "working_pattern"=>"full_time"}`
+
+But the pull request referenced above changed the search criteria to be stored in an array format like the below:
+`{"subject"=>"english", "working_patterns"=>["full_time"]}`
+
+Notice that the key also changed from `working_pattern` to `working_patterns` to reflect the fact that users would be able to select multiple working patterns.
+
+The task is intended to only be run once when the pull request referenced above is merged in to Production.
+
+

--- a/lib/tasks/update_subscriptions.rake
+++ b/lib/tasks/update_subscriptions.rake
@@ -2,6 +2,8 @@ class UpdateSubscriptionsWithNewWorkingPatterns
   def self.run!
     Subscription.all.each do |s|
       search_criteria_hash = s.search_criteria_to_h
+      # Old format hash = {"subject"=>"english", "working_pattern"=>"full_time"}
+      # New format hash = {"subject"=>"english", "working_patterns"=>["full_time"]}
       search_criteria_hash.transform_keys! { |k| k.gsub(/working_pattern\b/, 'working_patterns') }
                           .transform_values! {
                             |v| search_criteria_hash.key(v) == 'working_patterns' && v.is_a?(String) ? [v] : v

--- a/lib/tasks/update_subscriptions.rake
+++ b/lib/tasks/update_subscriptions.rake
@@ -1,6 +1,5 @@
-namespace :subscription_records do
-  desc 'converts old working pattern subscriptions to array style'
-  task convert_subscriptions: :environment do
+class UpdateSubscriptionsWithNewWorkingPatterns
+  def self.run!
     Subscription.all.each do |s|
       search_criteria_hash = s.search_criteria_to_h
       search_criteria_hash.transform_keys! { |k| k.gsub(/working_pattern\b/, 'working_patterns') }
@@ -8,7 +7,15 @@ namespace :subscription_records do
                             |v| search_criteria_hash.key(v) == 'working_patterns' && v.is_a?(String) ? [v] : v
                           }
       s.search_criteria = search_criteria_hash.to_json
-      s.save
+      s.save!
     end
+  end
+end
+
+
+namespace :subscription_records do
+  desc 'converts old working pattern subscriptions to array style'
+  task convert_subscriptions: :environment do
+    UpdateSubscriptionsWithNewWorkingPatterns.run!
   end
 end

--- a/lib/tasks/update_subscriptions.rake
+++ b/lib/tasks/update_subscriptions.rake
@@ -1,0 +1,14 @@
+namespace :subscription_records do
+  desc 'converts old working pattern subscriptions to array style'
+  task convert_subscriptions: :environment do
+    Subscription.all.each do |s|
+      search_criteria_hash = s.search_criteria_to_h
+      search_criteria_hash.transform_keys! { |k| k.gsub(/working_pattern\b/, 'working_patterns') }
+                          .transform_values! {
+                            |v| search_criteria_hash.key(v) == 'working_patterns' && v.is_a?(String) ? [v] : v
+                          }
+      s.search_criteria = search_criteria_hash.to_json
+      s.save
+    end
+  end
+end

--- a/spec/lib/tasks/update_subscriptions_rake_spec.rb
+++ b/spec/lib/tasks/update_subscriptions_rake_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'subscription_records:convert_subscriptions', type: :task do
+  let!(:old_style_subscription) do
+    create(:subscription, frequency: :daily, search_criteria: { subject: 'english', working_pattern: 'full_time' }.to_json)
+  end
+  
+  let!(:new_style_subscription) do
+    create(:subscription, frequency: :daily, search_criteria: { subject: 'english', working_patterns: ['full_time', 'part_time'] }.to_json)
+  end
+
+  let!(:no_working_pattern_subscription) do
+    create(:subscription, frequency: :daily, search_criteria: { subject: 'english' }.to_json)    
+  end
+
+  let!(:nil_criteria_subscription) do
+    create(:subscription, frequency: :daily, search_criteria: nil)
+  end
+
+  before do
+    UpdateSubscriptionsWithNewWorkingPatterns.run!
+  end 
+
+  it 'Converts a string working pattern to an array working pattern in search criteria' do
+    search_criteria_hash = old_style_subscription.reload.search_criteria_to_h
+    expect(search_criteria_hash).to eq({"subject"=>"english", "working_patterns"=>["full_time"]})
+  end
+
+  it 'Does not make any changes to the search criteria of a new style working pattern subscription' do
+    search_criteria_hash = new_style_subscription.reload.search_criteria_to_h
+    expect(search_criteria_hash).to eq({"subject"=>"english", "working_patterns"=>["full_time","part_time"]})
+  end
+
+  it 'Does not make any changes to the search criteria of a subscription with no working pattern' do
+    search_criteria_hash = no_working_pattern_subscription.reload.search_criteria_to_h
+    expect(search_criteria_hash).to eq({"subject"=>"english"})
+  end
+
+  it 'Does not make any changes to a subscription with nil search criteria' do
+    search_criteria_hash = nil_criteria_subscription.reload.search_criteria_to_h
+    expect(search_criteria_hash).to eq({})
+  end
+end
+
+

--- a/spec/lib/tasks/update_subscriptions_rake_spec.rb
+++ b/spec/lib/tasks/update_subscriptions_rake_spec.rb
@@ -2,15 +2,19 @@ require 'rails_helper'
 
 RSpec.describe 'subscription_records:convert_subscriptions', type: :task do
   let!(:old_style_subscription) do
-    create(:subscription, frequency: :daily, search_criteria: { subject: 'english', working_pattern: 'full_time' }.to_json)
+    create(:subscription, frequency: :daily,
+      search_criteria: { subject: 'english', working_pattern: 'full_time' }.to_json
+    )
   end
-  
+
   let!(:new_style_subscription) do
-    create(:subscription, frequency: :daily, search_criteria: { subject: 'english', working_patterns: ['full_time', 'part_time'] }.to_json)
+    create(:subscription, frequency: :daily,
+      search_criteria: { subject: 'english', working_patterns: ['full_time', 'part_time'] }.to_json
+    )
   end
 
   let!(:no_working_pattern_subscription) do
-    create(:subscription, frequency: :daily, search_criteria: { subject: 'english' }.to_json)    
+    create(:subscription, frequency: :daily, search_criteria: { subject: 'english' }.to_json)
   end
 
   let!(:nil_criteria_subscription) do
@@ -19,21 +23,21 @@ RSpec.describe 'subscription_records:convert_subscriptions', type: :task do
 
   before do
     UpdateSubscriptionsWithNewWorkingPatterns.run!
-  end 
+  end
 
   it 'Converts a string working pattern to an array working pattern in search criteria' do
     search_criteria_hash = old_style_subscription.reload.search_criteria_to_h
-    expect(search_criteria_hash).to eq({"subject"=>"english", "working_patterns"=>["full_time"]})
+    expect(search_criteria_hash).to eq({ 'subject'=>'english', 'working_patterns'=>['full_time'] })
   end
 
   it 'Does not make any changes to the search criteria of a new style working pattern subscription' do
     search_criteria_hash = new_style_subscription.reload.search_criteria_to_h
-    expect(search_criteria_hash).to eq({"subject"=>"english", "working_patterns"=>["full_time","part_time"]})
+    expect(search_criteria_hash).to eq({ 'subject'=>'english', 'working_patterns'=>['full_time', 'part_time'] })
   end
 
   it 'Does not make any changes to the search criteria of a subscription with no working pattern' do
     search_criteria_hash = no_working_pattern_subscription.reload.search_criteria_to_h
-    expect(search_criteria_hash).to eq({"subject"=>"english"})
+    expect(search_criteria_hash).to eq({ 'subject'=>'english' })
   end
 
   it 'Does not make any changes to a subscription with nil search criteria' do


### PR DESCRIPTION
Subscriptions that currently exist in the database have the old style
of working pattern based on only being able to select one, however the
subscriptions code was update to handle arrays for working patterns as
we wanted users to be be able to search for multiple working patterns.
The result is that subscriptions created before the mutliple working
patterns change would no longer receive emails.

This change adds a rake task to update all the subscriptions in the
database to make themcompatible with the working pattern changes
(specifically those relatedto job alerts).