### PR TITLE
Delete docs on vacancy deletion

### DIFF
--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -2,7 +2,7 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
   before_action :set_vacancy, only: %i[review]
 
   def show
-    vacancy = current_school.vacancies.active.find(id)
+    vacancy = find_active_vacancy_by_id
     unless vacancy.published?
       return redirect_to school_job_review_path(vacancy.id),
                          alert: I18n.t('messages.jobs.view.only_published')
@@ -39,10 +39,9 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
   end
 
   def destroy
-    @vacancy = current_school.vacancies.active.find(id)
+    @vacancy = find_active_vacancy_by_id
     @vacancy.delete_documents
     @vacancy.trash!
-    # binding.pry
     remove_google_index(@vacancy)
     Auditor::Audit.new(@vacancy, 'vacancy.delete', current_session_id).log
 
@@ -87,5 +86,9 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
 
   def set_vacancy
     @vacancy = current_school.vacancies.active.find(vacancy_id)
+  end
+
+  def find_active_vacancy_by_id
+    current_school.vacancies.active.find(id)
   end
 end

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -40,7 +40,9 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
 
   def destroy
     @vacancy = current_school.vacancies.active.find(id)
+    @vacancy.delete_documents
     @vacancy.trash!
+    # binding.pry
     remove_google_index(@vacancy)
     Auditor::Audit.new(@vacancy, 'vacancy.delete', current_session_id).log
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -261,6 +261,10 @@ class Vacancy < ApplicationRecord
     experience.present? && qualifications.present? && education.present?
   end
 
+  def delete_documents
+    self.documents.each{ |document| DocumentDelete.new(document).delete }
+  end
+
   private
 
   def slug_candidates

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -262,7 +262,7 @@ class Vacancy < ApplicationRecord
   end
 
   def delete_documents
-    self.documents.each{ |document| DocumentDelete.new(document).delete }
+    self.documents.each { |document| DocumentDelete.new(document).delete }
   end
 
   private

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -10,43 +10,43 @@ FactoryBot.define do
       create_list :document, 3, vacancy: vacancy
     end
 
-    job_title { Faker::Lorem.sentence[1...30].strip }
-    job_description { Faker::Lorem.paragraph(sentence_count: 4) }
-    education { Faker::Lorem.paragraph(sentence_count: 4) }
-    qualifications { Faker::Lorem.paragraph(sentence_count: 4) }
-    experience { Faker::Lorem.paragraph(sentence_count: 4) }
-    status { :published }
-    working_patterns { ['full_time'] }
-    expires_on { Faker::Time.forward(days: 14) }
-    expiry_time { expires_on&.change(sec: 0) }
-    publish_on { Time.zone.today }
-    minimum_salary { SalaryValidator::MIN_SALARY_ALLOWED }
-    maximum_salary { SalaryValidator::MAX_SALARY_LIMIT - 100 }
-    contact_email { Faker::Internet.email }
     application_link { Faker::Internet.url }
     benefits { Faker::Lorem.sentence }
-    newly_qualified_teacher { true }
-    reference { SecureRandom.uuid }
+    contact_email { Faker::Internet.email }
+    education { Faker::Lorem.paragraph(sentence_count: 4) }
+    experience { Faker::Lorem.paragraph(sentence_count: 4) }
+    expires_on { Faker::Time.forward(days: 14) }
+    expiry_time { expires_on&.change(sec: 0) }
     hired_status { nil }
+    job_description { Faker::Lorem.paragraph(sentence_count: 4) }
+    job_title { Faker::Lorem.sentence[1...30].strip }
     listed_elsewhere { nil }
+    maximum_salary { SalaryValidator::MAX_SALARY_LIMIT - 100 }
+    minimum_salary { SalaryValidator::MIN_SALARY_ALLOWED }
+    newly_qualified_teacher { true }
+    publish_on { Time.zone.today }
+    qualifications { Faker::Lorem.paragraph(sentence_count: 4) }
+    reference { SecureRandom.uuid }
+    status { :published }
     supporting_documents { 'yes' }
+    working_patterns { ['full_time'] }
 
     trait :fail_minimum_validation do
