### PR TITLE
Display 'no documents' text in supporting documents section (UD9)

### DIFF
--- a/app/models/concerns/vacancy_candidate_specification_validations.rb
+++ b/app/models/concerns/vacancy_candidate_specification_validations.rb
@@ -3,13 +3,17 @@ module VacancyCandidateSpecificationValidations
   include ApplicationHelper
 
   included do
-    validates :experience, :education, :qualifications, presence: true
+    validates :experience, :education, :qualifications, presence: true, unless: :upload_feature_enabled?
     validates :experience, length: { minimum: 1, maximum: 1000 },
                            if: proc { |model| model.experience.present? }
     validates :education, length: { minimum: 1, maximum: 1000 },
                           if: proc { |model| model.education.present? }
     validates :qualifications, length: { minimum: 1, maximum: 1000 },
                                if: proc { |model| model.qualifications.present? }
+  end
+
+  def upload_feature_enabled?
+    UploadDocumentsFeature.enabled?
   end
 
   def experience=(value)

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -8,229 +8,28 @@
     %p.govuk-body-l
       - if @vacancy.publish_on.today?
         = t('jobs.review')
-      - else 
+      - else
         = t('jobs.review_future')
     = render 'hiring_staff/vacancies/error_messages', errors: @vacancy.errors
 
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds
+    = render 'hiring_staff/vacancies/review_vacancy_sections/review_job_specification'
+    - if UploadDocumentsFeature.enabled?
+      = render 'hiring_staff/vacancies/review_vacancy_sections/review_supporting_documents'
+    - else
+      = render 'hiring_staff/vacancies/review_vacancy_sections/review_candidate_specification'
 
-    %h2.govuk-heading-m.mb0
-      = t('jobs.job_specification')
+    = render 'hiring_staff/vacancies/review_vacancy_sections/review_application_details'
 
