### PR TITLE
Make message fade out after 60 seconds (was 3)

### DIFF
--- a/app/frontend/src/submitFeedback.js
+++ b/app/frontend/src/submitFeedback.js
@@ -33,6 +33,7 @@ $(document).ready(function(){
     var notice = $('#awaiting_notice')
     var notice_count = notice.find('.count');
     var feedback_intro = $('#awaiting_feedback_intro')
+    const delayInMilliseconds = 60000
 
     if (count > 0) {
       row = form.parents('tr');
@@ -44,7 +45,7 @@ $(document).ready(function(){
       notification.text(count);
       text = form.data('successMessage');
       row.html('<td class="govuk-table__cell" colspan="6">'+ text +'</td>');
-      row.fadeOut(60000, function() {
+      row.fadeOut(delayInMilliseconds, function() {
         $(this).remove();
       })
     } else {

--- a/app/frontend/src/submitFeedback.js
+++ b/app/frontend/src/submitFeedback.js
@@ -44,7 +44,7 @@ $(document).ready(function(){
       notification.text(count);
       text = form.data('successMessage');
       row.html('<td class="govuk-table__cell" colspan="6">'+ text +'</td>');
-      row.fadeOut(3000, function() {
+      row.fadeOut(60000, function() {
         $(this).remove();
       })
     } else {


### PR DESCRIPTION
As a first, very easy win in implementing ticket TEVA-436, I made the fade out timer much longer. 

The intent is to make the message visible to users, given that users said they did not see a confirmation message.

For continuous delivery, this can be merged after approval, since doing the rest of the ticket will take X number of days to implement where X might be longer than the time remaining this sprint, and the ticket might not make it into the next sprint.

## Next steps:

- [ ] Success notification appears above Tab table (new design pattern)

- [ ] This notification can be dismissed by the user clicking “dismiss”

- [ ] The notification ALSO disappears when a) user submits another feedback, replacing the notification, or b) user navigates away from the page/interacts with something else

- [ ] We have checked that GTM tag on 'submit' button has not broken.
