### PR TITLE
Move filehandle creating until after records.none?

### DIFF
--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -80,7 +80,6 @@ class ExportTablesToBigQuery
         table: table
       })
 
-      fh = File.new(file, 'w')
 
       records = table.constantize
       records_count = records.count
@@ -94,6 +93,8 @@ class ExportTablesToBigQuery
 
       Rails.logger.info(logging_details.to_json)
       next if records.none?
+
+      fh = File.new(file, 'w')
 
       analyze_data_field(records, table.to_s) if records.all.first.respond_to?(:data)
 

--- a/spec/lib/export_tables_to_big_query_spec.rb
+++ b/spec/lib/export_tables_to_big_query_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+require 'export_tables_to_big_query'
+
+RSpec.describe ExportTablesToBigQuery do
+  let(:bigquery) do
+    double('bigquery', dataset: dataset)
+  end
+
+  let(:dataset) do
+    double('dataset').as_null_object
+  end
+
+  let(:storage) do
+    double('storage').as_null_object
+  end
+
+  subject do
+    described_class.new(bigquery: bigquery, storage: storage)
+  end
+
+  before do
+    allow(Dir).to receive(:children).and_return([])
+  end
+
+  describe '#run!' do
+    before do
+      allow(ApplicationRecord.connection).to receive(:tables).and_return(tables)
+      allow_any_instance_of(String).to receive(:constantize).and_return(table)
+    end
+
+    context 'when a table has no records' do
+      let(:tables) do
+        %w[empty_table]
+      end
+
+      let(:table) do
+        double('EmptyTable', count: 0, none?: true)
+      end
+
+      it 'an empty json tmpfile does not get created for that table' do
+        expect(File).not_to receive(:new).with(an_instance_of(Pathname), 'w')
+        subject.run!
+      end
+    end
+
+    context 'when a table has records' do
+      let(:tables) do
+        %w[table_with_records]
+      end
+
+      let(:table) do
+        double('TableWithRecords', count: 1, none?: false).as_null_object
+      end
+
+      it 'a json tmpfile gets created for that table' do
+        expect(File).to receive(:new).with(an_instance_of(Pathname), 'w').and_return(double.as_null_object)
+        subject.run!
+      end
+    end
+  end
+end


### PR DESCRIPTION
This resolves the runtime problem of the BigQuery export on TEVA-553. As
I originally wrote it, the file gets written even if there are no
records. This results in a zero-length file being uploaded to the cloud
storage bucket and imported to BigQuery. BigQuery throws an exception
because a file with no content at all cannot contain a schema.

I have moved the filenhandle creation for each new file until after the
check for empty tables. If a table is empty, its file gets skipped.

