### PR TITLE
Rename users dsi_users in BigQuery and add approvers

### DIFF
--- a/bigquery/monitor-tables-for-errors.sql
+++ b/bigquery/monitor-tables-for-errors.sql
@@ -14,17 +14,17 @@ IF
       "Table not updated last month as expected",
     IF
       (table LIKE "%school"
-        AND row_count <28000,
+        AND row_count <28000, #sets a minimum threshold for the number of schools that should be in the database - this should not change much unless we change the scope, so going below this threshold most likely means the dataset in BQ is incomplete
         "Table appears incomplete",
         #check whether there are at least this many schools in the schools table
       IF
         (table = "dsi_users"
-          AND row_count <25000,
+          AND row_count <25000, #sets a minimum threshold for the number of users that should be in the DSI database - this should not decrease, so going below this threshold most likely means the dataset in BQ is incomplete
           "Table appears incomplete",
           #check whether there are at least this many users in the dsi_users table
         IF
           (table = "dsi_approvers"
-            AND row_count <35000,
+            AND row_count <35000, #sets a minimum threshold for the number of approvers that should be in the DSI database - this should not decrease, so going below this threshold most likely means the dataset in BQ is incomplete
             "Table appears incomplete",
             #check whether there are at least this many approvers in the dsi_approvers table
           IF

--- a/bigquery/monitor-tables-for-errors.sql
+++ b/bigquery/monitor-tables-for-errors.sql
@@ -15,27 +15,56 @@ IF
     IF
       (table LIKE "%school"
         AND row_count <28000,
-        "Table appears incomplete", #check whether there are at least this many schools in the schools table
+        "Table appears incomplete",
+        #check whether there are at least this many schools in the schools table
       IF
-        ((table ="users"
-            AND (
-            SELECT
-              MAX(update_datetime)
-            FROM
-              `teacher-vacancy-service.production_dataset.users` ) < TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 3 DAY)) #check the last updated date for any user's data from DSI - produce error if more than three days old (i.e. if longer ago than the last working day)
-          OR (table LIKE "feb20_%"
-            AND (
-            SELECT
-              MAX(updated_at)
-            FROM
-              `teacher-vacancy-service.production_dataset.feb20_audit_data` ) < TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 3 DAY)) OR (table IN("alert_run","audit_data","detailed_school_type","general_feedback","leadership","pay_scale","region","school","school_type","subject","subscription","transaction_auditor","user","vacancy","vacancy_publish_feedback") #check the last entry in the audit log in the feb20_ tables from our database - error if this was more than 3 days ago
-            AND (
-            SELECT
-              MAX(PARSE_DATETIME("%e %B %E4Y %R",string_field_3))
-            FROM
-              `teacher-vacancy-service.production_dataset.audit_data` ) < DATETIME_SUB(CURRENT_DATETIME(),INTERVAL 3 DAY)), #check the last entry in the audit log in the legacy tables from our database - error if this was more than 3 days ago
-          "Latest date a row was updated in a frequently updated table from this source was at least 3 days ago",
-          "OK")))) AS status
+        (table = "dsi_users"
+          AND row_count <25000,
+          "Table appears incomplete",
+          #check whether there are at least this many users in the dsi_users table
+        IF
+          (table = "dsi_approvers"
+            AND row_count <35000,
+            "Table appears incomplete",
+            #check whether there are at least this many approvers in the dsi_approvers table
+          IF
+            ((table ="dsi_users"
+                AND (
+                SELECT
+                  MAX(update_datetime)
+                FROM
+                  `teacher-vacancy-service.production_dataset.dsi_users` ) < TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 3 DAY)) #check the last updated date for any user's data from DSI - produce error if more than three days old (i.e. if longer ago than the last working day)
+              OR (table LIKE "feb20_%"
+                AND (
+                SELECT
+                  MAX(updated_at)
+                FROM
+                  `teacher-vacancy-service.production_dataset.feb20_audit_data` ) < TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 3 DAY))
+              OR (table IN("alert_run",
+                  "audit_data",
+                  "detailed_school_type",
+                  "general_feedback",
+                  "leadership",
+                  "pay_scale",
+                  "region",
+                  "school",
+                  "school_type",
+                  "subject",
+                  "subscription",
+                  "transaction_auditor",
+                  "user",
+                  "vacancy",
+                  "vacancy_publish_feedback") #check the last entry in the audit log in the feb20_ tables from our database - error if this was more than 3 days ago
+                AND (
+                SELECT
+                  MAX(PARSE_DATETIME("%e %B %E4Y %R",
+                      string_field_3))
+                FROM
+                  `teacher-vacancy-service.production_dataset.audit_data` ) < DATETIME_SUB(CURRENT_DATETIME(),
+                  INTERVAL 3 DAY)),
+              #check the last entry in the audit log in the legacy tables from our database - error if this was more than 3 days ago
+              "Latest date a row was updated in a frequently updated table from this source was at least 3 days ago",
+              "OK")))))) AS status
 FROM (
   SELECT
     table,

--- a/bigquery/schools_joined_with_metrics.sql
+++ b/bigquery/schools_joined_with_metrics.sql
@@ -9,10 +9,10 @@ WITH
     `teacher-vacancy-service.production_dataset.dsi_users` AS users
   GROUP BY
     school_urn ),
