### PR TITLE
Fix bug when editing documents of legacy listings

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -14,6 +14,10 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
     session[:vacancy_attributes].present? ? session[:vacancy_attributes]['id'] : false
   end
 
+  def set_vacancy
+    @vacancy = params[:job_id] ? current_school.vacancies.find(params[:job_id]) : nil
+  end
+
   def store_vacancy_attributes(attributes)
     session[:vacancy_attributes] ||= {}
     session[:vacancy_attributes].merge!(attributes.compact)
@@ -46,6 +50,10 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
 
   def review_path_with_errors(vacancy)
     school_job_review_path(job_id: vacancy.id, anchor: 'errors', source: 'publish')
+  end
+
+  def redirect_unless_vacancy
+    redirect_unless_vacancy_session_id unless @vacancy
   end
 
   def redirect_unless_vacancy_session_id

--- a/app/controllers/hiring_staff/vacancies/documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/documents_controller.rb
@@ -5,8 +5,8 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
 
   before_action :set_vacancy
 
-  before_action :redirect_if_no_vacancy, only: %i[show create destroy]
-  before_action :redirect_if_no_supporting_documents
+  before_action :redirect_unless_vacancy
+  before_action :redirect_unless_supporting_documents
   before_action :redirect_to_next_step_if_save_and_continue, only: %i[create]
 
   before_action :set_documents_form, only: %i[show create]
@@ -33,15 +33,11 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
       render :destroy, layout: false, status: delete_operation_status ? :ok : :bad_request
     else
       flash[flash_type] = flash_message
-      redirect_to documents_school_job_path
+      redirect_to school_job_documents_path(@vacancy.id)
     end
   end
 
   private
-
-  def set_vacancy
-    @vacancy = current_school.vacancies.find(params[:job_id])
-  end
 
   def set_documents_form
     @documents_form = DocumentsForm.new
@@ -55,11 +51,12 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
     params.require(:documents_form).permit(documents: [])
   end
 
-  def redirect_if_no_vacancy
-    redirect_unless_vacancy_session_id unless @vacancy
-  end
+  def redirect_unless_supporting_documents
+    if params[:change] && !@vacancy.supporting_documents
+      @vacancy.supporting_documents = 'yes'
+      @vacancy.save
+    end
 
-  def redirect_if_no_supporting_documents
     redirect_to supporting_documents_school_job_path unless @vacancy.supporting_documents
   end
 

--- a/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
@@ -1,9 +1,9 @@
 class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacancies::ApplicationController
-  before_action :redirect_unless_vacancy_session_id, only: %i[new create]
+  before_action :set_vacancy
+
+  before_action :redirect_unless_vacancy, only: %i[new create]
 
   def new
-    redirect_to job_specification_school_job_path unless session_vacancy_id
-
     @supporting_documents_form = SupportingDocumentsForm.new(session[:vacancy_attributes])
     @supporting_documents_form.valid? if %i[step_2_intro review].include?(session[:current_step])
   end

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_supporting_documents.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_supporting_documents.html.haml
@@ -1,12 +1,12 @@
 %h2.govuk-heading-m.mb0
   = t('jobs.supporting_documents')
-  - if UploadDocumentsFeature.enabled? && @vacancy.documents.none?
+  - if UploadDocumentsFeature.enabled? && !@vacancy.supporting_documents
     .notification-tag
       %strong.govuk-tag.app-task-list__task-completed
-        = t('jobs.notfication_labels.new')
+        = t('jobs.notification_labels.new')
 
 .govuk-body-s.mb1#change-supporting-documents
-  = link_to school_job_documents_path(@vacancy.id), class: 'govuk-link', 'aria-label': 'Change supporting documents' do
+  = link_to school_job_documents_path(job_id: @vacancy.id, change: true), class: 'govuk-link', 'aria-label': 'Change the supporting documents' do
     Change
     %span.govuk-visually-hidden the supporting documents
 

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -191,6 +191,32 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
       end
     end
 
+    context '#supporting_documents' do
+      let(:feature_enabled?) { true }
+
+      scenario 'can edit documents for a legacy vacancy' do
+        vacancy.supporting_documents = nil
+        vacancy.documents = []
+        vacancy.save
+
+        visit edit_school_job_path(vacancy.id)
+
+        expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+        expect(page.find('h2', text: I18n.t('jobs.supporting_documents'))
+          .text).to include(I18n.t('jobs.notification_labels.new'))
+
+        find("[id='change-supporting-documents']").click_link('Change')
+
+        expect(page).to have_content(I18n.t('jobs.upload_file'))
+
+        click_on 'Update job'
+
+        expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+        expect(page.find('h2', text: I18n.t('jobs.supporting_documents'))
+          .text).to_not include(I18n.t('jobs.notification_labels.new'))
+      end
+    end
+
     context '#application_details' do
       scenario 'can not be edited when validation fails' do
         visit edit_school_job_path(vacancy.id)


### PR DESCRIPTION
Vacancies with the supporting_documents field not set could not be edited. Corrected this behaviour and added a test. Also tidied the code and made some minor corrections.