-      job_title { Faker::Job.title[0..2] }
-      job_description { Faker::Lorem.paragraph[0..5] }
-      experience { Faker::Lorem.paragraph[0..7] }
       education { Faker::Lorem.paragraph[0..8] }
+      experience { Faker::Lorem.paragraph[0..7] }
+      job_description { Faker::Lorem.paragraph[0..5] }
+      job_title { Faker::Job.title[0..2] }
       qualifications { Faker::Lorem.paragraph[0...8] }
     end
 
     trait :fail_maximum_validation do
-      job_title { Faker::Lorem.characters(number: 150) }
-      job_description { Faker::Lorem.characters(number: 50001) }
-      experience { Faker::Lorem.characters(number: 1010) }
       education { Faker::Lorem.characters(number: 1005) }
-      qualifications { Faker::Lorem.characters(number: 1002) }
-      minimum_salary { (SalaryValidator::MAX_SALARY_LIMIT + 100) }
+      experience { Faker::Lorem.characters(number: 1010) }
+      job_description { Faker::Lorem.characters(number: 50001) }
+      job_title { Faker::Lorem.characters(number: 150) }
       maximum_salary { SalaryValidator::MAX_SALARY_LIMIT + 100 }
+      minimum_salary { (SalaryValidator::MAX_SALARY_LIMIT + 100) }
+      qualifications { Faker::Lorem.characters(number: 1002) }
     end
 
     trait :fail_minimum_salary_max_validation do

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
     reference { SecureRandom.uuid }
     hired_status { nil }
     listed_elsewhere { nil }
+    supporting_documents { 'yes' }
 
     trait :fail_minimum_validation do
       job_title { Faker::Job.title[0..2] }

--- a/spec/features/hiring_staff_can_delete_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_delete_vacancies_spec.rb
@@ -19,19 +19,10 @@ RSpec.feature 'School deleting vacancies' do
   end
 
   scenario 'Deleting a vacancy triggers deletion of its supporting documents' do
-    document1 = create(:document, name: 'document1.pdf')
-    document2 = create(:document, name: 'document2.pdf')
-    vacancy = create(:vacancy,
-      school: school,
-      documents: [document1, document2])
+    vacancy = create(:vacancy, school: school)
 
-    document1_delete = instance_double(DocumentDelete)
-    document2_delete = instance_double(DocumentDelete)
-    allow(DocumentDelete).to receive(:new).with(document1).and_return(document1_delete)
-    allow(DocumentDelete).to receive(:new).with(document2).and_return(document1_delete)
-
-    expect(document1_delete).to receive(:delete)
-    expect(document2_delete).to receive(:delete)
+    expect(vacancy).to receive(:delete_documents).once
+    # vacancy.delete_documents
 
     delete_vacancy(school, vacancy.id)
   end

--- a/spec/features/hiring_staff_can_delete_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_delete_vacancies_spec.rb
@@ -18,6 +18,24 @@ RSpec.feature 'School deleting vacancies' do
     expect(page).to have_content('The job has been deleted')
   end
 
+  scenario 'Deleting a vacancy triggers deletion of its supporting documents' do
+    document1 = create(:document, name: 'document1.pdf')
+    document2 = create(:document, name: 'document2.pdf')
+    vacancy = create(:vacancy,
+      school: school,
+      documents: [document1, document2])
+
+    document1_delete = instance_double(DocumentDelete)
+    document2_delete = instance_double(DocumentDelete)
+    allow(DocumentDelete).to receive(:new).with(document1).and_return(document1_delete)
+    allow(DocumentDelete).to receive(:new).with(document2).and_return(document1_delete)
+
+    expect(document1_delete).to receive(:delete)
+    expect(document2_delete).to receive(:delete)
+
+    delete_vacancy(school, vacancy.id)
+  end
+
   scenario 'The last vacancy is deleted' do
     vacancy = create(:vacancy, school: school)
 

--- a/spec/features/hiring_staff_can_delete_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_delete_vacancies_spec.rb
@@ -1,43 +1,37 @@
 require 'rails_helper'
 RSpec.feature 'School deleting vacancies' do
   let(:school) { create(:school) }