-    .govuk-body-s.mb1
-      = link_to job_specification_school_job_path, class: 'govuk-link', 'aria-label': 'Change job specification' do
-        Change
-        %span.govuk-visually-hidden the job specification
-
-    %dl.app-check-your-answers.app-check-your-answers--short
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#job_title
-          = t('jobs.job_title')
-        %dd.app-check-your-answers__answer
-          = @vacancy.job_title
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_title'), 'aria-label': t('jobs.aria_labels.change_job_title'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#description
-          = t('jobs.description')
-        %dd.app-check-your-answers__answer
-          = @vacancy.job_description
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_description'), 'aria-label': t('jobs.aria_labels.change_job_description'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#main_subject
-          = t('jobs.main_subject')
-        %dd.app-check-your-answers__answer
-          = @vacancy.main_subject
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'main_subject'), 'aria-label': t('jobs.aria_labels.change_main_subject'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
-          = t('jobs.other_subjects')
-        %dd.app-check-your-answers__answer
-          = @vacancy.other_subjects
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'other_subjects'), 'aria-label': t('jobs.aria_labels.change_other_subjects'), class: 'govuk-link'
-
-      - if @vacancy.working_patterns?
-        .app-check-your-answers__contents
-          %dt.app-check-your-answers__question#working_patterns
-            = t('jobs.working_patterns')
-          %dd.app-check-your-answers__answer
-            = @vacancy.working_patterns
-            - if @vacancy.flexible_working?
-              = @vacancy.flexible_working
-          %dd.app-check-your-answers__change
-            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'working_patterns'), 'aria-label': t('jobs.aria_labels.change_working_patterns'), class: 'govuk-link'
-
-      - if @vacancy.weekly_hours?
-        .app-check-your-answers__contents
-          %dt.app-check-your-answers__question#weekly_hours
-            = t('jobs.weekly_hours')
-          %dd.app-check-your-answers__answer
-            = @vacancy.weekly_hours
-          %dd.app-check-your-answers__change
-            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'weekly_hours'), 'aria-label': t('jobs.aria_labels.change_weekly_hours'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#pay_scale
-          = t('jobs.pay_scale')
-        %dd.app-check-your-answers__answer
-          =@vacancy.pay_scale_range
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'pay_scale_range'), 'aria-label': t('jobs.aria_labels.change_pay_scale'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#salary_range
-          = t('jobs.salary_range')
-        %dd.app-check-your-answers__answer
-          = @vacancy.salary_range("to")
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'salary_range'), 'aria-label': t('jobs.aria_labels.change_salary_range'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#newly_qualified_teacher
-          = t('jobs.newly_qualified_teacher')
-        %dd.app-check-your-answers__answer
-          = @vacancy.newly_qualified_teacher
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'newly_qualified_teacher'), 'aria-label': t('jobs.aria_labels.newly_qualified_teacher'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#benefits
-          = t('jobs.benefits')
-        %dd.app-check-your-answers__answer
-          = @vacancy.benefits
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'benefits'), 'aria-label': t('jobs.aria_labels.change_employee_benefits'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#leadership_level
-          = t('jobs.leadership_level')
-        %dd.app-check-your-answers__answer
-          - if @vacancy.leadership
-            =@vacancy.leadership.title
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'leadership'), 'aria-label': t('jobs.aria_labels.change_leadership_level'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#starts_on
-          = t('jobs.starts_on')
-        %dd.app-check-your-answers__answer
-          = format_date @vacancy.starts_on
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'starts_on'), 'aria-label': t('jobs.aria_labels.change_expected_start_date'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#ends_on
-          = t('jobs.ends_on')
-        %dd.app-check-your-answers__answer
-          = format_date @vacancy.ends_on
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'ends_on'), 'aria-label': t('jobs.aria_labels.change_end_date'), class: 'govuk-link'
-
-
-    %h2.govuk-heading-m.mb0
-      = t('jobs.candidate_specification')
-
-    .govuk-body-s.mb1
-      = link_to candidate_specification_school_job_path, class: 'govuk-link', 'aria-label': 'Change candidate specification' do
-        Change
-        %span.govuk-visually-hidden the candidate specification
-
-    %dl.app-check-your-answers.app-check-your-answers--short
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#education
-          = t('jobs.education')
-        %dd.app-check-your-answers__answer
-          = @vacancy.education
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'education'), 'aria-label': t('jobs.aria_labels.change_essential_educational_requirements'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#qualifications
-          = t('jobs.qualifications')
-        %dd.app-check-your-answers__answer
-          = @vacancy.qualifications
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'qualifications'), 'aria-label': t('jobs.aria_labels.change_essential_qualifications'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#experience
-          = t('jobs.experience')
-        %dd.app-check-your-answers__answer
-          = @vacancy.experience
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'experience'), 'aria-label': t('jobs.aria_labels.change_essential_skills_and_experience'), class: 'govuk-link'
-
-    %h2.govuk-heading-m.mb0
-      = t('jobs.application_details')
-
-    .govuk-body-s.mb1
-      = link_to application_details_school_job_path, class: 'govuk-link', 'aria-label': 'Change application details' do
-        Change
-        %span.govuk-visually-hidden the application details
-
-    %dl.app-check-your-answers.app-check-your-answers--short
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#contact_email
-          = t('jobs.contact_email')
-        %dd.app-check-your-answers__answer
-          - if @vacancy.contact_email.present?
-            =mail_to 'Job contact email', @vacancy.contact_email, class: 'govuk-link', 'aria-label': t('jobs.aria_labels.contact_email_link', email: @vacancy.contact_email)
-            %dd.app-check-your-answers__change
-              = link_to t('buttons.change'), application_details_school_job_path(anchor: 'contact_email'), 'aria-label': t('jobs.aria_labels.change_job_contact_email'), class: 'govuk-link'
-          - else
-            %span= t('jobs.no_contact_email')
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#application_link
-          = t('jobs.application_link')
-        %dd.app-check-your-answers__answer
-          - if @vacancy.application_link.present?
-            = link_to @vacancy.application_link, class: 'govuk-link', 'aria-label': t('jobs.aria_labels.application_link_url', url: @vacancy.application_link) do
-              %span.govuk-body-m.govuk-link= t('jobs.application_link_url')
-              %br
-              %span.govuk-body-s.govuk-link= @vacancy.application_link
-          - else
-            %span= t('jobs.no_application_link')
-
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'application_link'), 'aria-label': t('jobs.aria_labels.change_application_link_URL'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#publish_on
-          = t('jobs.publication_date')
-        %dd.app-check-your-answers__answer
-          = format_date @vacancy.publish_on
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'publish_on'), 'aria-label': t('jobs.aria_labels.change_date_role_will_be_listed'), class: 'govuk-link'
-
-      .app-check-your-answers__contents
-        %dt.app-check-your-answers__question#expires_on
-          = t('jobs.application_deadline')
-        %dd.app-check-your-answers__answer
-          = format_date @vacancy.expires_on
-          = t('jobs.time_at') unless @vacancy.expiry_time.nil?
-          = format_time @vacancy.expiry_time 
-        %dd.app-check-your-answers__change
-          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'expires_on'), 'aria-label': t('jobs.aria_labels.change_application_deadline'), class: 'govuk-link'
-
-    %h2.govuk-heading-m 
+    %h2.govuk-heading-m
       - if @vacancy.publish_on.today?
         = t('jobs.publish_for') + @vacancy.job_title
