### PR TITLE
Show a list of uploaded documents on the summary page. (UD7)

### DIFF
--- a/app/models/concerns/vacancy_candidate_specification_validations.rb
+++ b/app/models/concerns/vacancy_candidate_specification_validations.rb
@@ -3,13 +3,17 @@ module VacancyCandidateSpecificationValidations
   include ApplicationHelper
 
   included do
-    validates :experience, :education, :qualifications, presence: true
+    validates :experience, :education, :qualifications, presence: true, unless: :upload_feature_enabled?
     validates :experience, length: { minimum: 1, maximum: 1000 },
                            if: proc { |model| model.experience.present? }
     validates :education, length: { minimum: 1, maximum: 1000 },
                           if: proc { |model| model.education.present? }
     validates :qualifications, length: { minimum: 1, maximum: 1000 },
                                if: proc { |model| model.qualifications.present? }
+  end
+
+  def upload_feature_enabled?
+    UploadDocumentsFeature.enabled?
   end
 
   def experience=(value)

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -252,6 +252,15 @@ class Vacancy < ApplicationRecord
     @skip_update_callbacks.present?
   end
 
+  def show_supporting_documents?
+    UploadDocumentsFeature.enabled? && !show_candidate_specification?
+  end
+
+  def show_candidate_specification?
+    # TODO: This method should change when the behaviour for changing candidate specification is defined
+    experience.present? && qualifications.present? && education.present?
+  end
+
   private
 
   def slug_candidates

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -8,229 +8,28 @@
     %p.govuk-body-l
       - if @vacancy.publish_on.today?
         = t('jobs.review')
-      - else 
+      - else
         = t('jobs.review_future')
     = render 'hiring_staff/vacancies/error_messages', errors: @vacancy.errors
 
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds
+    = render 'hiring_staff/vacancies/review_vacancy_sections/review_job_specification'
+    - if UploadDocumentsFeature.enabled?
+      = render 'hiring_staff/vacancies/review_vacancy_sections/review_supporting_documents'
+    - else
+      = render 'hiring_staff/vacancies/review_vacancy_sections/review_candidate_specification'
 
-    %h2.govuk-heading-m.mb0
-      = t('jobs.job_specification')
+    = render 'hiring_staff/vacancies/review_vacancy_sections/review_application_details'
 