+  let(:vacancy) { create(:vacancy, school: school) }
   let(:session_id) { SecureRandom.uuid }
 
   before(:each) do
     stub_hiring_staff_auth(urn: school.urn, session_id: session_id)
+    stub_document_deletion_of_vacancy
   end
 
   scenario 'A school can delete a vacancy from a list' do
-    vacancy1 = create(:vacancy, school: school)
     vacancy2 = create(:vacancy, school: school)
 
-    delete_vacancy(school, vacancy1.id)
+    delete_vacancy(school, vacancy.id)
 
-    expect(page).not_to have_content(vacancy1.job_title)
+    expect(page).not_to have_content(vacancy.job_title)
     expect(page).to have_content(vacancy2.job_title)
     expect(page).to have_content('The job has been deleted')
   end
 
   scenario 'Deleting a vacancy triggers deletion of its supporting documents' do
-    vacancy = create(:vacancy, school: school)
-
-    expect(vacancy).to receive(:delete_documents).once
-    # vacancy.delete_documents
+    expect(vacancy).to receive(:delete_documents)
 
     delete_vacancy(school, vacancy.id)
   end
 
   scenario 'The last vacancy is deleted' do
-    vacancy = create(:vacancy, school: school)
-
     delete_vacancy(school, vacancy.id)
 
     expect(page).to have_content(I18n.t('schools.no_jobs.heading'))
   end
 
   scenario 'Audits the vacancy deletion' do
-    vacancy = create(:vacancy, school: school)
-
     delete_vacancy(school, vacancy.id)
 
     activity = vacancy.activities.last
@@ -46,13 +40,13 @@ RSpec.feature 'School deleting vacancies' do
   end
 
   scenario 'Notifies the Google index service' do
-    vacancy = create(:vacancy, school: school)
-
     expect_any_instance_of(HiringStaff::Vacancies::ApplicationController)
       .to receive(:remove_google_index).with(vacancy)
 
     delete_vacancy(school, vacancy.id)
   end
+
+  private
 
   def delete_vacancy(school, vacancy_id)
     visit school_path(school)
@@ -60,5 +54,16 @@ RSpec.feature 'School deleting vacancies' do
     within("tr#school_vacancy_presenter_#{vacancy_id}") do
       click_on 'Delete'
     end
+  end
+
+  def stub_document_deletion_of_vacancy
+    # Stub vacancy lookup so that the controller uses these tests' vacancy objects
+    # to wrap the vacancy, instead of creating its own new vacancy object.
+    # We need to use a `vacancy` object created in the test so that we can stub out the method
+    # Vacancy#delete_documents, which otherwise will attempt HTTP connections.
+    hiring_staff_vacancies_controller = HiringStaff::VacanciesController.new
+    allow(HiringStaff::VacanciesController).to receive(:new).and_return(hiring_staff_vacancies_controller)
+    allow(hiring_staff_vacancies_controller).to receive(:find_active_vacancy_by_id).and_return(vacancy)
+    allow(vacancy).to receive(:delete_documents).and_return(nil)
   end
 end

--- a/spec/features/hiring_staff_can_delete_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_delete_vacancies_spec.rb
@@ -11,11 +11,7 @@ RSpec.feature 'School deleting vacancies' do
     vacancy1 = create(:vacancy, school: school)
     vacancy2 = create(:vacancy, school: school)
 
-    visit school_path(school)
-
-    within("tr#school_vacancy_presenter_#{vacancy1.id}") do
-      click_on 'Delete'
-    end
+    delete_vacancy(school, vacancy1.id)
 
     expect(page).not_to have_content(vacancy1.job_title)
     expect(page).to have_content(vacancy2.job_title)
@@ -25,10 +21,7 @@ RSpec.feature 'School deleting vacancies' do
   scenario 'The last vacancy is deleted' do
     vacancy = create(:vacancy, school: school)
 
-    visit school_path(school)
-    within("tr#school_vacancy_presenter_#{vacancy.id}") do
-      click_on 'Delete'
-    end
+    delete_vacancy(school, vacancy.id)
 
     expect(page).to have_content(I18n.t('schools.no_jobs.heading'))
   end