-      - else 
+      - else
         = t('jobs.publish_for_future') + @vacancy.publish_on.to_s
     %p= t('jobs.confirmation_summary_html')
 
     - if @vacancy.publish_on.today?
       = link_to t('jobs.submit'), school_job_publish_path(@vacancy.id), method: :post, class: "govuk-button", id: "vacancy-review-submit"
-    - else 
+    - else
       = link_to t('jobs.submit_future'), school_job_publish_path(@vacancy.id), method: :post, class: "govuk-button", id: "vacancy-review-submit"

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_application_details.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_application_details.html.haml
@@ -1,0 +1,53 @@
+%h2.govuk-heading-m.mb0
+  = t('jobs.application_details')
+
+.govuk-body-s.mb1
+  = link_to application_details_school_job_path, class: 'govuk-link', 'aria-label': 'Change application details' do
+    Change
+    %span.govuk-visually-hidden the application details
+
+%dl.app-check-your-answers.app-check-your-answers--short
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#contact_email
+      = t('jobs.contact_email')
+    %dd.app-check-your-answers__answer
+      - if @vacancy.contact_email.present?
+        =mail_to 'Job contact email', @vacancy.contact_email, class: 'govuk-link', 'aria-label': t('jobs.aria_labels.contact_email_link', email: @vacancy.contact_email)
+        %dd.app-check-your-answers__change
+          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'contact_email'), 'aria-label': t('jobs.aria_labels.change_job_contact_email'), class: 'govuk-link'
+      - else
+        %span= t('jobs.no_contact_email')
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#application_link
+      = t('jobs.application_link')
+    %dd.app-check-your-answers__answer
+      - if @vacancy.application_link.present?
+        = link_to @vacancy.application_link, class: 'govuk-link', 'aria-label': t('jobs.aria_labels.application_link_url', url: @vacancy.application_link) do
+          %span.govuk-body-m.govuk-link= t('jobs.application_link_url')
+          %br
+          %span.govuk-body-s.govuk-link= @vacancy.application_link
+      - else
+        %span= t('jobs.no_application_link')
+
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), application_details_school_job_path(anchor: 'application_link'), 'aria-label': t('jobs.aria_labels.change_application_link_URL'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#publish_on
+      = t('jobs.publication_date')
+    %dd.app-check-your-answers__answer
+      = format_date @vacancy.publish_on
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), application_details_school_job_path(anchor: 'publish_on'), 'aria-label': t('jobs.aria_labels.change_date_role_will_be_listed'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#expires_on
+      = t('jobs.application_deadline')
+    %dd.app-check-your-answers__answer
+      = format_date @vacancy.expires_on
+      = t('jobs.time_at') unless @vacancy.expiry_time.nil?
+      = format_time @vacancy.expiry_time
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), application_details_school_job_path(anchor: 'expires_on'), 'aria-label': t('jobs.aria_labels.change_application_deadline'), class: 'govuk-link'

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_candidate_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_candidate_specification.html.haml
@@ -1,0 +1,33 @@
+%h2.govuk-heading-m.mb0
+  = t('jobs.candidate_specification')
+
+.govuk-body-s.mb1
+  = link_to candidate_specification_school_job_path, class: 'govuk-link', 'aria-label': 'Change candidate specification' do
+    Change
+    %span.govuk-visually-hidden the candidate specification
+
+%dl.app-check-your-answers.app-check-your-answers--short
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#education
+      = t('jobs.education')
+    %dd.app-check-your-answers__answer
+      = @vacancy.education
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'education'), 'aria-label': t('jobs.aria_labels.change_essential_educational_requirements'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#qualifications
+      = t('jobs.qualifications')
+    %dd.app-check-your-answers__answer
+      = @vacancy.qualifications
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'qualifications'), 'aria-label': t('jobs.aria_labels.change_essential_qualifications'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#experience
+      = t('jobs.experience')
+    %dd.app-check-your-answers__answer
+      = @vacancy.experience
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'experience'), 'aria-label': t('jobs.aria_labels.change_essential_skills_and_experience'), class: 'govuk-link'

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
@@ -1,0 +1,118 @@
+%h2.govuk-heading-m.mb0
+  = t('jobs.job_specification')
+
+.govuk-body-s.mb1
+  = link_to job_specification_school_job_path, class: 'govuk-link', 'aria-label': 'Change job specification' do
+    Change
+    %span.govuk-visually-hidden the job specification
+
+%dl.app-check-your-answers.app-check-your-answers--short
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#job_title
+      = t('jobs.job_title')
+    %dd.app-check-your-answers__answer
+      = @vacancy.job_title
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_title'), 'aria-label': t('jobs.aria_labels.change_job_title'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#description
+      = t('jobs.description')
+    %dd.app-check-your-answers__answer
+      = @vacancy.job_description
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_description'), 'aria-label': t('jobs.aria_labels.change_job_description'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#main_subject
+      = t('jobs.main_subject')
+    %dd.app-check-your-answers__answer
+      = @vacancy.main_subject
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'main_subject'), 'aria-label': t('jobs.aria_labels.change_main_subject'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question
+      = t('jobs.other_subjects')
+    %dd.app-check-your-answers__answer
+      = @vacancy.other_subjects
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'other_subjects'), 'aria-label': t('jobs.aria_labels.change_other_subjects'), class: 'govuk-link'
+
+  - if @vacancy.working_patterns?
+    .app-check-your-answers__contents
+      %dt.app-check-your-answers__question#working_patterns
+        = t('jobs.working_patterns')
+      %dd.app-check-your-answers__answer
+        = @vacancy.working_patterns
+        - if @vacancy.flexible_working?
+          = @vacancy.flexible_working
+      %dd.app-check-your-answers__change
+        = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'working_patterns'), 'aria-label': t('jobs.aria_labels.change_working_patterns'), class: 'govuk-link'
+
+  - if @vacancy.weekly_hours?
+    .app-check-your-answers__contents
+      %dt.app-check-your-answers__question#weekly_hours
+        = t('jobs.weekly_hours')
+      %dd.app-check-your-answers__answer
+        = @vacancy.weekly_hours
+      %dd.app-check-your-answers__change
+        = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'weekly_hours'), 'aria-label': t('jobs.aria_labels.change_weekly_hours'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#pay_scale
+      = t('jobs.pay_scale')
+    %dd.app-check-your-answers__answer
+      =@vacancy.pay_scale_range
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'pay_scale_range'), 'aria-label': t('jobs.aria_labels.change_pay_scale'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#salary_range
+      = t('jobs.salary_range')
+    %dd.app-check-your-answers__answer
+      = @vacancy.salary_range("to")
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'salary_range'), 'aria-label': t('jobs.aria_labels.change_salary_range'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#newly_qualified_teacher
+      = t('jobs.newly_qualified_teacher')
+    %dd.app-check-your-answers__answer
+      = @vacancy.newly_qualified_teacher
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'newly_qualified_teacher'), 'aria-label': t('jobs.aria_labels.newly_qualified_teacher'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#benefits
+      = t('jobs.benefits')
+    %dd.app-check-your-answers__answer
+      = @vacancy.benefits
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'benefits'), 'aria-label': t('jobs.aria_labels.change_employee_benefits'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#leadership_level
+      = t('jobs.leadership_level')
+    %dd.app-check-your-answers__answer
+      - if @vacancy.leadership
+        =@vacancy.leadership.title
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'leadership'), 'aria-label': t('jobs.aria_labels.change_leadership_level'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#starts_on
+      = t('jobs.starts_on')
+    %dd.app-check-your-answers__answer
+      = format_date @vacancy.starts_on
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'starts_on'), 'aria-label': t('jobs.aria_labels.change_expected_start_date'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#ends_on
+      = t('jobs.ends_on')
+    %dd.app-check-your-answers__answer
+      = format_date @vacancy.ends_on
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'ends_on'), 'aria-label': t('jobs.aria_labels.change_end_date'), class: 'govuk-link'

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_supporting_documents.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_supporting_documents.html.haml
@@ -1,0 +1,16 @@
+%h2.govuk-heading-m.mb0
+  = t('jobs.supporting_documents')
+
+.govuk-body-s.mb1
+-#   = link_to documents_school_job_path, class: 'govuk-link', 'aria-label': 'Change supporting documents' do
+-#     Change
+-#     %span.govuk-visually-hidden the supporting documents
+
+%dl.app-check-your-answers.app-check-your-answers--short
+  - @vacancy.documents.each_with_index do |document, index|
+    - index_from_one = index + 1
+    .app-check-your-answers__contents
+      %dt.app-check-your-answers__question#supporting_documents
+        = "Document #{index_from_one}"
+      %dd.app-check-your-answers__answer
+        = document[:name]

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_supporting_documents.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_supporting_documents.html.haml
@@ -7,10 +7,15 @@
 -#     %span.govuk-visually-hidden the supporting documents
 
 %dl.app-check-your-answers.app-check-your-answers--short