-    .govuk-body-s.mb1
-      = link_to job_specification_school_job_path, class: 'govuk-link', 'aria-label': 'Change job specification' do
-        Change
-        %span.govuk-visually-hidden the job specification
-
-    %dl.app-check-your-answers.app-check-your-answers--short
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#job_title
-          = t('jobs.job_title')
-        %dd.app-check-your-answers__answer
-          = @vacancy.job_title
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_title'), 'aria-label': t('jobs.aria_labels.change_job_title'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#description
-          = t('jobs.description')
-        %dd.app-check-your-answers__answer
-          = @vacancy.job_description
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_description'), 'aria-label': t('jobs.aria_labels.change_job_description'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#main_subject
-          = t('jobs.main_subject')
-        %dd.app-check-your-answers__answer
-          = @vacancy.main_subject
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'main_subject'), 'aria-label': t('jobs.aria_labels.change_main_subject'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
-          = t('jobs.other_subjects')
-        %dd.app-check-your-answers__answer
-          = @vacancy.other_subjects
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'other_subjects'), 'aria-label': t('jobs.aria_labels.change_other_subjects'), class: 'govuk-link'
-
-      - if @vacancy.working_patterns?
-        .app-check-your-answers__contents
-          %dt.app-check-your-answers__question#working_patterns
-            = t('jobs.working_patterns')
-          %dd.app-check-your-answers__answer
-            = @vacancy.working_patterns
-            - if @vacancy.flexible_working?
-              = @vacancy.flexible_working
-          %dd.app-check-your-answers__change
-            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'working_patterns'), 'aria-label': t('jobs.aria_labels.change_working_patterns'), class: 'govuk-link'
-
-      - if @vacancy.weekly_hours?
-        .app-check-your-answers__contents
-          %dt.app-check-your-answers__question#weekly_hours
-            = t('jobs.weekly_hours')
-          %dd.app-check-your-answers__answer
-            = @vacancy.weekly_hours
-          %dd.app-check-your-answers__change
-            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'weekly_hours'), 'aria-label': t('jobs.aria_labels.change_weekly_hours'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#pay_scale
-          = t('jobs.pay_scale')
-        %dd.app-check-your-answers__answer
-          =@vacancy.pay_scale_range
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'pay_scale_range'), 'aria-label': t('jobs.aria_labels.change_pay_scale'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#salary_range
-          = t('jobs.salary_range')
-        %dd.app-check-your-answers__answer
-          = @vacancy.salary_range("to")
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'salary_range'), 'aria-label': t('jobs.aria_labels.change_salary_range'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#newly_qualified_teacher
-          = t('jobs.newly_qualified_teacher')
-        %dd.app-check-your-answers__answer
-          = @vacancy.newly_qualified_teacher
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'newly_qualified_teacher'), 'aria-label': t('jobs.aria_labels.newly_qualified_teacher'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#benefits
-          = t('jobs.benefits')
-        %dd.app-check-your-answers__answer
-          = @vacancy.benefits
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'benefits'), 'aria-label': t('jobs.aria_labels.change_employee_benefits'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#leadership_level
-          = t('jobs.leadership_level')
-        %dd.app-check-your-answers__answer
-          - if @vacancy.leadership
-            =@vacancy.leadership.title
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'leadership'), 'aria-label': t('jobs.aria_labels.change_leadership_level'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#starts_on
-          = t('jobs.starts_on')
-        %dd.app-check-your-answers__answer
-          = format_date @vacancy.starts_on
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'starts_on'), 'aria-label': t('jobs.aria_labels.change_expected_start_date'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#ends_on
-          = t('jobs.ends_on')
-        %dd.app-check-your-answers__answer
-          = format_date @vacancy.ends_on
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'ends_on'), 'aria-label': t('jobs.aria_labels.change_end_date'), class: 'govuk-link'
-
-
-    %h2.govuk-heading-m.mb0
-      = t('jobs.candidate_specification')
-
-    .govuk-body-s.mb1
-      = link_to candidate_specification_school_job_path, class: 'govuk-link', 'aria-label': 'Change candidate specification' do
-        Change
-        %span.govuk-visually-hidden the candidate specification
-
-    %dl.app-check-your-answers.app-check-your-answers--short
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#education
-          = t('jobs.education')
-        %dd.app-check-your-answers__answer
-          = @vacancy.education
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'education'), 'aria-label': t('jobs.aria_labels.change_essential_educational_requirements'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#qualifications
-          = t('jobs.qualifications')
-        %dd.app-check-your-answers__answer
-          = @vacancy.qualifications
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'qualifications'), 'aria-label': t('jobs.aria_labels.change_essential_qualifications'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#experience
-          = t('jobs.experience')
-        %dd.app-check-your-answers__answer
-          = @vacancy.experience
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'experience'), 'aria-label': t('jobs.aria_labels.change_essential_skills_and_experience'), class: 'govuk-link'
-
-    %h2.govuk-heading-m.mb0
-      = t('jobs.application_details')
-
-    .govuk-body-s.mb1
-      = link_to application_details_school_job_path, class: 'govuk-link', 'aria-label': 'Change application details' do
-        Change
-        %span.govuk-visually-hidden the application details
-
-    %dl.app-check-your-answers.app-check-your-answers--short
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#contact_email
-          = t('jobs.contact_email')
-        %dd.app-check-your-answers__answer
-          - if @vacancy.contact_email.present?
-            =mail_to 'Job contact email', @vacancy.contact_email, class: 'govuk-link', 'aria-label': t('jobs.aria_labels.contact_email_link', email: @vacancy.contact_email)
-            %dd.app-check-your-answers__change
-              = link_to t('buttons.change'), application_details_school_job_path(anchor: 'contact_email'), 'aria-label': t('jobs.aria_labels.change_job_contact_email'), class: 'govuk-link'
-          - else
-            %span= t('jobs.no_contact_email')
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#application_link
-          = t('jobs.application_link')
-        %dd.app-check-your-answers__answer
-          - if @vacancy.application_link.present?
-            = link_to @vacancy.application_link, class: 'govuk-link', 'aria-label': t('jobs.aria_labels.application_link_url', url: @vacancy.application_link) do
-              %span.govuk-body-m.govuk-link= t('jobs.application_link_url')
-              %br
-              %span.govuk-body-s.govuk-link= @vacancy.application_link
-          - else
-            %span= t('jobs.no_application_link')
-
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'application_link'), 'aria-label': t('jobs.aria_labels.change_application_link_URL'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#publish_on
-          = t('jobs.publication_date')
-        %dd.app-check-your-answers__answer
-          = format_date @vacancy.publish_on
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'publish_on'), 'aria-label': t('jobs.aria_labels.change_date_role_will_be_listed'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#expires_on
-          = t('jobs.application_deadline')
-        %dd.app-check-your-answers__answer
-          = format_date @vacancy.expires_on
-          = t('jobs.time_at') unless @vacancy.expiry_time.nil?
-          = format_time @vacancy.expiry_time 
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'expires_on'), 'aria-label': t('jobs.aria_labels.change_application_deadline'), class: 'govuk-link'
-
-    %h2.govuk-heading-m 
+    %h2.govuk-heading-m
       - if @vacancy.publish_on.today?
         = t('jobs.publish_for') + @vacancy.job_title