@@ -36,11 +29,7 @@ RSpec.feature 'School deleting vacancies' do
   scenario 'Audits the vacancy deletion' do
     vacancy = create(:vacancy, school: school)
 
-    visit school_path(school)
-
-    within("tr#school_vacancy_presenter_#{vacancy.id}") do
-      click_on 'Delete'
-    end
+    delete_vacancy(school, vacancy.id)
 
     activity = vacancy.activities.last
     expect(activity.session_id).to eq(session_id)
@@ -53,9 +42,13 @@ RSpec.feature 'School deleting vacancies' do
     expect_any_instance_of(HiringStaff::Vacancies::ApplicationController)
       .to receive(:remove_google_index).with(vacancy)
 
+    delete_vacancy(school, vacancy.id)
+  end
+
+  def delete_vacancy(school, vacancy_id)
     visit school_path(school)
 
-    within("tr#school_vacancy_presenter_#{vacancy.id}") do
+    within("tr#school_vacancy_presenter_#{vacancy_id}") do
       click_on 'Delete'
     end
   end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -297,7 +297,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       context 'when deleting uploaded files', js: true do
-        let(:document_delete) { double('document_upload') }
+        let(:document_delete) { double('document_delete') }
 
         before do
           allow(DocumentDelete).to receive(:new).and_return(document_delete)

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -556,12 +556,14 @@ RSpec.describe Vacancy, type: :model do
     it 'deletes all attached supporting documents' do
       document1 = create(:document, name: 'document1.pdf')
       document2 = create(:document, name: 'document2.pdf')
+
       vacancy = create(:vacancy, documents: [document1, document2])
 
       document1_delete = instance_double(DocumentDelete)
       document2_delete = instance_double(DocumentDelete)
+
       allow(DocumentDelete).to receive(:new).with(document1).and_return(document1_delete)
-      allow(DocumentDelete).to receive(:new).with(document2).and_return(document1_delete)
+      allow(DocumentDelete).to receive(:new).with(document2).and_return(document2_delete)
 
       expect(document1_delete).to receive(:delete)
       expect(document2_delete).to receive(:delete)

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -552,6 +552,24 @@ RSpec.describe Vacancy, type: :model do
     end
   end
 
+  describe '#delete_documents' do
+    it 'deletes all attached supporting documents' do
+      document1 = create(:document, name: 'document1.pdf')
+      document2 = create(:document, name: 'document2.pdf')
+      vacancy = create(:vacancy, documents: [document1, document2])
+
+      document1_delete = instance_double(DocumentDelete)
+      document2_delete = instance_double(DocumentDelete)
+      allow(DocumentDelete).to receive(:new).with(document1).and_return(document1_delete)
+      allow(DocumentDelete).to receive(:new).with(document2).and_return(document1_delete)
+
+      expect(document1_delete).to receive(:delete)
+      expect(document2_delete).to receive(:delete)
+
+      vacancy.delete_documents
+    end
+  end
+
   context 'content sanitization' do
     it '#job_description' do
       html = '<p> a paragraph <a href=\'link\'>with a link</a></p><br>'

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -516,15 +516,9 @@ RSpec.describe Vacancy, type: :model do
 
   describe 'when supporting documents are provided' do
     it 'should return the document name' do
-      document = create(
-        :document, name: 'Test.png',
-        size: 1000,
-        content_type: 'image/png',
-        download_url: 'test/test.png',
-        google_drive_id: 'testid'
-      )
+      document = create(:document, name: 'Test_doc.png')
       vacancy = create(:vacancy, documents: [document])
-      expect(vacancy.documents.first.name).to eq('Test.png')
+      expect(vacancy.documents.first.name).to eq('Test_doc.png')
     end
   end
 


### PR DESCRIPTION
## Jira ticket URL:

https://dfedigital.atlassian.net/secure/RapidBoard.jspa?rapidView=21&modal=detail&selectedIssue=TEVA-424

## Changes in this PR:

With this PR, a request to delete a vacancy leads to a DocumentDelete object deleting each attached document. I don't test this all the way down the full stack as it were, because there is no change in the view and I trust the existing tests on the DocumentDelete; so I test that Vacancy#delete_documents is called, and that Vacancy#delete_documents calls the appropriate methods on DocumentDelete.
