### PR TITLE
Bigquery exclude closed schools from metrics

### DIFF
--- a/bigquery/calculated-daily-time-metrics-by-RSC-region.sql
+++ b/bigquery/calculated-daily-time-metrics-by-RSC-region.sql
@@ -1,161 +1,181 @@
+  #new version of this query that takes into account whether schools were open or closed on each day
 WITH
   dates AS ( #the range of dates we're calculating for - later, we could use this to limit the start date so we don't overwrite previously calculated data
   SELECT
     date
   FROM
     UNNEST(GENERATE_DATE_ARRAY('2018-05-03', DATE_ADD(CURRENT_DATE(), INTERVAL 2 YEAR), INTERVAL 1 DAY)) AS date ),
-  RSC_regions AS (
+  schools AS (
   SELECT
-    DISTINCT RSC_region
+    URN,
+    id,
+    data_CloseDate AS closed_date,
+    CAST(created_at AS DATE) AS created_at_date,
+    data_EstablishmentStatus_name AS status,
+    data_TypeOfEstablishment_name AS establishment_type,
+    data_RSCRegion_name AS RSC_region
   FROM
-    `teacher-vacancy-service.production_dataset.CALCULATED_schools_joined_with_metrics`
+    `teacher-vacancy-service.production_dataset.feb20_school`
   WHERE
-    RSC_region IS NOT NULL),
-  RSC_region_dates AS ( #every possible combination of date and RSC region
-  SELECT
-    date,
-    RSC_region
-  FROM
-    dates
-  CROSS JOIN
-    RSC_regions
-  ORDER BY
-    date,
-    RSC_region ASC ),
-  signup_metrics AS (
-  SELECT
-    date,
-    RSC_region,
-    ( #the total number of schools that had signed up by each date in each region
+    ((data_CloseDate IS NULL
+        AND data_EstablishmentStatus_name != "Closed")
+      OR (data_EstablishmentStatus_name = "Closed"
+        AND data_CloseDate > '2018-05-03'))
+    AND data_TypeOfEstablishment_code IN (
     SELECT
-      COUNT(DISTINCT urn)
-    FROM (
-      SELECT
-        urn,
-        signup_date,
-        RSC_region AS school_RSC_region,
-        signed_up
-      FROM
-        `teacher-vacancy-service.production_dataset.CALCULATED_schools_joined_with_metrics`) AS schools
-    WHERE
-      schools.signup_date IS NOT NULL
-      AND schools.signup_date <= date
-      AND schools.school_RSC_region=RSC_region
-      AND schools.signed_up IS TRUE ) AS schools_signed_up
-  FROM
-    RSC_region_dates
-  WHERE
-    date <= CURRENT_DATE()),
-  published_vacancies_with_school_details AS ( #join some schools data we'll need later on to the vacancies table, and exclude unpublished vacancies
+      Code
+    FROM
+      `teacher-vacancy-service.production_dataset.STATIC_establishment_types_in_scope`)),
+  vacancies AS (
   SELECT
-    vacancy.publish_on AS publish_on,
-    vacancy.expires_on AS expires_on,
-    school.urn AS school_urn,
-    school.RSC_region AS school_RSC_region
+    id,
+    publish_on,
+    expires_on,
+    school_id
   FROM
-    `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
-  LEFT JOIN
-    `teacher-vacancy-service.production_dataset.CALCULATED_schools_joined_with_metrics` AS school
-  ON
-    vacancy.school_id=school.id
+    `teacher-vacancy-service.production_dataset.feb20_vacancy`
   WHERE
-    vacancy.status != "trashed" #exclude deleted vacancies
-    AND vacancy.status != "draft" #exclude vacancies which have not (yet) been published
-    ),
-  usage_metrics AS (
+    (status NOT IN ("trashed",
+        "deleted",
+        "draft")) ),
+  metrics AS (
   SELECT
     date,
     RSC_region,
-    ( #the total number of schools that published a vacancy before each date
+  IF
+    (date > CURRENT_DATE(),
+      NULL,
+      COUNTIF(in_scope)) AS schools_in_scope,
+  IF
+    (date > CURRENT_DATE(),
+      NULL,
+      COUNTIF(signed_up)) AS schools_signed_up,
+  IF
+    (date > CURRENT_DATE(),
+      NULL,
+      COUNTIF(has_published_so_far)) AS schools_which_published_so_far,
+  IF
+    (date > CURRENT_DATE(),
+      NULL,
+      COUNTIF(has_published_in_the_last_year)) AS schools_which_published_in_the_last_year,
+  IF
+    (date > CURRENT_DATE(),
+      NULL,
+      COUNTIF(has_published_in_the_last_quarter)) AS schools_which_published_in_the_last_quarter,
+  IF
+    (date > CURRENT_DATE(),
+      NULL,
+      COUNTIF(had_live_vacancies)) AS schools_which_had_vacancies_live
+  FROM (
     SELECT
-      COUNT(DISTINCT school_urn),
+      schools.urn AS urn,
+      dates.date AS date,
+      schools.RSC_region AS RSC_region,
+    IF
+      ((schools.status != "Closed" #if the school is not closed
+        OR schools.closed_date > dates.date) #or if the school closed after the date we're calculating for
+          AND schools.created_at_date <= dates.date, #and if the school was first listed on GIAS before or on the date we're calculating for
+        TRUE,
+        FALSE) AS in_scope,
+    IF
+      (schools.status = "Closed"
+        AND schools.closed_date <= dates.date,
+        FALSE,
+        #mark schools which were closed as not signed up, regardless of whether this is before or after 20th November 2019
+      IF
+        ( historic_signups.School_been_added
+          AND dates.date<='2019-11-20',
+        IF
+          (historic_signups.Date_first_signed_up<dates.date,
+            TRUE,
+            FALSE),
+          #up until 20th November 2019, take signup data from the static table of historic signup data for each school
+        IF
+          (COUNTIF(users.from_date<=dates.date
+              AND (users.to_date IS NULL
+                OR users.to_date>dates.date))>=1,
+            #after 20th November 2019, count the number of users who had access, see if it is 1 or more, and if so count the school as signed up
+            TRUE,
+            FALSE))) AS signed_up,
+    IF
+      (COUNTIF(vacancies.publish_on<=dates.date)>1,
+        TRUE,
+        FALSE) AS has_published_so_far,
+    IF
+      (COUNTIF(vacancies.publish_on<=dates.date
+          AND vacancies.publish_on>=DATE_SUB(dates.date,INTERVAL 1 YEAR))>1,
+        TRUE,
+        FALSE) AS has_published_in_the_last_year,
+    IF
+      (COUNTIF(vacancies.publish_on<=dates.date
+          AND vacancies.publish_on>=DATE_SUB(dates.date,INTERVAL 3 MONTH))>1,
+        TRUE,
+        FALSE) AS has_published_in_the_last_quarter,
+    IF
+      (COUNTIF(vacancies.publish_on<=dates.date
+          AND vacancies.expires_on>dates.date)>1,
+        TRUE,
+        FALSE) AS had_live_vacancies
     FROM
-      published_vacancies_with_school_details
-    WHERE
-      publish_on <= date
-      AND RSC_region=school_RSC_region ) AS schools_which_published_so_far,
-    ( #the total number of schools that published a vacancy in the year before each date
-    SELECT
-      COUNT(DISTINCT school_urn),
-    FROM
-      published_vacancies_with_school_details
-    WHERE
-      publish_on <= date
-      AND publish_on > DATE_SUB(date, INTERVAL 1 YEAR)
-      AND RSC_region=school_RSC_region ) AS schools_which_published_in_the_last_year,
-    ( #the total number of schools that published a vacancy in the quarter before each date
-    SELECT
-      COUNT(DISTINCT school_urn),
-    FROM
-      published_vacancies_with_school_details
-    WHERE
-      publish_on <= date
-      AND publish_on > DATE_SUB(date, INTERVAL 3 MONTH)
-      AND RSC_region=school_RSC_region ) AS schools_which_published_in_the_last_quarter,
-    ( #the total number of schools that had a live vacancy on this date
-    SELECT
-      COUNT(DISTINCT school_urn),
-    FROM
-      published_vacancies_with_school_details
-    WHERE
-      publish_on <= date
-      AND expires_on > date
-      AND RSC_region=school_RSC_region ) AS schools_which_had_vacancies_live,
-  FROM
-    RSC_region_dates
-  WHERE
-    date <= CURRENT_DATE()),
-  schools_in_scope AS ( #the number of schools currently in scope in each region - currently this is assumed to be the current value of this for all time (we don't yet have the data from GIAS to be able to refine this further)
-  SELECT
-    COUNT(*) AS schools_in_scope,
-    RSC_region
-  FROM
-    `teacher-vacancy-service.production_dataset.CALCULATED_schools_joined_with_metrics` AS schools
+      schools
+    CROSS JOIN
+      dates
+    LEFT JOIN
+      `teacher-vacancy-service.production_dataset.STATIC_schools_historic_pre201119` AS historic_signups
+    ON
+      historic_signups.URN=schools.urn
+    LEFT JOIN
+      `teacher-vacancy-service.production_dataset.CALCULATED_timestamped_dsi_users` AS users
+    ON
+      users.school_urn=schools.urn
+    LEFT JOIN
+      vacancies
+    ON
+      vacancies.school_id=schools.id
+    GROUP BY
+      urn,
+      date,
+      RSC_region,
+      closed_date,
+      created_at_date,
+      schools.status,
+      historic_signups.School_been_added,
+      historic_signups.Date_first_signed_up)
   GROUP BY
-    RSC_region )
+    date,
+    RSC_region)
 SELECT
-  RSC_region_dates.date,
-  RSC_region_dates.RSC_region,
-  signup_metrics.schools_signed_up,
-  schools_in_scope.schools_in_scope,
-  SAFE_DIVIDE(signup_metrics.schools_signed_up,
-    schools_in_scope.schools_in_scope) AS proportion_of_schools_signed_up,
-  usage_metrics.schools_which_published_in_the_last_year AS schools_which_published_vacancies_in_the_last_year,
-  usage_metrics.schools_which_published_in_the_last_quarter AS schools_which_published_vacancies_in_the_last_quarter,
-  usage_metrics.schools_which_published_so_far AS schools_which_published_vacancies_so_far,
-  usage_metrics.schools_which_had_vacancies_live AS schools_which_had_vacancies_live,
-  SAFE_DIVIDE(usage_metrics.schools_which_published_in_the_last_year,
-    schools_in_scope.schools_in_scope) AS proportion_of_schools_which_published_in_the_last_year,
-  SAFE_DIVIDE(usage_metrics.schools_which_published_in_the_last_quarter,
-    schools_in_scope.schools_in_scope) AS proportion_of_schools_which_published_in_the_last_quarter,
-  SAFE_DIVIDE(usage_metrics.schools_which_published_so_far,
-    schools_in_scope.schools_in_scope) AS proportion_of_schools_which_published_so_far,
-  SAFE_DIVIDE(usage_metrics.schools_which_had_vacancies_live,
-    schools_in_scope.schools_in_scope) AS proportion_of_schools_which_had_vacancies_live,
-  SAFE_DIVIDE(usage_metrics.schools_which_published_in_the_last_year,
-    signup_metrics.schools_signed_up) AS proportion_of_signed_up_schools_which_published_in_the_last_year,
-  SAFE_DIVIDE(usage_metrics.schools_which_published_in_the_last_quarter,
-    signup_metrics.schools_signed_up) AS proportion_of_signed_up_schools_which_published_in_the_last_quarter,
-  SAFE_DIVIDE(usage_metrics.schools_which_published_so_far,
-    signup_metrics.schools_signed_up) AS proportion_of_signed_up_schools_which_published_so_far,
-  SAFE_DIVIDE(usage_metrics.schools_which_had_vacancies_live,
-    signup_metrics.schools_signed_up) AS proportion_of_signed_up_schools_which_had_vacancies_live
+  dates.date,
+  metrics.RSC_region,
+  metrics.schools_signed_up,
+  metrics.schools_in_scope,
+  SAFE_DIVIDE(metrics.schools_signed_up,
+    metrics.schools_in_scope) AS proportion_of_schools_signed_up,
+  metrics.schools_which_published_in_the_last_year AS schools_which_published_vacancies_in_the_last_year,
+  metrics.schools_which_published_in_the_last_quarter AS schools_which_published_vacancies_in_the_last_quarter,
+  metrics.schools_which_published_so_far AS schools_which_published_vacancies_so_far,
+  metrics.schools_which_had_vacancies_live AS schools_which_had_vacancies_live,
+  SAFE_DIVIDE(metrics.schools_which_published_in_the_last_year,
+    metrics.schools_in_scope) AS proportion_of_schools_which_published_in_the_last_year,
+  SAFE_DIVIDE(metrics.schools_which_published_in_the_last_quarter,
+    metrics.schools_in_scope) AS proportion_of_schools_which_published_in_the_last_quarter,
+  SAFE_DIVIDE(metrics.schools_which_published_so_far,
+    metrics.schools_in_scope) AS proportion_of_schools_which_published_so_far,
+  SAFE_DIVIDE(metrics.schools_which_had_vacancies_live,
+    metrics.schools_in_scope) AS proportion_of_schools_which_had_vacancies_live,
+  SAFE_DIVIDE(metrics.schools_which_published_in_the_last_year,
+    metrics.schools_signed_up) AS proportion_of_signed_up_schools_which_published_in_the_last_year,
+  SAFE_DIVIDE(metrics.schools_which_published_in_the_last_quarter,
+    metrics.schools_signed_up) AS proportion_of_signed_up_schools_which_published_in_the_last_quarter,
+  SAFE_DIVIDE(metrics.schools_which_published_so_far,
+    metrics.schools_signed_up) AS proportion_of_signed_up_schools_which_published_so_far,
+  SAFE_DIVIDE(metrics.schools_which_had_vacancies_live,
+    metrics.schools_signed_up) AS proportion_of_signed_up_schools_which_had_vacancies_live
 FROM
-  RSC_region_dates
+  dates
 LEFT JOIN
-  signup_metrics
-ON
-  signup_metrics.date=RSC_region_dates.date
-  AND signup_metrics.RSC_region=RSC_region_dates.RSC_region
-LEFT JOIN
-  usage_metrics
-ON
-  usage_metrics.date=RSC_region_dates.date
-  AND usage_metrics.RSC_region=RSC_region_dates.RSC_region
-LEFT JOIN
-  schools_in_scope
-ON
-  schools_in_scope.RSC_region=signup_metrics.RSC_region
+  metrics
+USING
+  (date)
 ORDER BY
-  date,
-  RSC_region ASC
+  date

--- a/bigquery/calculated-daily-time-metrics-by-RSC-region.sql
+++ b/bigquery/calculated-daily-time-metrics-by-RSC-region.sql
@@ -84,36 +84,36 @@ WITH
         #mark schools which were closed as not signed up, regardless of whether this is before or after 20th November 2019
       IF
         ( historic_signups.School_been_added
-          AND dates.date<='2019-11-20',
+          AND dates.date <= '2019-11-20',
         IF
           (historic_signups.Date_first_signed_up<dates.date,
             TRUE,
             FALSE),
           #up until 20th November 2019, take signup data from the static table of historic signup data for each school
         IF
-          (COUNTIF(users.from_date<=dates.date
+          (COUNTIF(users.from_date <= dates.date
               AND (users.to_date IS NULL
-                OR users.to_date>dates.date))>=1,
+                OR users.to_date > dates.date)) >= 1,
             #after 20th November 2019, count the number of users who had access, see if it is 1 or more, and if so count the school as signed up
             TRUE,
             FALSE))) AS signed_up,
     IF
-      (COUNTIF(vacancies.publish_on<=dates.date)>1,
+      (COUNTIF(vacancies.publish_on <= dates.date) > 1,
         TRUE,
         FALSE) AS has_published_so_far,
     IF
-      (COUNTIF(vacancies.publish_on<=dates.date
-          AND vacancies.publish_on>=DATE_SUB(dates.date,INTERVAL 1 YEAR))>1,
+      (COUNTIF(vacancies.publish_on <= dates.date
+          AND vacancies.publish_on >= DATE_SUB(dates.date,INTERVAL 1 YEAR)) > 1,
         TRUE,
         FALSE) AS has_published_in_the_last_year,
     IF
-      (COUNTIF(vacancies.publish_on<=dates.date
-          AND vacancies.publish_on>=DATE_SUB(dates.date,INTERVAL 3 MONTH))>1,
+      (COUNTIF(vacancies.publish_on <= dates.date
+          AND vacancies.publish_on >= DATE_SUB(dates.date,INTERVAL 3 MONTH)) > 1,
         TRUE,
         FALSE) AS has_published_in_the_last_quarter,
     IF
-      (COUNTIF(vacancies.publish_on<=dates.date
-          AND vacancies.expires_on>dates.date)>1,
+      (COUNTIF(vacancies.publish_on <= dates.date
+          AND vacancies.expires_on > dates.date) > 1,
         TRUE,
         FALSE) AS had_live_vacancies
     FROM
@@ -123,15 +123,15 @@ WITH
     LEFT JOIN
       `teacher-vacancy-service.production_dataset.STATIC_schools_historic_pre201119` AS historic_signups
     ON
-      historic_signups.URN=schools.urn
+      historic_signups.URN = schools.urn
     LEFT JOIN
       `teacher-vacancy-service.production_dataset.CALCULATED_timestamped_dsi_users` AS users
     ON
-      users.school_urn=schools.urn
+      users.school_urn = schools.urn
     LEFT JOIN
       vacancies
     ON
-      vacancies.school_id=schools.id
+      vacancies.school_id = schools.id
     GROUP BY
       urn,
       date,

--- a/bigquery/calculated-daily-time-metrics.sql
+++ b/bigquery/calculated-daily-time-metrics.sql
@@ -70,8 +70,9 @@ WITH
       dates.date AS date,
     IF
       ((schools.status != "Closed" #if the school is not closed
-        OR schools.closed_date > dates.date) #or if the school closed after the date we're calculating for
-          AND schools.created_at_date <= dates.date, #and if the school was first listed on GIAS before or on the date we're calculating for
+          OR schools.closed_date > dates.date) #or if the school closed after the date we're calculating for
+        AND schools.created_at_date <= dates.date,
+        #and if the school was first listed on GIAS before or on the date we're calculating for
         TRUE,
         FALSE) AS in_scope,
     IF
@@ -88,29 +89,29 @@ WITH
             FALSE),
           #up until 20th November 2019, take signup data from the static table of historic signup data for each school
         IF
-          (COUNTIF(users.from_date<=dates.date
+          (COUNTIF(users.from_date <= dates.date
               AND (users.to_date IS NULL
-                OR users.to_date>dates.date))>=1,
+                OR users.to_date > dates.date)) >= 1,
             #after 20th November 2019, count the number of users who had access, see if it is 1 or more, and if so count the school as signed up
             TRUE,
             FALSE))) AS signed_up,
     IF
-      (COUNTIF(vacancies.publish_on<=dates.date)>1,
+      (COUNTIF(vacancies.publish_on <= dates.date) > 1,
         TRUE,
         FALSE) AS has_published_so_far,
     IF
-      (COUNTIF(vacancies.publish_on<=dates.date
-          AND vacancies.publish_on>=DATE_SUB(dates.date,INTERVAL 1 YEAR))>1,
+      (COUNTIF(vacancies.publish_on <= dates.date
+          AND vacancies.publish_on >= DATE_SUB(dates.date,INTERVAL 1 YEAR)) > 1,
         TRUE,
         FALSE) AS has_published_in_the_last_year,
     IF
-      (COUNTIF(vacancies.publish_on<=dates.date
-          AND vacancies.publish_on>=DATE_SUB(dates.date,INTERVAL 3 MONTH))>1,
+      (COUNTIF(vacancies.publish_on <= dates.date
+          AND vacancies.publish_on >= DATE_SUB(dates.date,INTERVAL 3 MONTH)) > 1,
         TRUE,
         FALSE) AS has_published_in_the_last_quarter,
     IF
-      (COUNTIF(vacancies.publish_on<=dates.date
-          AND vacancies.expires_on>dates.date)>1,
+      (COUNTIF(vacancies.publish_on <= dates.date
+          AND vacancies.expires_on > dates.date) > 1,
         TRUE,
         FALSE) AS had_live_vacancies
     FROM
@@ -120,15 +121,15 @@ WITH
     LEFT JOIN
       `teacher-vacancy-service.production_dataset.STATIC_schools_historic_pre201119` AS historic_signups
     ON
-      historic_signups.URN=schools.urn
+      historic_signups.URN = schools.urn
     LEFT JOIN
       `teacher-vacancy-service.production_dataset.CALCULATED_timestamped_dsi_users` AS users
     ON
-      users.school_urn=schools.urn
+      users.school_urn = schools.urn
     LEFT JOIN
       vacancies
     ON
-      vacancies.school_id=schools.id
+      vacancies.school_id = schools.id
     GROUP BY
       urn,
       date,
@@ -176,6 +177,6 @@ USING
 LEFT JOIN
   `teacher-vacancy-service.production_dataset.nightly_goals_from_google_sheets` AS goals #pull in manually set goals for metrics from a Google Sheet
 ON
-  dates.date=goals.Date
+  dates.date = goals.Date
 ORDER BY
   date

--- a/bigquery/timestamped-dsi-users.sql
+++ b/bigquery/timestamped-dsi-users.sql
@@ -20,9 +20,24 @@ IF
   current_table.school_urn
 FROM
   `teacher-vacancy-service.production_dataset.dsi_users` AS current_table
-INNER JOIN
+FULL JOIN
   `teacher-vacancy-service.production_dataset.CALCULATED_timestamped_dsi_users` AS previous_table
 ON
   current_table.user_id=previous_table.user_id
   AND current_table.school_urn=previous_table.school_urn
   AND CAST(current_table.approval_datetime AS DATE)=previous_table.from_date
+WHERE
+IF
+  ((
+    SELECT
+      COUNT(*)
+    FROM
+      `teacher-vacancy-service.production_dataset.CALCULATED_timestamped_dsi_users`
+    WHERE
+      user_id NOT IN (
+      SELECT
+        user_id
+      FROM
+        `teacher-vacancy-service.production_dataset.dsi_users`)) < 500,
+    TRUE,
+    ERROR("Error: Today's user table appears to have  than the previous version."))

--- a/bigquery/timestamped-dsi-users.sql
+++ b/bigquery/timestamped-dsi-users.sql
@@ -1,0 +1,28 @@
+SELECT
+  current_table.user_id AS user_id,
+  COALESCE(current_table.role,
+    previous_table.role) AS role,
+  CAST(current_table.approval_datetime AS DATE) AS from_date,
+IF
+  (current_table.user_id IS NULL
+    AND previous_table.to_date IS NULL,
+    CURRENT_DATE(),
+    NULL) AS to_date,
+  #if we find that a user from the previous table isn't in the current table, set the to_date to today's date (i.e. assume that the user left about now)
+  COALESCE(CAST(current_table.update_datetime AS DATE),
+    previous_table.last_updated_date) AS last_updated_date,
+  COALESCE(current_table.given_name,
+    previous_table.given_name) AS given_name,
+  COALESCE(current_table.family_name,
+    previous_table.family_name) AS family_name,
+  COALESCE(current_table.email,
+    previous_table.email) AS email,
+  current_table.school_urn
+FROM
+  `teacher-vacancy-service.production_dataset.dsi_users` AS current_table
+INNER JOIN
+  `teacher-vacancy-service.production_dataset.CALCULATED_timestamped_dsi_users` AS previous_table
+ON
+  current_table.user_id=previous_table.user_id
+  AND current_table.school_urn=previous_table.school_urn
+  AND CAST(current_table.approval_datetime AS DATE)=previous_table.from_date


### PR DESCRIPTION
## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-502

## Changes in this PR:
- Exclude schools which had closed by each date / hadn't opened yet from nightly usage/signup metric calculations
- Make nightly usage/signup metric calculations 20x faster
- Start tracking when users lose access to Teaching Vacancies (the data from DSI only says who has access today rather than tracking this over time)
