### PR TITLE
removed job description column from vacancy csv

### DIFF
--- a/lib/export_tables_to_cloud_storage.rb
+++ b/lib/export_tables_to_cloud_storage.rb
@@ -41,7 +41,7 @@ class ExportTablesToCloudStorage
 
     TABLES.each do |table|
       file = Rails.root.join("tmp/csv_export/#{table.underscore}.csv")
-      records = table.constantize.all
+      table == 'Vacancy' ? records = vacancy_records_without_job_description : records = table.constantize.all
 
       next unless records.any?
 
@@ -66,5 +66,9 @@ class ExportTablesToCloudStorage
 
   def remove_csv_folder
     FileUtils.rm_rf(Rails.root.join('tmp/csv_export'))
+  end
+
+  def vacancy_records_without_job_description
+    Vacancy.select(Vacancy.column_names - ['job_description'].map(&:to_s))
   end
 end


### PR DESCRIPTION
Added a method to remove the job_description column when exporting the
vacancies table as a CSV to cloud storage. We did this as the job_description
column contained a lot of data and we suspect that data within the column
was preventing the exported vacancy.csv from being imported into bigquery

## Jira ticket URL:

https://dfedigital.atlassian.net/browse/TEVA-495
