### PR TITLE
Information banner when editing/reviewing legacy listings

### DIFF
--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -25,6 +25,7 @@ $govuk-image-url-function: frontend-image-url;
 @import 'components/feedback_form';
 @import 'components/filter_vacancies';
 @import 'components/flashes';
+@import 'components/information_summary.scss';
 @import 'components/links';
 @import 'components/location_finder';
 @import 'components/loader';

--- a/app/frontend/styles/components/information_summary.scss
+++ b/app/frontend/styles/components/information_summary.scss
@@ -1,0 +1,9 @@
+.govuk-info-summary {
+  @extend .govuk-error-summary;
+  border-color: #1d70b8;
+}
+
+.govuk-info-summary__dismiss-link {
+  float: right;
+  display: block;
+}

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -105,4 +105,10 @@ module VacanciesHelper
   def location_category_content?(filters)
     filters.location_category_search? && filters.only_active_to_hash.one?
   end
+
+  def new_sections(vacancy)
+    sections = []
+    sections << 'supporting_documents' if UploadDocumentsFeature.enabled? && !vacancy.supporting_documents
+    sections
+  end
 end

--- a/app/views/feedback/_outlined_flash_message.html.haml
+++ b/app/views/feedback/_outlined_flash_message.html.haml
@@ -2,4 +2,13 @@
   .govuk-body.mv0{ class: "govuk-#{style}-summary__body" }
     %a.govuk-link.govuk-link--no-visited-state.govuk-success-summary__dismiss-link.js-dismissable__link{ href: '#' }
       = t('buttons.dismiss')
+    - if defined?(heading)
+      %h3.govuk-heading-s.mb0
+        = heading
     = message
+    <br>
+    - if defined?(links)
+      - links.each do |section|
+        %a.govuk-link.govuk-link--no-visited-state{ href: "##{section}"}
+          = t("jobs.#{section}")
+        <br>

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -5,6 +5,8 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-l
       = t('jobs.edit_heading', school: @vacancy.school.name)
+    - if new_sections(@vacancy).any?
+      = render 'feedback/outlined_flash_message', style: 'info', message: t('messages.jobs.new_sections.message'), heading: t('messages.jobs.new_sections.heading'), links: new_sections(@vacancy)
 
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_supporting_documents.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_supporting_documents.html.haml
@@ -1,4 +1,4 @@
-%h2.govuk-heading-m.mb0
+%h2.govuk-heading-m.mb0#supporting_documents
   = t('jobs.supporting_documents')
   - if UploadDocumentsFeature.enabled? && !@vacancy.supporting_documents
     .notification-tag

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -11,6 +11,8 @@
       - else
         = t('jobs.review_future')
     = render 'hiring_staff/vacancies/error_messages', errors: @vacancy.errors
+    - if new_sections(@vacancy).any?
+      = render 'feedback/outlined_flash_message', style: 'info', message: t('messages.jobs.new_sections.message'), heading: t('messages.jobs.new_sections.heading'), links: new_sections(@vacancy)
 
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -503,6 +503,9 @@ en:
 
   messages:
     jobs:
+      new_sections:
+        heading: 'New section'
+        message: 'Improve your job listing using the new sections and features below'
       delete: The job has been deleted
       updated: 'The job has been updated'
       view:

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -202,6 +202,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         visit edit_school_job_path(vacancy.id)
 
         expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+        expect(page).to have_content(I18n.t('messages.jobs.new_sections.message'))
         expect(page.find('h2', text: I18n.t('jobs.supporting_documents'))
           .text).to include(I18n.t('jobs.notification_labels.new'))
 

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -73,4 +73,17 @@ RSpec.describe VacanciesHelper, type: :helper do
       expect(helper.vacancy_params_whitelist).to match_array(filters)
     end
   end
+
+  describe '#new_sections' do
+    let(:vacancy) { double('vacancy') }
+
+    before do
+      allow(UploadDocumentsFeature).to receive(:enabled?).and_return(true)
+    end
+
+    it 'should include supporting_documents for legacy listings' do
+      allow(vacancy).to receive(:supporting_documents).and_return(nil)
+      expect(helper.new_sections(vacancy)).to include('supporting_documents')
+    end
+  end
 end


### PR DESCRIPTION
[UD14.2 (TEVA-576)](https://dfedigital.atlassian.net/browse/TEVA-576)

![image](https://user-images.githubusercontent.com/25187547/76087303-cc500a80-5fad-11ea-8383-ae12a6398a0b.png)

Adds an information banner that alerts hiring staff users to the supporting documents feature when they edit/review a vacancy created before the feature existed.
