### PR TITLE
UD1 Redux: Change redirect and update tests, to conform with UX design

### DIFF
--- a/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
@@ -29,6 +29,6 @@ class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacan
 
   def next_step
     @supporting_documents_form.supporting_documents == 'yes' ?
-      documents_school_job_path : candidate_specification_school_job_path
+      documents_school_job_path : application_details_school_job_path
   end
 end

--- a/app/views/hiring_staff/vacancies/supporting_documents/new.html.haml
+++ b/app/views/hiring_staff/vacancies/supporting_documents/new.html.haml
@@ -5,19 +5,18 @@
   %span.govuk-caption-l
     Step 2 of 3
 
-.govuk-main-wrapper
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      = form_for @supporting_documents_form, action: :post, url: supporting_documents_school_job_path(school_id: @school.id), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-        = f.govuk_error_summary 'Please correct the following errors'
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = form_for @supporting_documents_form, action: :post, url: supporting_documents_school_job_path(school_id: @school.id), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+      = f.govuk_error_summary 'Please correct the following errors'
 
-        %h2.govuk-heading-m
-          = t('jobs.supporting_documents')
+      %h2.govuk-heading-m
+        = t('jobs.supporting_documents')
 
-        = f.govuk_collection_radio_buttons :supporting_documents,
-          %w[yes no],
-          :to_s,
-          :capitalize,
-          legend: { text: t('helpers.fieldset.supporting_documents_form.supporting_documents_html'), size: 's' },
-          hint_text: t('helpers.hint.supporting_documents_form.supporting_documents')
-        = f.govuk_submit t('buttons.save_and_continue')
+      = f.govuk_collection_radio_buttons :supporting_documents,
+        %w[yes no],
+        :to_s,
+        :capitalize,
+        legend: { text: t('helpers.fieldset.supporting_documents_form.supporting_documents_html'), size: 's' },
+        hint_text: t('helpers.hint.supporting_documents_form.supporting_documents')
+      = f.govuk_submit t('buttons.save_and_continue')

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -179,8 +179,8 @@ RSpec.feature 'Creating a vacancy' do
         choose 'No'
         click_on 'Save and continue'
 
-        expect(page).to have_content('Step 2 of 3')
-        expect(page.current_path).to eq(candidate_specification_school_job_path)
+        expect(page).to have_content('Step 3 of 3')
+        expect(page.current_path).to eq(application_details_school_job_path)
       end
 
       scenario 'redirects to step 2, upload_documents, when choosing yes' do


### PR DESCRIPTION
Previously this feature was implemented so that choosing 'No' and submit on supporting_documents led to the old version of Step 2. In fact, 'No' and submit should lead to Step 3.

There is an unrelated failing test on this commit, which was present on `develop` before I branched off. See discussion here: https://ukgovernmentdfe.slack.com/archives/CG9A8H1HP/p1581079193008500

## Jira ticket URL:

https://dfedigital.atlassian.net/browse/TEVA-406?atlOrigin=eyJpIjoiOGNiNDk4ZWY1YjRlNGQ3MGEyODY1MmU4ZGY1ZGMyYzIiLCJwIjoiaiJ9
