### PR TITLE
Remove weekly hours from vacancy csv

### DIFF
--- a/lib/export_tables_to_cloud_storage.rb
+++ b/lib/export_tables_to_cloud_storage.rb
@@ -41,7 +41,7 @@ class ExportTablesToCloudStorage
 
     TABLES.each do |table|
       file = Rails.root.join("tmp/csv_export/#{table.underscore}.csv")
-      table == 'Vacancy' ? records = vacancy_records_without_job_description : records = table.constantize.all
+      table == 'Vacancy' ? records = vacancy_records_with_removed_fields : records = table.constantize.all
 
       next unless records.any?
 
@@ -68,7 +68,7 @@ class ExportTablesToCloudStorage
     FileUtils.rm_rf(Rails.root.join('tmp/csv_export'))
   end
 
-  def vacancy_records_without_job_description
-    Vacancy.select(Vacancy.column_names - ['job_description'].map(&:to_s))
+  def vacancy_records_with_removed_fields
+    Vacancy.select(Vacancy.column_names - ['job_description', 'weekly_hours'].map(&:to_s))
   end
 end


### PR DESCRIPTION
Removed the weekly hours column from the csv created by exporting the
tables to google cloud storage. This column was causing an error when
attempting to import the csv to bigquery.