### PR TITLE
Teva 579 bigquery try to reduce loading

### DIFF
--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -30,7 +30,7 @@ class ExportTablesToBigQuery
     activities
     ar_internal_metadata
     audit_data
-    friendly_id_slugs
+    friendlyuid_slugs
     schema_migrations
     sessions
   ].freeze
@@ -65,6 +65,10 @@ class ExportTablesToBigQuery
     upload_to_google_cloud_storage
     load_to_bigquery
     Rails.logger.info({ status: 'finished', removed: tmpdir }.to_json)
+  rescue => e
+    Rails.logger.error({ status: 'error', message: e.message }.to_json)
+    Rollbar.error(e)
+    raise e
   ensure
     # Without the ensure subsequent runs on an container where this has failed recently will fail due to a lack of disk
     # space. This is a temporary fix until we have time to look at moving the ever-growing AuditData table off postgres.

--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -29,6 +29,7 @@ class ExportTablesToBigQuery
   EXCLUDE_TABLES = %w[
     activities
     ar_internal_metadata
+    audit_data
     friendly_id_slugs
     schema_migrations
     sessions

--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -30,7 +30,7 @@ class ExportTablesToBigQuery
     activities
     ar_internal_metadata
     audit_data
-    friendlyuid_slugs
+    friendly_id_slugs
     schema_migrations
     sessions
   ].freeze


### PR DESCRIPTION
 It appears that ECS (or terraform) is killing the container running the export job for reasons of excessive usage.  I *think* it is around the auto-scaling setting for max CPU usage, but am not sure and experimentation takes at least 40 minutes per run. 

After discussing with Steven, we decided we can turn off `AuditData` for now. 