-      - else 
+      - else
         = t('jobs.publish_for_future') + @vacancy.publish_on.to_s
     %p= t('jobs.confirmation_summary_html')
 
     - if @vacancy.publish_on.today?
       = link_to t('jobs.submit'), school_job_publish_path(@vacancy.id), method: :post, class: "govuk-button", id: "vacancy-review-submit"
-    - else 
+    - else
       = link_to t('jobs.submit_future'), school_job_publish_path(@vacancy.id), method: :post, class: "govuk-button", id: "vacancy-review-submit"

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -15,9 +15,9 @@
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds
     = render 'hiring_staff/vacancies/review_vacancy_sections/review_job_specification'
-    - if UploadDocumentsFeature.enabled?
+    - if @vacancy.show_supporting_documents?
       = render 'hiring_staff/vacancies/review_vacancy_sections/review_supporting_documents'
-    - else
+    - if @vacancy.show_candidate_specification?
       = render 'hiring_staff/vacancies/review_vacancy_sections/review_candidate_specification'
 
     = render 'hiring_staff/vacancies/review_vacancy_sections/review_application_details'

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_application_details.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_application_details.html.haml
@@ -1,0 +1,53 @@
+%h2.govuk-heading-m.mb0
+  = t('jobs.application_details')
+
+.govuk-body-s.mb1
+  = link_to application_details_school_job_path, class: 'govuk-link', 'aria-label': 'Change application details' do
+    Change
+    %span.govuk-visually-hidden the application details
+
+%dl.app-check-your-answers.app-check-your-answers--short
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#contact_email
+      = t('jobs.contact_email')
+    %dd.app-check-your-answers__answer
+      - if @vacancy.contact_email.present?
+        =mail_to 'Job contact email', @vacancy.contact_email, class: 'govuk-link', 'aria-label': t('jobs.aria_labels.contact_email_link', email: @vacancy.contact_email)
+        %dd.app-check-your-answers__change
+          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'contact_email'), 'aria-label': t('jobs.aria_labels.change_job_contact_email'), class: 'govuk-link'
+      - else
+        %span= t('jobs.no_contact_email')
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#application_link
+      = t('jobs.application_link')
+    %dd.app-check-your-answers__answer
+      - if @vacancy.application_link.present?
+        = link_to @vacancy.application_link, class: 'govuk-link', 'aria-label': t('jobs.aria_labels.application_link_url', url: @vacancy.application_link) do
+          %span.govuk-body-m.govuk-link= t('jobs.application_link_url')
+          %br
+          %span.govuk-body-s.govuk-link= @vacancy.application_link
+      - else
+        %span= t('jobs.no_application_link')
+
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), application_details_school_job_path(anchor: 'application_link'), 'aria-label': t('jobs.aria_labels.change_application_link_URL'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#publish_on
+      = t('jobs.publication_date')
+    %dd.app-check-your-answers__answer
+      = format_date @vacancy.publish_on
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), application_details_school_job_path(anchor: 'publish_on'), 'aria-label': t('jobs.aria_labels.change_date_role_will_be_listed'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#expires_on
+      = t('jobs.application_deadline')
+    %dd.app-check-your-answers__answer
+      = format_date @vacancy.expires_on
+      = t('jobs.time_at') unless @vacancy.expiry_time.nil?
+      = format_time @vacancy.expiry_time
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), application_details_school_job_path(anchor: 'expires_on'), 'aria-label': t('jobs.aria_labels.change_application_deadline'), class: 'govuk-link'

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_candidate_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_candidate_specification.html.haml
@@ -1,0 +1,33 @@
+%h2.govuk-heading-m.mb0
+  = t('jobs.candidate_specification')
+
+.govuk-body-s.mb1
+  = link_to candidate_specification_school_job_path, class: 'govuk-link', 'aria-label': 'Change candidate specification' do
+    Change
+    %span.govuk-visually-hidden the candidate specification
+
+%dl.app-check-your-answers.app-check-your-answers--short
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#education
+      = t('jobs.education')
+    %dd.app-check-your-answers__answer
+      = @vacancy.education
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'education'), 'aria-label': t('jobs.aria_labels.change_essential_educational_requirements'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#qualifications
+      = t('jobs.qualifications')
+    %dd.app-check-your-answers__answer
+      = @vacancy.qualifications
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'qualifications'), 'aria-label': t('jobs.aria_labels.change_essential_qualifications'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#experience
+      = t('jobs.experience')
+    %dd.app-check-your-answers__answer
+      = @vacancy.experience
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'experience'), 'aria-label': t('jobs.aria_labels.change_essential_skills_and_experience'), class: 'govuk-link'

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
@@ -1,0 +1,118 @@
+%h2.govuk-heading-m.mb0
+  = t('jobs.job_specification')
+
+.govuk-body-s.mb1
+  = link_to job_specification_school_job_path, class: 'govuk-link', 'aria-label': 'Change job specification' do
+    Change
+    %span.govuk-visually-hidden the job specification
+
+%dl.app-check-your-answers.app-check-your-answers--short
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#job_title
+      = t('jobs.job_title')
+    %dd.app-check-your-answers__answer
+      = @vacancy.job_title
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_title'), 'aria-label': t('jobs.aria_labels.change_job_title'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#description
+      = t('jobs.description')
+    %dd.app-check-your-answers__answer
+      = @vacancy.job_description
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_description'), 'aria-label': t('jobs.aria_labels.change_job_description'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#main_subject
+      = t('jobs.main_subject')
+    %dd.app-check-your-answers__answer
+      = @vacancy.main_subject
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'main_subject'), 'aria-label': t('jobs.aria_labels.change_main_subject'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question
+      = t('jobs.other_subjects')
+    %dd.app-check-your-answers__answer
+      = @vacancy.other_subjects
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'other_subjects'), 'aria-label': t('jobs.aria_labels.change_other_subjects'), class: 'govuk-link'
+
+  - if @vacancy.working_patterns?
+    .app-check-your-answers__contents
+      %dt.app-check-your-answers__question#working_patterns
+        = t('jobs.working_patterns')
+      %dd.app-check-your-answers__answer
+        = @vacancy.working_patterns
+        - if @vacancy.flexible_working?
+          = @vacancy.flexible_working
+      %dd.app-check-your-answers__change
+        = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'working_patterns'), 'aria-label': t('jobs.aria_labels.change_working_patterns'), class: 'govuk-link'
+
+  - if @vacancy.weekly_hours?
+    .app-check-your-answers__contents
+      %dt.app-check-your-answers__question#weekly_hours
+        = t('jobs.weekly_hours')
+      %dd.app-check-your-answers__answer
+        = @vacancy.weekly_hours
+      %dd.app-check-your-answers__change
+        = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'weekly_hours'), 'aria-label': t('jobs.aria_labels.change_weekly_hours'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#pay_scale
+      = t('jobs.pay_scale')
+    %dd.app-check-your-answers__answer
+      =@vacancy.pay_scale_range
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'pay_scale_range'), 'aria-label': t('jobs.aria_labels.change_pay_scale'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#salary_range
+      = t('jobs.salary_range')
+    %dd.app-check-your-answers__answer
+      = @vacancy.salary_range("to")
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'salary_range'), 'aria-label': t('jobs.aria_labels.change_salary_range'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#newly_qualified_teacher
+      = t('jobs.newly_qualified_teacher')
+    %dd.app-check-your-answers__answer
+      = @vacancy.newly_qualified_teacher
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'newly_qualified_teacher'), 'aria-label': t('jobs.aria_labels.newly_qualified_teacher'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#benefits
+      = t('jobs.benefits')
+    %dd.app-check-your-answers__answer
+      = @vacancy.benefits
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'benefits'), 'aria-label': t('jobs.aria_labels.change_employee_benefits'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#leadership_level
+      = t('jobs.leadership_level')
+    %dd.app-check-your-answers__answer
+      - if @vacancy.leadership
+        =@vacancy.leadership.title
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'leadership'), 'aria-label': t('jobs.aria_labels.change_leadership_level'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#starts_on
+      = t('jobs.starts_on')
+    %dd.app-check-your-answers__answer
+      = format_date @vacancy.starts_on
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'starts_on'), 'aria-label': t('jobs.aria_labels.change_expected_start_date'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#ends_on
+      = t('jobs.ends_on')
+    %dd.app-check-your-answers__answer
+      = format_date @vacancy.ends_on
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'ends_on'), 'aria-label': t('jobs.aria_labels.change_end_date'), class: 'govuk-link'

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_supporting_documents.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_supporting_documents.html.haml
@@ -1,0 +1,16 @@
+%h2.govuk-heading-m.mb0
+  = t('jobs.supporting_documents')
+
+.govuk-body-s.mb1
+-#   = link_to documents_school_job_path, class: 'govuk-link', 'aria-label': 'Change supporting documents' do
+-#     Change
+-#     %span.govuk-visually-hidden the supporting documents
+
+%dl.app-check-your-answers.app-check-your-answers--short
+  - @vacancy.documents.each_with_index do |document, index|
+    - index_from_one = index + 1
+    .app-check-your-answers__contents
+      %dt.app-check-your-answers__question#supporting_documents
+        = "Document #{index_from_one}"
+      %dd.app-check-your-answers__answer
+        = document[:name]

