### PR TITLE
Add missing towns and cities to home page

### DIFF
--- a/lib/tasks/data/cities.yml
+++ b/lib/tasks/data/cities.yml
@@ -31,3 +31,19 @@
 - Peterborough
 - Plymouth
 - Portsmouth
+- Preston
+- Ripon
+- Salford
+- Salisbury
+- Sheffield
+- Southampton
+- St Albans
+- Stoke-on-Trent
+- Sunderland
+- Truro
+- Wakefield
+- Wells
+- Winchester
+- Wolverhampton
+- Worcester
+- York

--- a/spec/features/application_sitemap_spec.rb
+++ b/spec/features/application_sitemap_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Application sitemap', sitemap: true do
       document = Nokogiri::XML::Document.parse(body)
       nodes = document.search('url')
 
-      expect(nodes.count).to eq(136)
+      expect(nodes.count).to eq(152)
       expect(nodes.search("loc[text()='#{root_url(protocol: 'https')}']").text)
         .to eq(root_url(protocol: 'https'))
 


### PR DESCRIPTION
The towns and cities list stopped at p by mistake. It now has all the
towns and cities it was meant to have.

## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-429

## Screenshots of UI changes:

### Before
![image](https://user-images.githubusercontent.com/47317567/72721079-2b2f0100-3b73-11ea-94ad-9c709f557cd5.png)

### After
![image](https://user-images.githubusercontent.com/47317567/72721058-20746c00-3b73-11ea-9bc4-b55e41087403.png)