-  - @vacancy.documents.each_with_index do |document, index|
-    - index_from_one = index + 1
+  - if @vacancy.documents.empty?
     .app-check-your-answers__contents
-      %dt.app-check-your-answers__question#supporting_documents
-        = "Document #{index_from_one}"
-      %dd.app-check-your-answers__answer
-        = document[:name]
+      %dt#supporting_documents{class: "govuk-!-font-weight-bold"}
+        = "No documents uploaded"
+  - else
+    - @vacancy.documents.each_with_index do |document, index|
+      - index_from_one = index + 1
+      .app-check-your-answers__contents
+        %dt.app-check-your-answers__question#supporting_documents
+          = "Document #{index_from_one}"
+        %dd.app-check-your-answers__answer
+          = document[:name]

--- a/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 RSpec.feature 'Hiring staff can edit a draft vacancy' do
   let(:school) { create(:school) }
+
+  let(:feature_enabled?) { false }
+
   before do
+    allow(UploadDocumentsFeature).to receive(:enabled?).and_return(feature_enabled?)
+
     stub_hiring_staff_auth(urn: school.urn)
   end
 

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -3,7 +3,11 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   let(:school) { create(:school) }
   let(:session_id) { SecureRandom.uuid }
 
+  let(:feature_enabled?) { false }
+
   before(:each) do