--- a/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 RSpec.feature 'Hiring staff can edit a draft vacancy' do
   let(:school) { create(:school) }
+
+  let(:feature_enabled?) { false }
+
   before do
+    allow(UploadDocumentsFeature).to receive(:enabled?).and_return(feature_enabled?)
+
     stub_hiring_staff_auth(urn: school.urn)
   end
 

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -3,7 +3,11 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   let(:school) { create(:school) }
   let(:session_id) { SecureRandom.uuid }
 
+  let(:feature_enabled?) { false }
+
   before(:each) do
+    allow(UploadDocumentsFeature).to receive(:enabled?).and_return(feature_enabled?)
+
     stub_hiring_staff_auth(urn: school.urn, session_id: session_id)
   end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -389,6 +389,7 @@ RSpec.feature 'Creating a vacancy' do
           allow(document_upload).to receive_message_chain(:uploaded, :web_content_link).and_return('test_url')
           allow(document_upload).to receive_message_chain(:uploaded, :id).and_return('test_id')
           allow(document_upload).to receive(:safe_download).and_return(true)
+          allow(document_upload).to receive(:google_error).and_return(false)
         end
 
         scenario 'redirects to the vacancy review page when submitted successfully' do

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -378,6 +378,42 @@ RSpec.feature 'Creating a vacancy' do
           verify_all_vacancy_details(vacancy)
         end
       end