-  school_approver_metrics AS ( #work out current user-related metric values for all individual schools for use in the main query later
+  school_approver_metrics AS ( #work out current approver-related metric values for all individual schools for use in the main query later
   SELECT
     school_urn AS urn,
-    COUNT(*) AS number_of_approvers #the current number of users this school has authorised to access TV in DSI
+    COUNT(*) AS number_of_approvers #the current number of approvers this school has to authorise access to services in DSI
   FROM
     `teacher-vacancy-service.production_dataset.dsi_approvers` AS approvers
   GROUP BY

--- a/bigquery/schools_joined_with_metrics.sql
+++ b/bigquery/schools_joined_with_metrics.sql
@@ -6,7 +6,15 @@ WITH
     #the earliest date that a user is recorded as authorised for TV access in DSI - for schools who signed up *after* we moved to DSI for authorisation in Nov 2019 this is the date the school first signed up
     COUNT(*) AS number_of_users #the current number of users this school has authorised to access TV in DSI
   FROM
-    `teacher-vacancy-service.production_dataset.users` AS users
+    `teacher-vacancy-service.production_dataset.dsi_users` AS users
+  GROUP BY
+    school_urn ),
+  school_approver_metrics AS ( #work out current user-related metric values for all individual schools for use in the main query later
+  SELECT
+    school_urn AS urn,
+    COUNT(*) AS number_of_approvers #the current number of users this school has authorised to access TV in DSI
+  FROM
+    `teacher-vacancy-service.production_dataset.dsi_approvers` AS approvers
   GROUP BY
     school_urn ),
   school_vacancy_metrics AS ( #work out current vacancy-related metric values for all individual schools for use in the main query later
@@ -14,14 +22,19 @@ WITH
     school.urn AS urn,
     COUNT(*) AS vacancies_published,
     #the total number of vacancies this school published over all time
-    COUNTIF(PARSE_DATE("%e %B %E4Y",publish_on) > DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR)) AS vacancies_published_in_the_last_year,
-    COUNTIF(PARSE_DATE("%e %B %E4Y",publish_on) > DATE_SUB(CURRENT_DATE(), INTERVAL 3 MONTH)) AS vacancies_published_in_the_last_quarter,
+    COUNTIF(PARSE_DATE("%e %B %E4Y",
+        publish_on) > DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR)) AS vacancies_published_in_the_last_year,
+    COUNTIF(PARSE_DATE("%e %B %E4Y",
+        publish_on) > DATE_SUB(CURRENT_DATE(), INTERVAL 3 MONTH)) AS vacancies_published_in_the_last_quarter,
     COUNTIF(status="published"
-      AND PARSE_DATE("%e %B %E4Y",expires_on) > CURRENT_DATE()) AS vacancies_currently_live #count this as vacancies which have been published and have not yet expired
+      AND PARSE_DATE("%e %B %E4Y",
+        expires_on) > CURRENT_DATE()) AS vacancies_currently_live #count this as vacancies which have been published and have not yet expired
   FROM
     `teacher-vacancy-service.production_dataset.vacancy` AS vacancy
-  INNER JOIN `teacher-vacancy-service.production_dataset.school` AS school
-    ON vacancy.school_id=school.id
+  INNER JOIN
+    `teacher-vacancy-service.production_dataset.school` AS school
+  ON
+    vacancy.school_id=school.id
   WHERE
     status != "trashed" #exclude deleted vacancies from the counts above
     AND status != "draft" #exclude vacancies which have not (yet) been published from the counts above
@@ -81,6 +94,7 @@ IF
       FALSE)) AS signed_up,
   #similarly, if the school had signed up pre-DSI, sets signed_up to true; otherwise, work this out from the number of users the school has on DSI
   school_user_metrics.number_of_users AS number_of_users,
+  school_approver_metrics.number_of_approvers AS number_of_approvers,
   IFNULL(school_vacancy_metrics.vacancies_published,
     0) AS vacancies_published,
   #convert null values for vacancies_published into zeros
@@ -129,6 +143,10 @@ LEFT JOIN
   school_user_metrics
 ON
   school_user_metrics.urn=school.urn
+LEFT JOIN
+  school_approver_metrics
+ON
+  school_approver_metrics.urn=school.urn
 LEFT JOIN
   `teacher-vacancy-service.production_dataset.STATIC_schools_historic_pre201119` AS historic_signups
 ON


### PR DESCRIPTION
The users table got renamed to dsi_users in BigQuery. A new dsi_approvers table got added as well.

This PR:
- Changes all references to users to dsi_users
- Adds a 'Number of approvers' count to the calculated / joined schools table for quick reference
- Adds minimum size monitoring to both the dsi_users and dsi_approvers tables