+    allow(UploadDocumentsFeature).to receive(:enabled?).and_return(feature_enabled?)
+
     stub_hiring_staff_auth(urn: school.urn, session_id: session_id)
   end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       context 'without feature upload documents enabled' do
-        scenario 'redirects to step 2, candidate profile, when submitted succesfully' do
+        scenario 'redirects to step 2, candidate profile, when submitted successfully' do
           visit new_school_job_path
 
           fill_in_job_specification_form_fields(vacancy)
@@ -143,7 +143,7 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      scenario 'redirects to step 3, application_details profile, when submitted succesfuly' do
+      scenario 'redirects to step 3, application_details profile, when submitted successfully' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
@@ -170,7 +170,7 @@ RSpec.feature 'Creating a vacancy' do
           .to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.supporting_documents.inclusion'))
       end
 
-      scenario 'redirects to step 2, candidate_specification, when choosing no' do
+      scenario 'redirects to step 3, application details, when choosing no' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
@@ -348,17 +348,19 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      scenario 'redirects to the vacancy review page when submitted succesfully' do
-        visit new_school_job_path
+      context 'when the upload feature flag is OFF' do
+        scenario 'redirects to the vacancy review page when submitted successfully' do
+          visit new_school_job_path
 
-        fill_in_job_specification_form_fields(vacancy)
-        click_on 'Save and continue'
-        fill_in_candidate_specification_form_fields(vacancy)
-        click_on 'Save and continue'
-        fill_in_application_details_form_fields(vacancy)
-        click_on 'Save and continue'
-        expect(page).to have_content(I18n.t('jobs.review'))
-        verify_all_vacancy_details(vacancy)
+          fill_in_job_specification_form_fields(vacancy)
+          click_on 'Save and continue'
+          fill_in_candidate_specification_form_fields(vacancy)
+          click_on 'Save and continue'
+          fill_in_application_details_form_fields(vacancy)
+          click_on 'Save and continue'
+          expect(page).to have_content(I18n.t('jobs.review'))
+          verify_all_vacancy_details(vacancy)
+        end
       end
     end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -362,6 +362,42 @@ RSpec.feature 'Creating a vacancy' do
           verify_all_vacancy_details(vacancy)
         end
       end
