### PR TITLE
UD8: Add change upload documents link to summary page

### DIFF
--- a/app/controllers/hiring_staff/vacancies/documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/documents_controller.rb
@@ -55,8 +55,12 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
     redirect_to supporting_documents_school_job_path unless supporting_documents
   end
 
+  def next_step
+    application_details_school_job_path
+  end
+
   def redirect_to_next_step_if_save_and_continue
-    redirect_to application_details_school_job_path if params[:commit] == 'Save and continue'
+    redirect_to_next_step(vacancy) if params[:commit] == 'Save and continue'
   end
 
   def process_documents

--- a/app/controllers/hiring_staff/vacancies/documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/documents_controller.rb
@@ -52,7 +52,7 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
 
   def redirect_if_no_supporting_documents
     supporting_documents = session[:vacancy_attributes]['supporting_documents']
-    redirect_to supporting_documents_school_job_path unless supporting_documents == 'yes'
+    redirect_to supporting_documents_school_job_path unless supporting_documents
   end
 
   def redirect_to_next_step_if_save_and_continue

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_supporting_documents.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_supporting_documents.html.haml
@@ -1,10 +1,10 @@
 %h2.govuk-heading-m.mb0
   = t('jobs.supporting_documents')
 
-.govuk-body-s.mb1
--#   = link_to documents_school_job_path, class: 'govuk-link', 'aria-label': 'Change supporting documents' do
--#     Change
--#     %span.govuk-visually-hidden the supporting documents
+.govuk-body-s.mb1#change-supporting-documents
+  = link_to documents_school_job_path, class: 'govuk-link', 'aria-label': 'Change supporting documents' do
+    Change
+    %span.govuk-visually-hidden the supporting documents
 
 %dl.app-check-your-answers.app-check-your-answers--short
   - @vacancy.documents.each_with_index do |document, index|

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -655,15 +655,6 @@ RSpec.feature 'Creating a vacancy' do
 
       context 'editing the supporting_documents' do
         let(:feature_enabled?) { true }
-        let(:document_upload) { double('document_upload') }
-
-        before do
-          allow(DocumentUpload).to receive(:new).and_return(document_upload)
-          allow(document_upload).to receive(:upload)
-          allow(document_upload).to receive_message_chain(:uploaded, :web_content_link).and_return('test_url')
-          allow(document_upload).to receive_message_chain(:uploaded, :id).and_return('test_id')
-          allow(document_upload).to receive(:safe_download).and_return(true)
-        end
 
         scenario 'updates the vacancy details' do
           visit new_school_job_path
@@ -677,7 +668,7 @@ RSpec.feature 'Creating a vacancy' do
 
           fill_in_application_details_form_fields(vacancy)
           click_on 'Save and continue'
-          
+
           expect(page).to have_content('Review this job')
 
           within '#change-supporting-documents' do
@@ -686,10 +677,10 @@ RSpec.feature 'Creating a vacancy' do
 
           expect(page).to have_content('Step 2 of 3')
           expect(page.current_path).to eq(documents_school_job_path)
-          
 
-          # expect(page).to have_content("Review this job for #{school.name}")
-          # expect(page).to have_content('Teaching diploma')
+          click_on 'Save and continue'
+
+          expect(page).to have_content("Review this job for #{school.name}")
         end
       end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -568,7 +568,7 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content('An edited job title')
         end
 
-        scenario 'tracks any changes to  the vacancy details' do
+        scenario 'tracks any changes to the vacancy details' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
           current_title = vacancy.job_title
           current_slug = vacancy.slug
@@ -650,6 +650,46 @@ RSpec.feature 'Creating a vacancy' do
 
           expect(page).to have_content('Confirm and submit job')
           expect(page).to have_content('essential requirements')
+        end
+      end
+
+      context 'editing the supporting_documents' do
+        let(:feature_enabled?) { true }
+        let(:document_upload) { double('document_upload') }
+
+        before do
+          allow(DocumentUpload).to receive(:new).and_return(document_upload)
+          allow(document_upload).to receive(:upload)
+          allow(document_upload).to receive_message_chain(:uploaded, :web_content_link).and_return('test_url')
+          allow(document_upload).to receive_message_chain(:uploaded, :id).and_return('test_id')
+          allow(document_upload).to receive(:safe_download).and_return(true)
+        end
+
+        scenario 'updates the vacancy details' do
+          visit new_school_job_path
+
+          fill_in_job_specification_form_fields(vacancy)
+          click_on 'Save and continue'
+
+          # Choose 'no'
+          find('label[for="supporting-documents-form-supporting-documents-no-field"]').click
+          click_on 'Save and continue'
+
+          fill_in_application_details_form_fields(vacancy)
+          click_on 'Save and continue'
+          
+          expect(page).to have_content('Review this job')
+
+          within '#change-supporting-documents' do
+            click_on 'Change'
+          end
+
+          expect(page).to have_content('Step 2 of 3')
+          expect(page.current_path).to eq(documents_school_job_path)
+          
+
+          # expect(page).to have_content("Review this job for #{school.name}")
+          # expect(page).to have_content('Teaching diploma')
         end
       end
 


### PR DESCRIPTION
## Jira ticket URL:

https://dfedigital.atlassian.net/secure/RapidBoard.jspa?rapidView=21&modal=detail&selectedIssue=TEVA-414&search=ud8

## Changes in this PR:

This PR adds the link from the Review page section for supporting documents to the documents index page, and ensures that clicking 'Save and continue' from that index page returns the user to the Review page. This navigation sequence was checked with Chris (UX).

This used `application_controller.rb`'s `redirect_to_next_step` method.

Question for discussion: is it OK to not include adding or removing a document in the tests, but instead just test the pathway (page sequence)? By not including uploading in the tests, the tests are simpler and quicker. But we don't have the security of knowing that a change in supporting documents results in a change in the review page view, except insofar as existing tests for uploading cover this. My feeling is it's fine not to include uploading in the tests, since the uploading is performed by the same route (documents index page) in both the existing tests (for vacancy creation) and in the case of editing via the review link introduced by this PR.

## Before:

<img width="377" alt="Screenshot 2020-02-26 at 12 21 46" src="https://user-images.githubusercontent.com/60350599/75344474-936bb380-5892-11ea-871b-f80564629254.png">

## After:

<img width="377" alt="Screenshot 2020-02-26 at 12 20 14" src="https://user-images.githubusercontent.com/60350599/75344411-79ca6c00-5892-11ea-93b5-b3d79b6472ee.png">
<img width="377" alt="Screenshot 2020-02-26 at 12 20 51" src="https://user-images.githubusercontent.com/60350599/75344413-7a630280-5892-11ea-89a0-f69544b97fc2.png">
