### PR TITLE
Display no documents uploaded message

### DIFF
--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_supporting_documents.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_supporting_documents.html.haml
@@ -7,10 +7,15 @@
     %span.govuk-visually-hidden the supporting documents
 
 %dl.app-check-your-answers.app-check-your-answers--short
-  - @vacancy.documents.each_with_index do |document, index|
-    - index_from_one = index + 1
+  - if @vacancy.documents.none?
     .app-check-your-answers__contents
-      %dt.app-check-your-answers__question#supporting_documents
-        = "Document #{index_from_one}"
-      %dd.app-check-your-answers__answer
-        = document[:name]
+      %dt#supporting_documents{class: "govuk-!-font-weight-bold"}
+        = t('jobs.no_supporting_documents')
+  - else
+    - @vacancy.documents.each_with_index do |document, index|
+      - index_from_one = index + 1
+      .app-check-your-answers__contents
+        %dt.app-check-your-answers__question#supporting_documents
+          = "Document #{index_from_one}"
+        %dd.app-check-your-answers__answer
+          = document[:name]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,6 +168,7 @@ en:
     upload_file: 'Upload files'
     select_file: 'Select a file'
     no_files_message: 'No files chosen'
+    no_supporting_documents: 'No documents uploaded'
     file_delete_error_message: 'An error occurred while removing %{filename}'
     file_delete_success_message: '%{filename} was removed'
     file_google_error_message: '%{filename} could not be uploaded - try again'

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -38,6 +38,10 @@ module VacancyHelpers
     find('label[for="supporting-documents-form-supporting-documents-yes-field"]').click
   end
 
+  def select_no_for_supporting_documents
+    find('label[for="supporting-documents-form-supporting-documents-no-field"]').click
+  end
+
   def upload_document(form_id, input_name, filepath)
     page.attach_file(input_name, Rails.root.join(filepath))
     # Submit form on file upload without requiring Javascript driver
@@ -100,9 +104,9 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.starts_on) if vacancy.starts_on?
     expect(page).to have_content(vacancy.ends_on) if vacancy.ends_on?
 
-    if UploadDocumentsFeature.enabled?
-      expect(page).to have_content(I18n.t('jobs.supporting_documents'))
-    else
+    expect(page).to have_content(I18n.t('jobs.supporting_documents')) if vacancy.show_supporting_documents?
+
+    if vacancy.show_candidate_specification?
       expect(page.html).to include(vacancy.education)
       expect(page.html).to include(vacancy.qualifications)
       expect(page.html).to include(vacancy.experience)


### PR DESCRIPTION
This PR deals with [UD9](https://dfedigital.atlassian.net/browse/TEVA-416) of the Upload Documents Feature.

We want the Supporting documents section on the summary page to display to the user this text: 'No documents uploaded' when the user has not uploaded any files during their publishing journey.

Screenshot:
<img width="440" alt="Screenshot 2020-02-24 at 12 40 41" src="https://user-images.githubusercontent.com/32823756/75235704-985a3580-57b4-11ea-83e0-f23ee3e372f1.png">