+
+      context 'with upload feature flag turned ON' do
+        let(:feature_enabled?) { true }
+        let(:document_upload) { double('document_upload') }
+
+        before do
+          allow(DocumentUpload).to receive(:new).and_return(document_upload)
+          allow(document_upload).to receive(:upload)
+          allow(document_upload).to receive_message_chain(:uploaded, :web_content_link).and_return('test_url')
+          allow(document_upload).to receive_message_chain(:uploaded, :id).and_return('test_id')
+          allow(document_upload).to receive(:safe_download).and_return(true)
+        end
+
+        scenario 'redirects to the vacancy review page when submitted successfully' do
+          visit new_school_job_path
+
+          fill_in_job_specification_form_fields(vacancy)
+          click_on 'Save and continue'
+
+          fill_in_supporting_documents_form_fields
+          click_on 'Save and continue'
+
+          upload_document(
+            'new_documents_form',
+            'documents-form-documents-field',
+            'spec/fixtures/files/blank_job_spec.pdf'
+          )
+          click_on 'Save and continue'
+
+          fill_in_application_details_form_fields(vacancy)
+          click_on 'Save and continue'
+
+          expect(page).to have_content(I18n.t('jobs.review'))
+          verify_all_vacancy_details(vacancy)
+        end
+      end
     end
 
     context '#review' do

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -368,18 +368,18 @@ RSpec.feature 'Creating a vacancy' do
         let(:document_upload) { double('document_upload') }
 
         before do
+          visit new_school_job_path
+
+          fill_in_job_specification_form_fields(vacancy)
+          click_on 'Save and continue'
+        end
+
+        scenario 'redirects to the vacancy review page when submitted successfully WITH uploaded documents' do
           allow(DocumentUpload).to receive(:new).and_return(document_upload)
           allow(document_upload).to receive(:upload)
           allow(document_upload).to receive_message_chain(:uploaded, :web_content_link).and_return('test_url')
           allow(document_upload).to receive_message_chain(:uploaded, :id).and_return('test_id')
           allow(document_upload).to receive(:safe_download).and_return(true)
-        end
-
-        scenario 'redirects to the vacancy review page when submitted successfully' do
-          visit new_school_job_path
-
-          fill_in_job_specification_form_fields(vacancy)
-          click_on 'Save and continue'
 
           fill_in_supporting_documents_form_fields
           click_on 'Save and continue'
@@ -389,12 +389,28 @@ RSpec.feature 'Creating a vacancy' do
             'documents-form-documents-field',
             'spec/fixtures/files/blank_job_spec.pdf'
           )
+
           click_on 'Save and continue'
 
           fill_in_application_details_form_fields(vacancy)
           click_on 'Save and continue'
 
           expect(page).to have_content(I18n.t('jobs.review'))
