### PR TITLE
Add accessibility and content changes to upload document page

### DIFF
--- a/app/views/hiring_staff/vacancies/documents/index.html.haml
+++ b/app/views/hiring_staff/vacancies/documents/index.html.haml
@@ -2,7 +2,7 @@
   = t('jobs.publish_heading', school: @school.name)
   %span.govuk-caption-l
     Step 2 of 3
-  
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %form{action: "#", method: "post", enctype: "multipart/form-data"}
@@ -11,17 +11,15 @@
         = t('jobs.supporting_documents')
 
       .govuk-form-group.upload-group
-        %fieldset.govuk-fieldset{"aria-describedby": "file-upload-label"}
+        %label#file-upload-label.govuk-label.govuk-label--s{class: "govuk-!-margin-bottom-3", for: "upload"}
+          = t('jobs.upload_file')
 
-          %label#file-upload-label.govuk-label.govuk-label--s{class: "govuk-!-margin-bottom-3", for: "file-upload"}
-            = t('jobs.upload_file')
-
-          %button#file-upload.govuk-button.govuk-button--secondary{"data-module": "govuk-button"}
-            = t('jobs.choose_file')
-          %input#upload.hidden-input{type: "file", name: "upload", onchange: "form.submit()"}
+        %button#file-upload.govuk-button.govuk-button--secondary{"data-module": "govuk-button"}
+          = t('jobs.select_file')
+        %input#upload.hidden-input{"aria-describedby": "file-upload", alt: t('jobs.select_file'), type: "file", name: "upload", onchange: "form.submit()"}
 
       %p
         = t('jobs.no_files_message')
-          
-    %a.govuk-button{href: "#"} 
+
+    %a.govuk-button{href: "#"}
       = t('buttons.save_and_continue')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,7 +166,7 @@ en:
     candidate_specification: 'Candidate specification'
     supporting_documents: 'Supporting documents'
     upload_file: 'Upload files'
-    choose_file: 'Choose a file'
+    select_file: 'Select a file'
     no_files_message: 'No files chosen'
     application_details: 'Application details'
     no_contact_email: 'No job contact email given'


### PR DESCRIPTION
This adds some content and accessibility changes that were advised from content and UX review.
Changes:
- Add aria-described_by tag
- Change text on the upload button
---------------------------------------------------------------------------------------------------------
**Screenshot of upload documents page:**

<img width="615" alt="Screenshot 2020-02-13 at 10 26 21" src="https://user-images.githubusercontent.com/32823756/74428576-3400b300-4e51-11ea-93b5-450907e14178.png">