### PR TITLE
Reorder README set-up instructions and make more detailed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,27 @@
 
 ### Setting up the project
 
-1. Copy the docker environment variables and fill in any missing secrets from the [secrets
-repository][secret-docker-compose]:
+1. Copy the docker environment variables:
 
 ```bash
-$ cp docker-compose.env.sample docker-compose.env
+cp docker-compose.env.sample docker-compose.env
 ```
 
-2. Build the docker container and set up the database
+2. Navigate to the secrets repository, and fill in any missing secrets from the [docker-compose.env.gpg][secret-docker-compose]:
+
+```
+bin/pass secrets/dev/docker-compose.env > path/to/teacher-vacancy-service/docker-compose.env
+```
+
+3. [Follow these instructions to configure HTTPS](config/localhost/https/README.md)
+
+4. Build the docker container, set up the database, and start the application at https://localhost:3000
 
 ```bash
 bin/drebuild
 ```
 
-3. [Follow these instructions to configure HTTPS](config/localhost/https/README.md)
-
-4. Start the application
+### Starting the application
 
 ```bash
 bin/dstart

--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ bin/pass secrets/dev/docker-compose.env > path/to/teacher-vacancy-service/docker
 bin/drebuild
 ```
 
+[secret-docker-compose]:
+https://github.com/DFE-Digital/teaching-vacancies-service-secrets/blob/master/secrets/dev/docker-compose.env.gpg
+[docs-to-read-secrets]:
+https://github.com/DFE-Digital/teaching-vacancies-service-secrets#reading-secrets
+
 ### Starting the application
 
 ```bash
 bin/dstart
 ```
-
-[secret-docker-compose]:
-https://github.com/DFE-Digital/teaching-vacancies-service-secrets/blob/master/secrets/dev/docker-compose.env.gpg
-[docs-to-read-secrets]:
-https://github.com/DFE-Digital/teaching-vacancies-service-secrets#reading-secrets
 
 ## User accounts & data
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 cp docker-compose.env.sample docker-compose.env
 ```
 
-2. Navigate to the secrets repository, and fill in any missing secrets from the [docker-compose.env.gpg][secret-docker-compose]:
+2. Navigate to the secrets repository, and [fill in][docs-to-read-secrets] any missing secrets from the [docker-compose.env.gpg][secret-docker-compose]. 
 
 ```
 bin/pass secrets/dev/docker-compose.env > path/to/teacher-vacancy-service/docker-compose.env
@@ -37,6 +37,8 @@ bin/dstart
 
 [secret-docker-compose]:
 https://github.com/DFE-Digital/teaching-vacancies-service-secrets/blob/master/secrets/dev/docker-compose.env.gpg
+[docs-to-read-secrets]:
+https://github.com/DFE-Digital/teaching-vacancies-service-secrets#reading-secrets
 
 ## User accounts & data
 


### PR DESCRIPTION
## Changes in this PR:

The set-up instructions had some lack of clarity for a new joiner.

**Reordering**: The https configuration needs to be done _before_ running `bin/rebuild`, because `bin/rebuild` runs `bin/dstart`.

**Adding**: Added instruction to copy from the secrets repo.

**Refactoring**: The instruction to start the application was redundant as `bin/rebuild` runs it, so I gave it its own section.

## Screenshots of UI changes:

### Before
<img width="804" alt="Screenshot 2020-01-30 at 18 16 27" src="https://user-images.githubusercontent.com/60350599/73477850-e5e9ab00-438c-11ea-8a60-d0c18e73fe8f.png">

### After
<img width="891" alt="Screenshot 2020-01-30 at 18 17 48" src="https://user-images.githubusercontent.com/60350599/73477813-db2f1600-438c-11ea-86a4-e4a4876c05f4.png">