+
+      context 'with upload feature flag turned ON' do
+        let(:feature_enabled?) { true }
+        let(:document_upload) { double('document_upload') }
+
+        before do
+          allow(DocumentUpload).to receive(:new).and_return(document_upload)
+          allow(document_upload).to receive(:upload)
+          allow(document_upload).to receive_message_chain(:uploaded, :web_content_link).and_return('test_url')
+          allow(document_upload).to receive_message_chain(:uploaded, :id).and_return('test_id')
+          allow(document_upload).to receive(:safe_download).and_return(true)
+        end
+
+        scenario 'redirects to the vacancy review page when submitted successfully' do
+          visit new_school_job_path
+
+          fill_in_job_specification_form_fields(vacancy)
+          click_on 'Save and continue'
+
+          fill_in_supporting_documents_form_fields
+          click_on 'Save and continue'
+
+          upload_document(
+            'new_documents_form',
+            'documents-form-documents-field',
+            'spec/fixtures/files/blank_job_spec.pdf'
+          )
+          click_on 'Save and continue'
+
+          fill_in_application_details_form_fields(vacancy)
+          click_on 'Save and continue'
+
+          expect(page).to have_content(I18n.t('jobs.review'))
+          verify_all_vacancy_details(vacancy)
+        end
+      end
     end
 
     context '#review' do

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       context 'without feature upload documents enabled' do
-        scenario 'redirects to step 2, candidate profile, when submitted succesfully' do
+        scenario 'redirects to step 2, candidate profile, when submitted successfully' do
           visit new_school_job_path
 
           fill_in_job_specification_form_fields(vacancy)
