### PR TITLE
Add gias data into schools table as json

### DIFF
--- a/db/migrate/20200213152822_add_gias_data_to_column_in_schools.rb
+++ b/db/migrate/20200213152822_add_gias_data_to_column_in_schools.rb
@@ -1,0 +1,5 @@
+class AddGiasDataToColumnInSchools < ActiveRecord::Migration[5.2]
+  def change
+    add_column :schools, :gias_data, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_04_151802) do
+ActiveRecord::Schema.define(version: 2020_02_13_152822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -129,6 +129,7 @@ ActiveRecord::Schema.define(version: 2020_02_04_151802) do
     t.text "northing"
     t.point "geolocation"
     t.string "local_authority"
+    t.json "gias_data"
     t.index ["detailed_school_type_id"], name: "index_schools_on_detailed_school_type_id"
     t.index ["region_id"], name: "index_schools_on_region_id"
     t.index ["school_type_id"], name: "index_schools_on_school_type_id"

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe School, type: :model do
+  it { expect(subject.attributes).to include('gias_data') }
+  it { expect(described_class.columns_hash['gias_data'].type).to eql(:json) }
+
   context 'when there is no previous geolocation' do
     let(:school) { create(:school, easting: nil, northing: nil) }
 


### PR DESCRIPTION
Add `gias_data` to `School` model. 
Refactor to reduce maintenance overhead:

 * Refactored the mappings between attributes and imported rows to a hash as this is easier to maintain than assignment lists. Broke these out by complexity.
 * Moved these to the top of the lib to make the immediately obvious to anyone looking for them.
 * Alphabetised them to make duplicates more obvious.
 * Simplified the specs somewhat, although a complete refactor from integration to unit tests would be sensible.
 * Removed a few expectations from the spec that were already covered in the model spec.

TODO: To complete TEVA-28 we still need to export this to BigQuery. Will probably do this in the branch that relates to fixing the BigQuery json schema problem (TEVA-494).