+          expect(page).to_not have_content('No documents uploaded')
+
+          verify_all_vacancy_details(vacancy)
+        end
+
+        scenario 'redirects to the vacancy review page when submitted successfully WITHOUT uploaded documents' do
+          select_no_for_supporting_documents
+          click_on 'Save and continue'
+
+          fill_in_application_details_form_fields(vacancy)
+          click_on 'Save and continue'
+
+          expect(page).to have_content(I18n.t('jobs.review'))
+          expect(page).to have_content('No documents uploaded')
+
           verify_all_vacancy_details(vacancy)
         end
       end

--- a/spec/form_models/candidate_specification_form_spec.rb
+++ b/spec/form_models/candidate_specification_form_spec.rb
@@ -1,8 +1,11 @@
 require 'rails_helper'
 RSpec.describe CandidateSpecificationForm, type: :model do
   subject { CandidateSpecificationForm.new({}) }
+  let(:feature_enabled?) { false }
 
   describe 'validations' do
+    before { allow(UploadDocumentsFeature).to receive(:enabled?).and_return(feature_enabled?) }
+
     describe '#education' do
       let(:candidate_specification_form) { CandidateSpecificationForm.new(education: education) }
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe Vacancy, type: :model do
   end
 
   describe 'validations' do
+    let(:feature_enabled?) { false }
+
+    before { allow(UploadDocumentsFeature).to receive(:enabled?).and_return(feature_enabled?) }
+
     context 'a new record' do
       it { should validate_presence_of(:job_title) }
       it { should validate_presence_of(:job_description) }
@@ -39,9 +43,19 @@ RSpec.describe Vacancy, type: :model do
     context 'a record saved with job spec details' do
       subject { create(:vacancy) }
 
-      it { should validate_presence_of(:education) }
-      it { should validate_presence_of(:qualifications) }
-      it { should validate_presence_of(:experience) }
+      context 'when upload document feature is OFF, validates candidate specification fields' do
+        it { should validate_presence_of(:education) }
+        it { should validate_presence_of(:qualifications) }
+        it { should validate_presence_of(:experience) }
+      end
+
+      context 'when upload document feature is ON, does not validate candidate specification fields' do
+        let(:feature_enabled?) { true }
+
+        it { should_not validate_presence_of(:education) }
+        it { should_not validate_presence_of(:qualifications) }
+        it { should_not validate_presence_of(:experience) }
+      end
     end
 
     context 'set minimum length of mandatory fields' do

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -100,9 +100,14 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.starts_on) if vacancy.starts_on?
     expect(page).to have_content(vacancy.ends_on) if vacancy.ends_on?
 
-    expect(page.html).to include(vacancy.education)
-    expect(page.html).to include(vacancy.qualifications)
-    expect(page.html).to include(vacancy.experience)
+    if UploadDocumentsFeature.enabled?
+      expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+    else
+      expect(page.html).to include(vacancy.education)
+      expect(page.html).to include(vacancy.qualifications)
+      expect(page.html).to include(vacancy.experience)
+    end
+
     expect(page).to have_content(vacancy.leadership.title)
 
     expect(page).to have_content(vacancy.contact_email)

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -38,6 +38,10 @@ module VacancyHelpers
     find('label[for="supporting-documents-form-supporting-documents-yes-field"]').click
   end
 
+  def select_no_for_supporting_documents
+    find('label[for="supporting-documents-form-supporting-documents-no-field"]').click
+  end
+
   def upload_document(form_id, input_name, filepath)
     page.attach_file(input_name, Rails.root.join(filepath))
     # Submit form on file upload without requiring Javascript driver


### PR DESCRIPTION
This PR deals with [UD9](https://dfedigital.atlassian.net/browse/TEVA-416) of the Upload Documents Feature.

We want the Supporting documents section on the summary page to display to the user this text: 'No documents uploaded' when the user has not uploaded any files during their publishing journey.

Screenshot:
<img width="440" alt="Screenshot 2020-02-24 at 12 40 41" src="https://user-images.githubusercontent.com/32823756/75235704-985a3580-57b4-11ea-83e0-f23ee3e372f1.png">