@@ -143,7 +143,7 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      scenario 'redirects to step 3, application_details profile, when submitted succesfuly' do
+      scenario 'redirects to step 3, application_details profile, when submitted successfully' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
@@ -170,7 +170,7 @@ RSpec.feature 'Creating a vacancy' do
           .to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.supporting_documents.inclusion'))
       end
 
-      scenario 'redirects to step 2, candidate_specification, when choosing no' do
+      scenario 'redirects to step 3, application details, when choosing no' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
@@ -364,17 +364,19 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      scenario 'redirects to the vacancy review page when submitted succesfully' do
-        visit new_school_job_path
+      context 'when the upload feature flag is OFF' do
+        scenario 'redirects to the vacancy review page when submitted successfully' do
+          visit new_school_job_path
 
-        fill_in_job_specification_form_fields(vacancy)
-        click_on 'Save and continue'
-        fill_in_candidate_specification_form_fields(vacancy)
-        click_on 'Save and continue'
-        fill_in_application_details_form_fields(vacancy)
-        click_on 'Save and continue'
-        expect(page).to have_content(I18n.t('jobs.review'))
-        verify_all_vacancy_details(vacancy)
+          fill_in_job_specification_form_fields(vacancy)
+          click_on 'Save and continue'
+          fill_in_candidate_specification_form_fields(vacancy)
+          click_on 'Save and continue'
+          fill_in_application_details_form_fields(vacancy)
+          click_on 'Save and continue'
+          expect(page).to have_content(I18n.t('jobs.review'))
+          verify_all_vacancy_details(vacancy)
+        end
       end
     end
 

