### PR TITLE
Teva 608 remove duplicate data

### DIFF
--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -25,7 +25,6 @@ class ExportTablesToBigQuery
     job_description
     qualifications
     supporting_documents
-    working_patterns
   ].freeze
 
   # This is to deal with a gem that automatically maps an interger column to a look up table of strings.
@@ -38,6 +37,7 @@ class ExportTablesToBigQuery
     'status' => :string,
     'visit_purpose' => :string,
     'user_participation_response' => :string,
+    'working_patterns' => :string,
   }.freeze
 
   EXCLUDE_TABLES = %w[
@@ -84,6 +84,7 @@ class ExportTablesToBigQuery
       # Another bloody enum gem edge case. Only in vacancies and causes that whole table to fail despite the column
       # being nullable.
       data = '' if c.name == 'hired_status' && data.nil?
+      data = data.to_s if c.name == 'working_patterns'
       data = data.to_s(:db) if !data.nil? && (c.type == :datetime || c.type == :date)
       @bigquery_data[c.name] = data
     end

--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -16,6 +16,7 @@ class ExportTablesToBigQuery
   DROP_THESE_ATTRIBUTES = %w[
     benefits
     data
+    description
     education
     experience
     frequency


### PR DESCRIPTION
This fixes the issue with GIAS data being duplicated between schools, stops the school narrative description from being saved to BQ and re-adds `working_patterns` as a string column. 