### PR TITLE
Fix formatting of json import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ group :development, :test do
   gem 'dotenv-rails'
   gem 'elasticsearch-extensions'
   gem 'pry'
+  gem 'pry-rails'
   gem 'rspec-rails'
   gem 'teaspoon-mocha'
   gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,6 +314,8 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_activity (1.6.4)
       actionpack (>= 3.0.0)
       activerecord (>= 3.0)
@@ -561,6 +563,7 @@ DEPENDENCIES
   pg (~> 1.1)
   poltergeist
   pry
+  pry-rails
   public_activity
   puma (~> 4.3)
   rack_session_access

--- a/lib/update_school_data.rb
+++ b/lib/update_school_data.rb
@@ -78,7 +78,10 @@ class UpdateSchoolData
   end
 
   def set_gias_data_as_json(school, row)
-    school.gias_data = row.to_json
+    scratch = {}
+    row.each { |element| scratch[element.first] = element.last }
+    # The gias_data column is type `json`. It automatically converts the ruby hash to json.
+    school.gias_data = scratch
   end
 
   def set_region(school, row)


### PR DESCRIPTION
Change representation of import data

Serializing the row results in a json array string being stored. What we want is a hash. ActiveRecord handles this automatically when you pass a ruby hash to a json or jsonb attribute.

Data from this hash can be accessed like `school.gias_data['URN']`.