--- a/spec/form_models/candidate_specification_form_spec.rb
+++ b/spec/form_models/candidate_specification_form_spec.rb
@@ -1,8 +1,11 @@
 require 'rails_helper'
 RSpec.describe CandidateSpecificationForm, type: :model do
   subject { CandidateSpecificationForm.new({}) }
+  let(:feature_enabled?) { false }
 
   describe 'validations' do
+    before { allow(UploadDocumentsFeature).to receive(:enabled?).and_return(feature_enabled?) }
+
     describe '#education' do
       let(:candidate_specification_form) { CandidateSpecificationForm.new(education: education) }
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe Vacancy, type: :model do
   end
 
   describe 'validations' do
+    let(:feature_enabled?) { false }
+
+    before { allow(UploadDocumentsFeature).to receive(:enabled?).and_return(feature_enabled?) }
+
     context 'a new record' do
       it { should validate_presence_of(:job_title) }
       it { should validate_presence_of(:job_description) }
@@ -39,9 +43,19 @@ RSpec.describe Vacancy, type: :model do
     context 'a record saved with job spec details' do
       subject { create(:vacancy) }
 
-      it { should validate_presence_of(:education) }
-      it { should validate_presence_of(:qualifications) }
-      it { should validate_presence_of(:experience) }
+      context 'when upload document feature is OFF, validates candidate specification fields' do
+        it { should validate_presence_of(:education) }
+        it { should validate_presence_of(:qualifications) }
+        it { should validate_presence_of(:experience) }
+      end
+
+      context 'when upload document feature is ON, does not validate candidate specification fields' do
+        let(:feature_enabled?) { true }
+
+        it { should_not validate_presence_of(:education) }
+        it { should_not validate_presence_of(:qualifications) }
+        it { should_not validate_presence_of(:experience) }
+      end
     end
 
     context 'set minimum length of mandatory fields' do

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -100,9 +100,14 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.starts_on) if vacancy.starts_on?
     expect(page).to have_content(vacancy.ends_on) if vacancy.ends_on?
 
-    expect(page.html).to include(vacancy.education)
-    expect(page.html).to include(vacancy.qualifications)
-    expect(page.html).to include(vacancy.experience)
+    if UploadDocumentsFeature.enabled?
+      expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+    else
+      expect(page.html).to include(vacancy.education)
+      expect(page.html).to include(vacancy.qualifications)
+      expect(page.html).to include(vacancy.experience)
+    end
+
     expect(page).to have_content(vacancy.leadership.title)
 
     expect(page).to have_content(vacancy.contact_email)


### PR DESCRIPTION
**NB: This PR for ticket [UD7](https://dfedigital.atlassian.net/browse/TEVA-413) covers creating a section for users to see uploaded documents for a vacancy at the review step. It does not include enabling users to go back and change supporting documents from the review step. Ticket [UD8](https://dfedigital.atlassian.net/browse/TEVA-414) covers this, and this ticket will be picked up subsequently.**

**Screenshot (Full Screen):**
<img width="381" alt="Screenshot 2020-02-21 at 10 36 53" src="https://user-images.githubusercontent.com/32823756/75027892-34bfc780-5497-11ea-949c-b8216508c04c.png">

**Screenshot (Supporting Documents Section):**
<img width="646" alt="Screenshot 2020-02-21 at 10 37 00" src="https://user-images.githubusercontent.com/32823756/75027960-515bff80-5497-11ea-9688-db48a5f38432.png">