### PR TITLE
Teva 559 sign in issue messages

### DIFF
--- a/app/views/hiring_staff/identifications/new.html.haml
+++ b/app/views/hiring_staff/identifications/new.html.haml
@@ -3,6 +3,13 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
+    - if ENV['FEATURE_SIGN_IN_ALERT'].to_s == "true"
+      .govuk-error-summary{ aria: { labelledby: "error-summary-title" }, role: "alert", tabindex: "-1" }
+        %h2.govuk-error-summary__title
+          = t('.you_might_have_problems_signing_in')
+        .govuk-error-summary__body
+          = t('.some_of_our_users')
+
     %h1.govuk-heading-l= t('sign_in.title')
 
     %p= t('pages.home.signin.description')

--- a/app/views/pages/home/_signin.html.haml
+++ b/app/views/pages/home/_signin.html.haml
@@ -2,7 +2,10 @@
 
 %p= t('.description')
 
-= simple_form_for :identifications, url: identifications_path, defaults: { input_html: { class: 'text' } }, method: :post do |f|
-  = f.submit t('sign_in.link'), class: 'govuk-button'
+- if ENV['FEATURE_SIGN_IN_ALERT'].to_s == 'true'
+  = link_to t('sign_in.link'), new_identifications_path, class: 'govuk-button identifications-button'
+- else
+  = simple_form_for :identifications, url: identifications_path, defaults: { input_html: { class: 'text' } }, method: :post do |f|
+    = f.submit t('sign_in.link'), class: 'govuk-button'
 
 %p= t('.signin_guidance_html', link: link_to(t('.signin_link'), new_identifications_path))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,10 @@ en:
         page_description: If you already have a Teaching Vacancies account you can sign in to the service here.
         request_account_title: Request an account
         request_account_html: Don't have an account? You can get one if you work at a publicly funded school or trust in England, but you'll need your headteacher or senior leader to authorise you. Just ask them to send your full name and email address to %{mail_to}. Or email your details directly to that address, copying in your headteacher or senior leader.
+        some_of_our_users: >-
+          Some of our users are having having trouble signing in. We're working on the problem now. If you can't sign
+          in, try again soon.
+        you_might_have_problems_signing_in: You might have problems signing in
   nav:
     sign_in: 'List a teaching job'
     sign_out: 'Sign out'

--- a/spec/views/hiring_staff/identifications/new.html.haml_spec.rb
+++ b/spec/views/hiring_staff/identifications/new.html.haml_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe 'hiring_staff/identifications/new.html.haml' do
+  context 'FEATURE_SIGN_IN_ALERT is a string "false"' do
+    before do
+      allow(ENV).to receive(:[]).with('FEATURE_SIGN_IN_ALERT').and_return('false')
+      render
+    end
+
+    it 'does not show the sign in warning' do
+      expect(render).not_to match(/you might have problems signing in/i)
+    end
+  end
+
+  context 'FEATURE_SIGN_IN_ALERT is a boolean false' do
+    before do
+      allow(ENV).to receive(:[]).with('FEATURE_SIGN_IN_ALERT').and_return(false)
+      render
+    end
+
+    it 'does not show the sign in warning' do
+      expect(render).not_to match(/you might have problems signing in/i)
+    end
+  end
+
+  context 'FEATURE_SIGN_IN_ALERT is as string "true"' do
+    before do
+      allow(ENV).to receive(:[]).with('FEATURE_SIGN_IN_ALERT').and_return('true')
+      render
+    end
+
+    it 'shows the sign in warning' do
+      expect(render).to match('You might have problems signing in')
+    end
+  end
+
+  context 'FEATURE_SIGN_IN_ALERT is as boolean true' do
+    before do
+      allow(ENV).to receive(:[]).with('FEATURE_SIGN_IN_ALERT').and_return(true)
+      render
+    end
+
+    it 'shows the sign in warning' do
+      expect(render).to match('You might have problems signing in')
+    end
+  end
+end

--- a/spec/views/pages/home/_signin.html.haml_spec.rb
+++ b/spec/views/pages/home/_signin.html.haml_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe 'pages/home/_signin.html.haml' do
+  context 'FEATURE_SIGN_IN_ALERT is a string "false"' do
+    before do
+      allow(ENV).to receive(:[]).with('FEATURE_SIGN_IN_ALERT').and_return('false')
+      render
+    end
+
+    it 'displays the regular signin workflow' do
+      expect(render).to have_css('.identifications')
+    end
+  end
+
+  context 'FEATURE_SIGN_IN_ALERT is a boolean false' do
+    before do
+      allow(ENV).to receive(:[]).with('FEATURE_SIGN_IN_ALERT').and_return(false)
+      render
+    end
+
+    it 'displays the regular signin workflow' do
+      expect(render).to have_css('.identifications')
+    end
+  end
+
+  context 'FEATURE_SIGN_IN_ALERT is as string "true"' do
+    before do
+      allow(ENV).to receive(:[]).with('FEATURE_SIGN_IN_ALERT').and_return('true')
+      render
+    end
+
+    it 'displays the regular signin workflow' do
+      expect(render).to have_css('.identifications-button')
+    end
+  end
+
+  context 'FEATURE_SIGN_IN_ALERT is as boolean true' do
+    before do
+      allow(ENV).to receive(:[]).with('FEATURE_SIGN_IN_ALERT').and_return(true)
+      render
+    end
+
+    it 'displays the regular signin workflow' do
+      expect(render).to have_css('.identifications-button')
+    end
+  end
+end


### PR DESCRIPTION
Shows the agreed error message when the feature flag is set.  

 - [x] Product to sign off before release. 

<img width="1052" alt="Screenshot 2020-03-02 at 13 52 40" src="https://user-images.githubusercontent.com/20921/75682329-276fbd80-5c8d-11ea-8968-8f0c368a3d51.png">
