### PR TITLE
Ensure tempfiles get removed even in the event of an exception

### DIFF
--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -64,8 +64,13 @@ class ExportTablesToBigQuery
     export
     upload_to_google_cloud_storage
     load_to_bigquery
-    FileUtils.rm_rf(Rails.root.join(tmpdir))
     Rails.logger.info({ status: 'finished', removed: tmpdir }.to_json)
+  ensure
+    # Without the ensure subsequent runs on an container where this has failed recently will fail due to a lack of disk
+    # space. This is a temporary fix until we have time to look at moving the ever-growing AuditData table off postgres.
+    # This is a temporary fix until we have time to look at moving the ever-growing AuditData table off postgres.
+    # Without AuditData, the files are small.
+    FileUtils.rm_rf(Rails.root.join(tmpdir))
   end
 
   private

--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -68,7 +68,6 @@ class ExportTablesToBigQuery
   ensure
     # Without the ensure subsequent runs on an container where this has failed recently will fail due to a lack of disk
     # space. This is a temporary fix until we have time to look at moving the ever-growing AuditData table off postgres.
-    # This is a temporary fix until we have time to look at moving the ever-growing AuditData table off postgres.
     # Without AuditData, the files are small.
     FileUtils.rm_rf(Rails.root.join(tmpdir))
   end


### PR DESCRIPTION
Prior to this change any exception would prevent the temp files being
removed. This fixes that and should temporarily stop breakages that
arise when a container's drive gets full.

The best long term solution is to stop storing AuditData in our
database and store it somewhere better suited to unbounded data-sets,
like DynamoDB or Firestore.

The second best solution is to increase the disk size of the ec2
instances hosting the containers.