### PR TITLE
Index home page on root path

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :check_staging_auth, except: :check
   before_action :set_headers
   before_action :detect_device_format
+  before_action :set_root_headers
 
   include AuthenticationConcerns
   include Ip
@@ -68,6 +69,10 @@ class ApplicationController < ActionController::Base
     super
     payload[:remote_ip] = request_ip
     payload[:session_id] = "#{session.id[0..7]}…" if session.id
+  end
+
+  def set_root_headers
+    response.set_header('X-Robots-Tag', 'index, nofollow') if request.path == root_path
   end
 
   def set_headers

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,7 +6,7 @@ class PagesController < ApplicationController
   end
 
   def set_headers
-    return super if root_path? || page_path.include?('user-not-authorised')
+    return super if root_path? || page_path.include?('user-not-authorised') || page_path.include?('home')
 
     response.set_header('X-Robots-Tag', 'index, nofollow')
   end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe PagesController, type: :controller do
       it { should respond_with(:success) }
       it { should render_template(page) }
 
-      it 'should not have a noindex header, unless it is the unauthorised user page' do
-        if page == 'user-not-authorised'
+      it 'should not have a noindex header, unless it is the unauthorised user page or the home page' do
+        if page == 'user-not-authorised' || page == 'home'
           expect(response.headers['X-Robots-Tag']).to include('noindex')
         else
           expect(response.headers['X-Robots-Tag']).to_not include('noindex')

--- a/spec/features/job_seekers_can_view_home_page_spec.rb
+++ b/spec/features/job_seekers_can_view_home_page_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Viewing the home page' do
   before { visit page_path(:home) }
 
-  scenario 'searching from the blue box lands on the jobs index page' do
+  scenario 'searching from the blue box lands on the jobs index page', elasticsearch: true do
     within '.search_panel' do
       fill_in 'location', with: 'bristol'
       fill_in 'subject', with: 'math'
@@ -22,5 +22,12 @@ RSpec.feature 'Viewing the home page' do
     expect(page).to have_field('phases_primary', checked: true)
     expect(page).to have_field('phases_secondary', checked: true)
     expect(page).to have_field('phases_not_applicable', checked: false)
+  end
+
+  context 'request headers' do
+    scenario 'should not have a noindex header on the home page when visiting the root path' do
+      visit root_path
+      expect(response_headers['X-Robots-Tag']).to_not include('noindex')
+    end
   end
 end


### PR DESCRIPTION
When we switched over to the new homepage we introduced a bug where we
set a noindex header on the homepage - this was because the homepage was
accessible through two paths, the root path (/) and the home page path
(/pages/home), but we were setting the noindex header for both paths.
This was bad as it would negatively impact our visibility on search
engines.

This commit allows the home page to be indexed with the root path, but a
noindex header is still set on the home page path (/pages/home). Some
tests were also added to the test suite to test for this.
