### PR TITLE
Removes end_of_day to show actual end time

### DIFF
--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -47,5 +47,5 @@ json.hiringOrganization do
   json.identifier vacancy.school.urn
 end
 
-json.validThrough vacancy.expires_on.end_of_day.to_time.iso8601
+json.validThrough vacancy.expires_on.to_time.iso8601
 json.workHours vacancy.weekly_hours if vacancy.weekly_hours?


### PR DESCRIPTION
The current result on the `validThrough` attribute always returns end of day. The UI, however, uses the expires on flag. This change will ensure that the date/time returned matches the UI.

Alternative suggestion would be to add an additional variable to show the vacancy expiry time.