### PR TITLE
Don't copy candidate specification fields when upload docs feature on

### DIFF
--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -4,27 +4,35 @@ class CopyVacancy
   end
 
   def call
-    new_vacancy = @vacancy.dup
-    new_vacancy.status = :draft
-    new_vacancy.weekly_pageviews = 0
-    new_vacancy.weekly_pageviews_updated_at = Time.zone.now
-    new_vacancy.total_pageviews = 0
-    new_vacancy.total_pageviews_updated_at = Time.zone.now
-    new_vacancy.total_get_more_info_clicks = 0
-    new_vacancy.total_get_more_info_clicks_updated_at = Time.zone.now
+    @new_vacancy = @vacancy.dup
+    @new_vacancy.status = :draft
+    @new_vacancy.weekly_pageviews = 0
+    @new_vacancy.weekly_pageviews_updated_at = Time.zone.now
+    @new_vacancy.total_pageviews = 0
+    @new_vacancy.total_pageviews_updated_at = Time.zone.now
+    @new_vacancy.total_get_more_info_clicks = 0
+    @new_vacancy.total_get_more_info_clicks_updated_at = Time.zone.now
 
     if UploadDocumentsFeature.enabled? && @vacancy.any_candidate_specification?
-      new_vacancy.experience = nil
-      new_vacancy.education = nil
-      new_vacancy.qualifications = nil
+      @new_vacancy.experience = nil
+      @new_vacancy.education = nil
+      @new_vacancy.qualifications = nil
     end
 
-    new_vacancy.save
+    @new_vacancy.save
 
+    copy_documents
+
+    @new_vacancy
+  end
+
+  private
+
+  def copy_documents
     @vacancy.documents.each do |document|
       document_copy = DocumentCopy.new(document.google_drive_id)
       document_copy.copy
-      new_vacancy.documents.create({
+      @new_vacancy.documents.create({
         name: document.name,
         size: document.size,
         content_type: document.content_type,
@@ -32,7 +40,5 @@ class CopyVacancy
         google_drive_id: document_copy.copied.id
       }) unless document_copy.google_error
     end
-
-    new_vacancy
   end
 end

--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -12,6 +12,13 @@ class CopyVacancy
     new_vacancy.total_pageviews_updated_at = Time.zone.now
     new_vacancy.total_get_more_info_clicks = 0
     new_vacancy.total_get_more_info_clicks_updated_at = Time.zone.now
+
+    if UploadDocumentsFeature.enabled? && @vacancy.any_candidate_specification?
+      new_vacancy.experience = nil
+      new_vacancy.education = nil
+      new_vacancy.qualifications = nil
+    end
+
     new_vacancy.save
 
     @vacancy.documents.each do |document|

--- a/spec/services/copy_vacancy_spec.rb
+++ b/spec/services/copy_vacancy_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.describe CopyVacancy do
   describe '#call' do
     let(:document_copy) { double('document_copy') }
+    let(:feature_enabled?) { false }
 
     before do
+      allow(UploadDocumentsFeature).to receive(:enabled?).and_return(feature_enabled?)
       allow(DocumentCopy).to receive(:new).and_return(document_copy)
       allow(document_copy).to receive(:copy).and_return(document_copy)
       allow(document_copy).to receive_message_chain(:copied, :web_content_link).and_return('test_url')
@@ -37,19 +39,33 @@ RSpec.describe CopyVacancy do
       Timecop.return
     end
 
-    it 'copies documents when copying a vacancy' do
-      document = create(:document,
-        name: 'Test.png',
-        size: 1000,
-        content_type: 'image/png',
-        download_url: 'test/test.png',
-        google_drive_id: 'testid'
-      )
-      vacancy = create(:vacancy, documents: [document])
+    context 'when upload documents feature flag is ON' do
+      let(:feature_enabled?) { true }
 
-      result = described_class.new(vacancy).call
+      it 'copies documents when copying a vacancy' do
+        document = create(:document,
+          name: 'Test.png',
+          size: 1000,
+          content_type: 'image/png',
+          download_url: 'test/test.png',
+          google_drive_id: 'testid'
+        )
+        vacancy = create(:vacancy, documents: [document])
+  
+        result = described_class.new(vacancy).call
+  
+        expect(result.documents.first.name).to eq(vacancy.documents.first.name)
+      end
 
-      expect(result.documents.first.name).to eq(vacancy.documents.first.name)
+      it 'does not copy candidate specification when upload documents feature flag ON' do
+        vacancy = create(:vacancy)
+  
+        result = described_class.new(vacancy).call
+  
+        expect(result.experience).to eq(nil)
+        expect(result.education).to eq(nil)
+        expect(result.qualifications).to eq(nil)
+      end
     end
 
     context 'not all fields are copied' do

--- a/spec/services/copy_vacancy_spec.rb
+++ b/spec/services/copy_vacancy_spec.rb
@@ -51,17 +51,17 @@ RSpec.describe CopyVacancy do
           google_drive_id: 'testid'
         )
         vacancy = create(:vacancy, documents: [document])
-  
+
         result = described_class.new(vacancy).call
-  
+
         expect(result.documents.first.name).to eq(vacancy.documents.first.name)
       end
 
       it 'does not copy candidate specification when upload documents feature flag ON' do
         vacancy = create(:vacancy)
-  
+
         result = described_class.new(vacancy).call
-  
+
         expect(result.experience).to eq(nil)
         expect(result.education).to eq(nil)
         expect(result.qualifications).to eq(nil)


### PR DESCRIPTION
Add logic to copy vacancy service that does not copy candidate specification fields.
This avoids persisting redundant data on the database that we no longer need and want users to move away from.