### PR TITLE
Combine leadership and NQT to job role in hiring staff journey

### DIFF
--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -7,7 +7,6 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
   def create
     old_vacancy = Vacancy.find(vacancy_id)
     @copy_form = CopyVacancyForm.new(vacancy: old_vacancy)
-
     proposed_vacancy = @copy_form.apply_changes!(copy_form_params)
 
     if proposed_vacancy.valid? && @copy_form.valid?
@@ -23,12 +22,26 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
   private
 
   def copy_form_params
+    persist_nqt_job_role_to_nqt_attribute
     params.require(:copy_vacancy_form).permit(:job_title,
                                               :starts_on_dd, :starts_on_mm, :starts_on_yyyy,
                                               :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
                                               :expires_on_dd, :expires_on_mm, :expires_on_yyyy,
                                               :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem,
-                                              :publish_on_dd, :publish_on_mm, :publish_on_yyyy)
+                                              :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
+                                              :newly_qualified_teacher, job_role: [])
+  end
+
+  # Only necessary until changes to search are implemented
+  # TODO remove after migration to remove newly qualified teacher column
+  def persist_nqt_job_role_to_nqt_attribute
+    job_role = params.require(:copy_vacancy_form)[:job_role]
+
+    if job_role && job_role.include?(I18n.t('jobs.job_role_options.nqt_suitable'))
+      params[:copy_vacancy_form][:newly_qualified_teacher] = true
+    elsif job_role
+      params[:copy_vacancy_form][:newly_qualified_teacher] = false
+    end
   end
 
   def vacancy_id

--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -29,17 +29,17 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
                                               :expires_on_dd, :expires_on_mm, :expires_on_yyyy,
                                               :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem,
                                               :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
-                                              :newly_qualified_teacher, job_role: [])
+                                              :newly_qualified_teacher, job_roles: [])
   end
 
   # Only necessary until changes to search are implemented
   # TODO remove after migration to remove newly qualified teacher column
   def persist_nqt_job_role_to_nqt_attribute
-    job_role = params.require(:copy_vacancy_form)[:job_role]
+    job_roles = params.require(:copy_vacancy_form)[:job_roles]
 
-    if job_role && job_role.include?(I18n.t('jobs.job_role_options.nqt_suitable'))
+    if job_roles && job_roles.include?(I18n.t('jobs.job_role_options.nqt_suitable'))
       params[:copy_vacancy_form][:newly_qualified_teacher] = true
-    elsif job_role
+    elsif job_roles
       params[:copy_vacancy_form][:newly_qualified_teacher] = false
     end
   end

--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -1,4 +1,8 @@
+require 'persist_nqt_job_role'
+
 class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::ApplicationController
+  include PersistNQTJobRole
+
   def new
     vacancy = Vacancy.find(vacancy_id)
     @copy_form = CopyVacancyForm.new(vacancy: vacancy)
@@ -22,7 +26,7 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
   private
 
   def copy_form_params
-    persist_nqt_job_role_to_nqt_attribute
+    persist_nqt_job_role_to_nqt_attribute(:copy_vacancy_form)
     params.require(:copy_vacancy_form).permit(:job_title,
                                               :starts_on_dd, :starts_on_mm, :starts_on_yyyy,
                                               :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
@@ -30,18 +34,6 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
                                               :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem,
                                               :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
                                               :newly_qualified_teacher, job_roles: [])
-  end
-
-  # Only necessary until changes to search are implemented
-  # TODO remove after migration to remove newly qualified teacher column
-  def persist_nqt_job_role_to_nqt_attribute
-    job_roles = params.require(:copy_vacancy_form)[:job_roles]
-
-    if job_roles && job_roles.include?(I18n.t('jobs.job_role_options.nqt_suitable'))
-      params[:copy_vacancy_form][:newly_qualified_teacher] = true
-    elsif job_roles
-      params[:copy_vacancy_form][:newly_qualified_teacher] = false
-    end
   end
 
   def vacancy_id

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -57,17 +57,17 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
                   :starts_on_yyyy, :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
                   :flexible_working, :newly_qualified_teacher,
                   :first_supporting_subject_id, :second_supporting_subject_id,
-                  working_patterns: [], job_role: []).merge(completed_step: current_step)
+                  working_patterns: [], job_roles: []).merge(completed_step: current_step)
   end
 
   # Only necessary until changes to search are implemented
   # TODO remove after migration to remove newly qualified teacher column
   def persist_nqt_job_role_to_nqt_attribute
-    job_role = params.require(:job_specification_form)[:job_role]
+    job_roles = params.require(:job_specification_form)[:job_roles]
 
-    if job_role && job_role.include?(I18n.t('jobs.job_role_options.nqt_suitable'))
+    if job_roles && job_roles.include?(I18n.t('jobs.job_role_options.nqt_suitable'))
       params[:job_specification_form][:newly_qualified_teacher] = true
-    elsif job_role
+    elsif job_roles
       params[:job_specification_form][:newly_qualified_teacher] = false
     end
   end

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -1,4 +1,8 @@
+require 'persist_nqt_job_role'
+
 class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancies::ApplicationController
+  include PersistNQTJobRole
+
   def new
     @job_specification_form = JobSpecificationForm.new(school_id: current_school.id)
     return if session[:current_step].blank?
@@ -49,7 +53,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   private
 
   def job_specification_form_params
-    persist_nqt_job_role_to_nqt_attribute
+    persist_nqt_job_role_to_nqt_attribute(:job_specification_form)
     params.require(:job_specification_form)
           .permit(:job_title, :job_description, :leadership_id,
                   :subject_id,
@@ -58,18 +62,6 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
                   :flexible_working, :newly_qualified_teacher,
                   :first_supporting_subject_id, :second_supporting_subject_id,
                   working_patterns: [], job_roles: []).merge(completed_step: current_step)
-  end
-
-  # Only necessary until changes to search are implemented
-  # TODO remove after migration to remove newly qualified teacher column
-  def persist_nqt_job_role_to_nqt_attribute
-    job_roles = params.require(:job_specification_form)[:job_roles]
-
-    if job_roles && job_roles.include?(I18n.t('jobs.job_role_options.nqt_suitable'))
-      params[:job_specification_form][:newly_qualified_teacher] = true
-    elsif job_roles
-      params[:job_specification_form][:newly_qualified_teacher] = false
-    end
   end
 
   def save_vacancy_without_validation

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -60,6 +60,8 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
                   working_patterns: [], job_role: []).merge(completed_step: current_step)
   end
 
+  # Only necessary until changes to search are implemented
+  # TODO remove after migration to remove newly qualified teacher column
   def persist_nqt_job_role_to_nqt_attribute
     job_role = params.require(:job_specification_form)[:job_role]
 
@@ -71,7 +73,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   end
 
   def save_vacancy_without_validation
-    # TODO remove after migration to remove column
+    # TODO remove after migration to remove minimum salary column
     @job_specification_form.vacancy.minimum_salary = ''
     @job_specification_form.vacancy.school_id = current_school.id
     @job_specification_form.vacancy.send :set_slug

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -49,13 +49,14 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   private
 
   def job_specification_form_params
-    params.require(:job_specification_form).permit(:job_title, :job_description, :leadership_id,
-                                                   :subject_id,
-                                                   :starts_on_dd, :starts_on_mm,
-                                                   :starts_on_yyyy, :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
-                                                   :flexible_working, :newly_qualified_teacher,
-                                                   :first_supporting_subject_id, :second_supporting_subject_id,
-                                                   working_patterns: []).merge(completed_step: current_step)
+    params.require(:job_specification_form)
+          .permit(:job_title, :job_description, :leadership_id,
+                  :subject_id,
+                  :starts_on_dd, :starts_on_mm,
+                  :starts_on_yyyy, :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
+                  :flexible_working, :newly_qualified_teacher,
+                  :first_supporting_subject_id, :second_supporting_subject_id,
+                  working_patterns: [], job_role: []).merge(completed_step: current_step)
   end
 
   def save_vacancy_without_validation

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -49,6 +49,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   private
 
   def job_specification_form_params
+    persist_nqt_job_role_to_nqt_attribute
     params.require(:job_specification_form)
           .permit(:job_title, :job_description, :leadership_id,
                   :subject_id,

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -59,6 +59,16 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
                   working_patterns: [], job_role: []).merge(completed_step: current_step)
   end
 
+  def persist_nqt_job_role_to_nqt_attribute
+    job_role = params.require(:job_specification_form)[:job_role]
+
+    if job_role && job_role.include?(I18n.t('jobs.job_role_options.nqt_suitable'))
+      params[:job_specification_form][:newly_qualified_teacher] = true
+    elsif job_role
+      params[:job_specification_form][:newly_qualified_teacher] = false
+    end
+  end
+
   def save_vacancy_without_validation
     # TODO remove after migration to remove column
     @job_specification_form.vacancy.minimum_salary = ''

--- a/app/form_models/copy_vacancy_form.rb
+++ b/app/form_models/copy_vacancy_form.rb
@@ -26,7 +26,7 @@ class CopyVacancyForm < VacancyForm
     @expiry_time_meridiem = vacancy.expiry_time&.strftime('%P')
     self.vacancy = vacancy
     self.job_title = vacancy.job_title
-    self.job_role = vacancy.job_role
+    self.job_roles = vacancy.job_roles
 
     self.publish_on = nil if vacancy.publish_on.past?
     reset_date_fields if vacancy.expires_on.past?

--- a/app/form_models/copy_vacancy_form.rb
+++ b/app/form_models/copy_vacancy_form.rb
@@ -26,6 +26,7 @@ class CopyVacancyForm < VacancyForm
     @expiry_time_meridiem = vacancy.expiry_time&.strftime('%P')
     self.vacancy = vacancy
     self.job_title = vacancy.job_title
+    self.job_role = vacancy.job_role
 
     self.publish_on = nil if vacancy.publish_on.past?
     reset_date_fields if vacancy.expires_on.past?
@@ -34,7 +35,6 @@ class CopyVacancyForm < VacancyForm
   def apply_changes!(params = {})
     assign_attributes(params.extract!(:expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem))
     vacancy.assign_attributes(params)
-
     vacancy
   end
 

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -108,6 +108,7 @@ module VacanciesHelper
 
   def new_sections(vacancy)
     sections = []
+    sections << 'job_role' unless vacancy.job_role.any?
     sections << 'supporting_documents' unless vacancy.supporting_documents
     sections
   end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -108,7 +108,7 @@ module VacanciesHelper
 
   def new_sections(vacancy)
     sections = []
-    sections << 'job_role' unless vacancy.job_role.any?
+    sections << 'job_role' unless vacancy.job_roles.any?
     sections << 'supporting_documents' unless vacancy.supporting_documents
     sections
   end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -10,6 +10,10 @@ module VacanciesHelper
 
   WORD_EXCEPTIONS = ['and', 'the', 'of', 'upon'].freeze
 
+  def job_role_options
+    Vacancy::JOB_ROLE_OPTIONS
+  end
+
   def working_pattern_options
     Vacancy::WORKING_PATTERN_OPTIONS.map do |key, _value|
       [Vacancy.human_attribute_name("working_patterns.#{key}"), key]

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -6,7 +6,7 @@ module VacancyJobSpecificationValidations
     validates :job_title, :job_description, presence: true
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
 
-    validates :job_role, presence: true
+    validates :job_roles, presence: true
 
     validates :job_description, length: { minimum: 10, maximum: 50_000 }, if: :job_description?
 

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -5,6 +5,9 @@ module VacancyJobSpecificationValidations
   included do
     validates :job_title, :job_description, presence: true
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
+    
+    validates :job_role, presence: true
+
     validates :job_description, length: { minimum: 10, maximum: 50_000 }, if: :job_description?
 
     validates :working_patterns, presence: true

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -5,7 +5,7 @@ module VacancyJobSpecificationValidations
   included do
     validates :job_title, :job_description, presence: true
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
-    
+
     validates :job_role, presence: true
 
     validates :job_description, length: { minimum: 10, maximum: 50_000 }, if: :job_description?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -2,6 +2,13 @@ require 'elasticsearch/model'
 require 'auditor'
 
 class Vacancy < ApplicationRecord
+  JOB_ROLE_OPTIONS = [
+    'Teacher',
+    'Leadership',
+    'SEN specialist',
+    'Suitable for NQTs'
+  ].freeze
+
   FLEXIBLE_WORKING_PATTERN_OPTIONS = {
     'part_time' => 100,
     'job_share' => 101,

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -3,8 +3,8 @@ require 'auditor'
 
 class Vacancy < ApplicationRecord
   JOB_ROLE_OPTIONS = [
-    I18n.t('teacher'),
-    I18n.t('leadership'),
+    I18n.t('jobs.job_role_options.teacher'),
+    I18n.t('jobs.job_role_options.leadership'),
     I18n.t('jobs.job_role_options.sen_specialist'),
     I18n.t('jobs.job_role_options.nqt_suitable')
   ].freeze

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -3,10 +3,10 @@ require 'auditor'
 
 class Vacancy < ApplicationRecord
   JOB_ROLE_OPTIONS = [
-    'Teacher',
-    'Leadership',
-    'SEN specialist',
-    'Suitable for NQTs'
+    I18n.t('teacher'),
+    I18n.t('leadership'),
+    I18n.t('jobs.job_role_options.sen_specialist'),
+    I18n.t('jobs.job_role_options.nqt_suitable')
   ].freeze
 
   FLEXIBLE_WORKING_PATTERN_OPTIONS = {

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -3,7 +3,7 @@ class VacancyPresenter < BasePresenter
   include ActionView::Helpers::UrlHelper
 
   delegate :working_patterns, to: :model, prefix: true
-  delegate :job_role, to: :model, prefix: true
+  delegate :job_roles, to: :model, prefix: true
 
   def share_url(source: nil, medium: nil, campaign: nil, content: nil)
     params = { protocol: 'https' }
@@ -148,7 +148,7 @@ class VacancyPresenter < BasePresenter
     "#{job_title} at #{school_name}"
   end
 
-  def show_job_role
-    model.job_role.join(', ')
+  def show_job_roles
+    model.job_roles.join(', ')
   end
 end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -147,4 +147,8 @@ class VacancyPresenter < BasePresenter
   def job_title_and_school
     "#{job_title} at #{school_name}"
   end
+
+  def show_job_role
+    model.job_role.join(', ')
+  end
 end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -3,6 +3,7 @@ class VacancyPresenter < BasePresenter
   include ActionView::Helpers::UrlHelper
 
   delegate :working_patterns, to: :model, prefix: true
+  delegate :job_role, to: :model, prefix: true
 
   def share_url(source: nil, medium: nil, campaign: nil, content: nil)
     params = { protocol: 'https' }

--- a/app/services/persist_nqt_job_role.rb
+++ b/app/services/persist_nqt_job_role.rb
@@ -1,0 +1,13 @@
+module PersistNQTJobRole
+  # Only necessary until changes to search are implemented
+  # TODO remove after migration to remove newly qualified teacher column
+  def persist_nqt_job_role_to_nqt_attribute(form)
+    job_roles = params.require(form)[:job_roles]
+
+    if job_roles && job_roles.include?(I18n.t('jobs.job_role_options.nqt_suitable'))
+      params[form][:newly_qualified_teacher] = true
+    elsif job_roles
+      params[form][:newly_qualified_teacher] = false
+    end
+  end
+end

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -18,6 +18,15 @@
                 wrapper_html: { id: 'job_title' },
                 input_html: { class: 'govuk-input' },
                 required: true
+      - if @copy_form.vacancy.job_role.none?
+        = f.input :job_role,
+                  as: :check_boxes,
+                  wrapper: :checkboxes,
+                  label: t('jobs.job_role'),
+                  hint: t('jobs.form_hints.job_role'),
+                  wrapper_html: { id: 'job_role' },
+                  collection: job_role_options,
+                  required: true
 
       %div.govuk-form-group#starts_on
         = f.gov_uk_date_field :starts_on,

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -18,11 +18,11 @@
                 wrapper_html: { id: 'job_title' },
                 input_html: { class: 'govuk-input' },
                 required: true
-      - if @copy_form.vacancy.job_role.none?
-        = f.input :job_role,
+      - if @copy_form.vacancy.job_roles.none?
+        = f.input :job_roles,
                   as: :check_boxes,
                   wrapper: :checkboxes,
-                  label: t('jobs.job_role'),
+                  label: t('jobs.job_roles'),
                   hint: t('jobs.form_hints.job_role'),
                   wrapper_html: { id: 'job_role' },
                   collection: job_role_options,

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -7,7 +7,7 @@
 
 = simple_form_for @copy_form, html: { class: 'copy-form' }, action: :post, url: school_job_copy_path do |f|
   %h2.govuk-heading-m
-    = t('jobs.job_specification')
+    = t('jobs.job_details')
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/hiring_staff/vacancies/documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/documents/show.html.haml
@@ -1,4 +1,4 @@
-= render 'hiring_staff/vacancies/vacancy_form_partials/title', form_section_title: 'Supporting documents', form_section_step: 3, form_section_total_steps: 4
+= render 'hiring_staff/vacancies/vacancy_form_partials/title', form_section_title: I18n.t('jobs.supporting_documents')
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -24,7 +24,7 @@
     %dt.app-check-your-answers__question#job_role
       = t('jobs.job_role')
     %dd.app-check-your-answers__answer
-      = @vacancy.job_role.join(', ')
+      = @vacancy.show_job_role
     %dd.app-check-your-answers__change
       = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'job_role'), 'aria-label': t('jobs.aria_labels.change_job_role'), class: 'govuk-link'
 

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -1,5 +1,9 @@
 %h2.govuk-heading-m.mb0
   = t('jobs.job_details')
+  - unless @vacancy.job_role.any?
+    .notification-tag
+      %strong.govuk-tag.app-task-list__task-completed
+        = t('jobs.notification_labels.new')
 
 .govuk-body-s.mb1
   = link_to edit_school_job_job_specification_path(@vacancy.id), class: 'govuk-link', 'aria-label': t('jobs.aria_labels.change_job_specification') do

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -1,6 +1,6 @@
 %h2.govuk-heading-m.mb0
   = t('jobs.job_details')
-  - unless @vacancy.job_role.any?
+  - unless @vacancy.job_roles.any?
     .notification-tag
       %strong.govuk-tag.app-task-list__task-completed
         = t('jobs.notification_labels.new')
@@ -22,9 +22,9 @@
 
   .app-check-your-answers__contents
     %dt.app-check-your-answers__question#job_role
-      = t('jobs.job_role')
+      = t('jobs.job_roles')
     %dd.app-check-your-answers__answer
-      = @vacancy.show_job_role
+      = @vacancy.show_job_roles
     %dd.app-check-your-answers__change
       = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'job_role'), 'aria-label': t('jobs.aria_labels.change_job_role'), class: 'govuk-link'
 

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -9,7 +9,7 @@
 %dl.app-check-your-answers.app-check-your-answers--short
 
   .app-check-your-answers__contents
-    %dt.app-check-your-answers__question
+    %dt.app-check-your-answers__question#job_title
       = t('jobs.job_title')
     %dd.app-check-your-answers__answer
       = @vacancy.job_title
@@ -17,7 +17,15 @@
       = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'job_title'), 'aria-label': t('jobs.aria_labels.change_job_title'), class: 'govuk-link'
 
   .app-check-your-answers__contents
-    %dt.app-check-your-answers__question
+    %dt.app-check-your-answers__question#job_role
+      = t('jobs.job_role')
+    %dd.app-check-your-answers__answer
+      = @vacancy.job_role.join(', ')
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'job_role'), 'aria-label': t('jobs.aria_labels.change_job_role'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#description
       = t('jobs.job_description')
     %dd.app-check-your-answers__answer
       = @vacancy.job_description
@@ -25,7 +33,7 @@
       = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'job_description'), 'aria-label': t('jobs.aria_labels.change_job_description'), class: 'govuk-link'
 
   .app-check-your-answers__contents
-    %dt.app-check-your-answers__question
+    %dt.app-check-your-answers__question#main_subject
       = t('jobs.main_subject')
     %dd.app-check-your-answers__answer
       = @vacancy.main_subject
@@ -34,23 +42,15 @@
 
   .app-check-your-answers__contents
     %dt.app-check-your-answers__question
-      = t('jobs.first_supporting_subject')
+      = t('jobs.other_subjects')
     %dd.app-check-your-answers__answer
-      = @vacancy.first_supporting_subject
+      = @vacancy.other_subjects
     %dd.app-check-your-answers__change
-      = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'first_supporting_subject'), 'aria-label': t('jobs.aria_labels.change_first_supporting_subject'), class: 'govuk-link'
-
-  .app-check-your-answers__contents
-    %dt.app-check-your-answers__question
-      = t('jobs.second_supporting_subject')
-    %dd.app-check-your-answers__answer
-      = @vacancy.second_supporting_subject
-    %dd.app-check-your-answers__change
-      = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'second_supporting_subject'), 'aria-label': t('jobs.aria_labels.change_second_supporting_subject'), class: 'govuk-link'
+      = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'other_subjects'), 'aria-label': t('jobs.aria_labels.change_other_subjects'), class: 'govuk-link'
 
   - if @vacancy.working_patterns?
     .app-check-your-answers__contents
-      %dt.app-check-your-answers__question
+      %dt.app-check-your-answers__question#working_patterns
         = t('jobs.working_patterns')
       %dd.app-check-your-answers__answer
         = @vacancy.working_patterns
@@ -58,24 +58,7 @@
         = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'working_patterns'), 'aria-label': t('jobs.aria_labels.change_working_patterns'), class: 'govuk-link'
 
   .app-check-your-answers__contents
-    %dt.app-check-your-answers__question
-      = t('jobs.newly_qualified_teacher')
-    %dd.app-check-your-answers__answer
-      = @vacancy.newly_qualified_teacher
-    %dd.app-check-your-answers__change
-      = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'newly_qualified_teacher'), 'aria-label': t('jobs.aria_labels.newly_qualified_teacher'), class: 'govuk-link'
-
-  .app-check-your-answers__contents
-    %dt.app-check-your-answers__question
-      = t('jobs.leadership_level')
-    %dd.app-check-your-answers__answer
-      - if @vacancy.leadership
-        = @vacancy.leadership.title
-    %dd.app-check-your-answers__change
-      = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'leadership'), 'aria-label': t('jobs.aria_labels.change_leadership_level'), class: 'govuk-link'
-
-  .app-check-your-answers__contents
-    %dt.app-check-your-answers__question
+    %dt.app-check-your-answers__question#starts_on
       = t('jobs.starts_on')
     %dd.app-check-your-answers__answer
       = format_date @vacancy.starts_on
@@ -83,7 +66,7 @@
       = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'starts_on'), 'aria-label': t('jobs.aria_labels.change_expected_start_date'), class: 'govuk-link'
 
   .app-check-your-answers__contents
-    %dt.app-check-your-answers__question
+    %dt.app-check-your-answers__question#ends_on
       = t('jobs.ends_on')
     %dd.app-check-your-answers__answer
       = format_date @vacancy.ends_on

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -1,5 +1,5 @@
 %h2.govuk-heading-m.mb0
-  = t('jobs.job_specification')
+  = t('jobs.job_details')
 
 .govuk-body-s.mb1
   = link_to edit_school_job_job_specification_path(@vacancy.id), class: 'govuk-link', 'aria-label': t('jobs.aria_labels.change_job_specification') do

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -18,7 +18,7 @@
 
   .app-check-your-answers__contents
     %dt.app-check-your-answers__question
-      = t('jobs.description')
+      = t('jobs.job_description')
     %dd.app-check-your-answers__answer
       = @vacancy.job_description
     %dd.app-check-your-answers__change

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -18,10 +18,10 @@
                   required: true
         %span#job_specification_form_job_title-info.govuk-hint.govuk-character-count__message{ "aria-live": "polite" }
           You can enter up to 100 characters
-      = f.input :job_role,
+      = f.input :job_roles,
                 as: :check_boxes,
                 wrapper: :checkboxes,
-                label: t('jobs.job_role'),
+                label: t('jobs.job_roles'),
                 hint: t('jobs.form_hints.job_role'),
                 wrapper_html: { id: 'job_role' },
                 collection: job_role_options,

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -21,7 +21,7 @@
       = f.input :job_description,
                 wrapper: 'textarea',
                 as: :text,
-                label: t('jobs.description'),
+                label: t('jobs.job_description'),
                 hint: t('jobs.form_hints.description'),
                 input_html: { rows: 10 },
                 wrapper_html: { id: 'job_description' },

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -4,7 +4,7 @@
   = t('jobs.edit_heading', school: current_school.name)
 = simple_form_for @job_specification_form, method: :put, url: school_job_job_specification_path(@job_specification_form.id) do |f|
   %h2.govuk-heading-m
-    = t('jobs.job_specification')
+    = t('jobs.job_details')
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -18,6 +18,14 @@
                   required: true
         %span#job_specification_form_job_title-info.govuk-hint.govuk-character-count__message{ "aria-live": "polite" }
           You can enter up to 100 characters
+      = f.input :job_role,
+                as: :check_boxes,
+                wrapper: :checkboxes,
+                label: t('jobs.job_role'),
+                hint: t('jobs.form_hints.job_role'),
+                wrapper_html: { id: 'job_role' },
+                collection: job_role_options,
+                required: true
       = f.input :job_description,
                 wrapper: 'textarea',
                 as: :text,
@@ -33,18 +41,22 @@
                 wrapper_html: { id: 'main_subject' },
                 collection: subject_options,
                 required: false
-      = f.input :first_supporting_subject_id,
-                label: t('jobs.first_supporting_subject'),
-                hint: t('jobs.form_hints.supporting_subject'),
-                wrapper_html: { id: 'first_supporting_subject' },
-                collection: subject_options,
-                required: false
-      = f.input :second_supporting_subject_id,
-                label: t('jobs.second_supporting_subject'),
-                hint: t('jobs.form_hints.supporting_subject'),
-                wrapper_html: { id: 'second_supporting_subject' },
-                collection: subject_options,
-                required: false
+
+      #other_subjects
+        = f.input :first_supporting_subject_id,
+                  wrapper: 'select',
+                  label: t('jobs.first_supporting_subject'),
+                  hint: t('jobs.form_hints.supporting_subject'),
+                  wrapper_html: { id: 'first_supporting_subject' },
+                  collection: subject_options,
+                  required: false
+        = f.input :second_supporting_subject_id,
+                  wrapper: 'select',
+                  label: t('jobs.second_supporting_subject'),
+                  hint: t('jobs.form_hints.supporting_subject'),
+                  wrapper_html: { id: 'second_supporting_subject' },
+                  collection: subject_options,
+                  required: false
 
       = f.input :working_patterns,
                 as: :check_boxes,
@@ -55,15 +67,9 @@
                 collection: working_pattern_options,
                 required: true
 
-      = f.input :flexible_working, as: :boolean,
-                wrapper: :inline_checkbox,
-                wrapper_html: { id: 'flexible_working' },
-                input_html: { 'aria-label': t('jobs.aria_labels.flexible_working') }
-
       %div.govuk-form-group#starts_on
         = f.gov_uk_date_field :starts_on,
                               legend_options: { page_heading: false, class: "govuk-label" }
-
 
       %div.govuk-form-group#ends_on
         = f.gov_uk_date_field :ends_on,

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -20,10 +20,10 @@
                   required: true
         %span#job_specification_form_job_title-info.govuk-hint.govuk-character-count__message{ "aria-live": "polite" }
           You can enter up to 100 characters
-      = f.input :job_role,
+      = f.input :job_roles,
                 as: :check_boxes,
                 wrapper: :checkboxes,
-                label: t('jobs.job_role'),
+                label: t('jobs.job_roles'),
                 hint: t('jobs.form_hints.job_role'),
                 wrapper_html: { id: 'job_role' },
                 collection: job_role_options,

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -9,7 +9,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h2.govuk-heading-m
-        = t('jobs.job_specification')
+        = t('jobs.job_details')
       = render 'hiring_staff/vacancies/error_messages', errors: @job_specification_form.errors
       .govuk-character-count{ "data-module": "govuk-character-count", "data-maxlength": 100 }
         = f.input :job_title,

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -69,18 +69,6 @@
                 collection: working_pattern_options,
                 required: true
 
-      = f.input :newly_qualified_teacher, as: :boolean,
-                hint: t('jobs.form_hints.newly_qualified_teacher'),
-                wrapper: :inline_checkbox,
-                wrapper_html: { id: 'newly_qualified_teacher' },
-                input_html: { 'aria-label': t('jobs.aria_labels.newly_qualified_teacher') }
-      = f.input :leadership_id,
-                wrapper: 'select',
-                label: t('jobs.leadership_level'),
-                collection: Leadership.order(:title),
-                wrapper_html: { id: 'leadership' },
-                required: false
-
       %div.govuk-form-group#starts_on
         = f.gov_uk_date_field :starts_on,
                               legend_options: { page_heading: false, class: "govuk-label" }

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -20,6 +20,14 @@
                   required: true
         %span#job_specification_form_job_title-info.govuk-hint.govuk-character-count__message{ "aria-live": "polite" }
           You can enter up to 100 characters
+      = f.input :job_role,
+                as: :check_boxes,
+                wrapper: :checkboxes,
+                label: t('jobs.job_role'),
+                hint: t('jobs.form_hints.job_role'),
+                wrapper_html: { id: 'job_role' },
+                collection: job_role_options,
+                required: true
       = f.input :job_description,
                 wrapper: 'textarea',
                 as: :text,

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -31,7 +31,7 @@
       = f.input :job_description,
                 wrapper: 'textarea',
                 as: :text,
-                label: t('jobs.description'),
+                label: t('jobs.job_description'),
                 hint: t('jobs.form_hints.description'),
                 input_html: { rows: 10 },
                 wrapper_html: { id: 'job_description' },

--- a/app/views/hiring_staff/vacancies/pay_package/show.html.haml
+++ b/app/views/hiring_staff/vacancies/pay_package/show.html.haml
@@ -1,4 +1,4 @@
-= render 'hiring_staff/vacancies/vacancy_form_partials/title', form_section_title: 'Pay package', form_section_step: 2, form_section_total_steps: 4
+= render 'hiring_staff/vacancies/vacancy_form_partials/title', form_section_title: I18n.t('jobs.pay_package')
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
@@ -1,6 +1,6 @@
 %h2.govuk-heading-m.mb0
   = t('jobs.job_details')
-  - unless @vacancy.job_role.any?
+  - unless @vacancy.job_roles.any?
     .notification-tag
       %strong.govuk-tag.app-task-list__task-completed
         = t('jobs.notification_labels.new')
@@ -22,9 +22,9 @@
 
   .app-check-your-answers__contents
     %dt.app-check-your-answers__question#job_role
-      = t('jobs.job_role')
+      = t('jobs.job_roles')
     %dd.app-check-your-answers__answer
-      = @vacancy.show_job_role
+      = @vacancy.show_job_roles
     %dd.app-check-your-answers__change
       = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_role'), 'aria-label': t('jobs.aria_labels.change_job_role'), class: 'govuk-link'
 

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
@@ -24,7 +24,7 @@
     %dt.app-check-your-answers__question#job_role
       = t('jobs.job_role')
     %dd.app-check-your-answers__answer
-      = @vacancy.job_role.join(', ')
+      = @vacancy.show_job_role
     %dd.app-check-your-answers__change
       = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_role'), 'aria-label': t('jobs.aria_labels.change_job_role'), class: 'govuk-link'
 

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
@@ -1,5 +1,9 @@
 %h2.govuk-heading-m.mb0
   = t('jobs.job_details')
+  - unless @vacancy.job_role.any?
+    .notification-tag
+      %strong.govuk-tag.app-task-list__task-completed
+        = t('jobs.notification_labels.new')
 
 .govuk-body-s.mb1
   = link_to job_specification_school_job_path, class: 'govuk-link', 'aria-label': 'Change job specification' do

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
@@ -1,5 +1,5 @@
 %h2.govuk-heading-m.mb0
-  = t('jobs.job_specification')
+  = t('jobs.job_details')
 
 .govuk-body-s.mb1
   = link_to job_specification_school_job_path, class: 'govuk-link', 'aria-label': 'Change job specification' do

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
@@ -18,7 +18,7 @@
 
   .app-check-your-answers__contents
     %dt.app-check-your-answers__question#description
-      = t('jobs.description')
+      = t('jobs.job_description')
     %dd.app-check-your-answers__answer
       = @vacancy.job_description
     %dd.app-check-your-answers__change

--- a/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/review_vacancy_sections/_review_job_specification.html.haml
@@ -17,6 +17,14 @@
       = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_title'), 'aria-label': t('jobs.aria_labels.change_job_title'), class: 'govuk-link'
 
   .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#job_role
+      = t('jobs.job_role')
+    %dd.app-check-your-answers__answer
+      = @vacancy.job_role.join(', ')
+    %dd.app-check-your-answers__change
+      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_role'), 'aria-label': t('jobs.aria_labels.change_job_role'), class: 'govuk-link'
+
+  .app-check-your-answers__contents
     %dt.app-check-your-answers__question#description
       = t('jobs.job_description')
     %dd.app-check-your-answers__answer
@@ -48,23 +56,6 @@
         = @vacancy.working_patterns
       %dd.app-check-your-answers__change
         = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'working_patterns'), 'aria-label': t('jobs.aria_labels.change_working_patterns'), class: 'govuk-link'
-
-  .app-check-your-answers__contents
-    %dt.app-check-your-answers__question#newly_qualified_teacher
-      = t('jobs.newly_qualified_teacher')
-    %dd.app-check-your-answers__answer
-      = @vacancy.newly_qualified_teacher
-    %dd.app-check-your-answers__change
-      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'newly_qualified_teacher'), 'aria-label': t('jobs.aria_labels.newly_qualified_teacher'), class: 'govuk-link'
-
-  .app-check-your-answers__contents
-    %dt.app-check-your-answers__question#leadership_level
-      = t('jobs.leadership_level')
-    %dd.app-check-your-answers__answer
-      - if @vacancy.leadership
-        =@vacancy.leadership.title
-    %dd.app-check-your-answers__change
-      = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'leadership'), 'aria-label': t('jobs.aria_labels.change_leadership_level'), class: 'govuk-link'
 
   .app-check-your-answers__contents
     %dt.app-check-your-answers__question#starts_on

--- a/app/views/vacancies/_job_details_section.html.haml
+++ b/app/views/vacancies/_job_details_section.html.haml
@@ -37,7 +37,7 @@
           %td.govuk-table__cell
             = @vacancy.leadership.title
 
-  %h4.govuk-heading-s= t('jobs.description')
+  %h4.govuk-heading-s= t('jobs.job_description')
   %p= @vacancy.job_description
 
   - if @vacancy.documents.none? && @vacancy.any_candidate_specification?

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -4,7 +4,7 @@ en:
       blank: Enter a job title
       too_short: Job title must be at least %{count} characters
       too_long: Job title must not be more than %{count} characters
-    job_role:
+    job_roles:
       blank: Select a job role
     job_description:
       blank: Enter a job description

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -4,6 +4,8 @@ en:
       blank: Enter a job title
       too_short: Job title must be at least %{count} characters
       too_long: Job title must not be more than %{count} characters
+    job_role:
+      blank: Select a job role
     job_description:
       blank: Enter a job description
       too_short: Job description must be at least %{count} characters

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,7 +168,7 @@ en:
       - 'Schools have listed %{count} jobs but they have since expired.'
     job_details: 'Job details'
     job_title: 'Job title'
-    job_role: 'Job role'
+    job_roles: 'Job role'
     job_role_options:
       teacher: 'Teacher'
       leadership: 'Leadership'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,6 +170,8 @@ en:
     job_title: 'Job title'
     job_role: 'Job role'
     job_role_options:
+      teacher: 'Teacher'
+      leadership: 'Leadership'
       sen_specialist: 'SEN specialist'
       nqt_suitable: 'Suitable for NQTs'
     job_description: 'Job description'    

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,6 +169,9 @@ en:
     job_details: 'Job details'
     job_title: 'Job title'
     job_role: 'Job role'
+    job_role_options:
+      sen_specialist: 'SEN specialist'
+      nqt_suitable: 'Suitable for NQTs'
     job_description: 'Job description'    
     salary: 'Salary'
     benefits: 'Employee benefits'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,6 +169,7 @@ en:
       - 'Schools have listed %{count} jobs but they have since expired.'
     job_details: 'Job details'
     job_title: 'Job title'
+    job_role: 'Job role'
     salary: 'Salary'
     benefits: 'Employee benefits'
     salary_range_html: "Salary range (<span class='text-red'>Required</span>)"
@@ -304,6 +305,7 @@ en:
       sort_by_link: Sort jobs by %{column} in %{order}ending order
     form_hints:
       job_title: "For secondary school roles include subject and, if relevant, level of seniority ('Subject leader for science', for example)."
+      job_role: 'Select all that describe the role'
       description: 'Briefly describe the duties and responsibilities involved in the role (minimum 10 characters)'
       subject: 'What subject will the teacher focus on?'
       salary_range: 'Enter full-time equivalent annual salary, before tax (for example, 30,000 for a half-time role that pays £15,000 per year)'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,7 +139,6 @@ en:
     starts_on: 'Expected start date'
     ends_on: 'End date'
     expired: 'This job post has expired'
-    description: 'Job description'
     education: 'Essential educational requirements'
     qualifications: 'Essential qualifications'
     experience: 'Essential skills and experience'
@@ -170,6 +169,7 @@ en:
     job_details: 'Job details'
     job_title: 'Job title'
     job_role: 'Job role'
+    job_description: 'Job description'    
     salary: 'Salary'
     benefits: 'Employee benefits'
     salary_range_html: "Salary range (<span class='text-red'>Required</span>)"

--- a/db/migrate/20200319165536_add_job_role_to_vacancies.rb
+++ b/db/migrate/20200319165536_add_job_role_to_vacancies.rb
@@ -1,5 +1,5 @@
 class AddJobRoleToVacancies < ActiveRecord::Migration[5.2]
   def change
-    add_column :vacancies, :job_role, :string, array: true
+    add_column :vacancies, :job_roles, :string, array: true
   end
 end

--- a/db/migrate/20200319165536_add_job_role_to_vacancies.rb
+++ b/db/migrate/20200319165536_add_job_role_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddJobRoleToVacancies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :vacancies, :job_role, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -226,7 +226,7 @@ ActiveRecord::Schema.define(version: 2020_04_01_125329) do
     t.string "supporting_documents"
     t.string "salary"
     t.integer "completed_step"
-    t.string "job_role", array: true
+    t.string "job_roles", array: true
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["expiry_time"], name: "index_vacancies_on_expiry_time"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -226,6 +226,7 @@ ActiveRecord::Schema.define(version: 2020_04_01_125329) do
     t.string "supporting_documents"
     t.string "salary"
     t.integer "completed_step"
+    t.string "job_role", array: true
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["expiry_time"], name: "index_vacancies_on_expiry_time"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"

--- a/lib/job_posting.rb
+++ b/lib/job_posting.rb
@@ -13,7 +13,7 @@ class JobPosting
     {
       job_title: @schema['title'],
       job_description: @schema['description'],
-      job_role: @schema['jobRole'],
+      job_roles: @schema['jobRoles'],
       salary: @schema['salary'],
       benefits: @schema['jobBenefits'],
       education: @schema['educationRequirements'],

--- a/lib/job_posting.rb
+++ b/lib/job_posting.rb
@@ -13,6 +13,7 @@ class JobPosting
     {
       job_title: @schema['title'],
       job_description: @schema['description'],
+      job_role: @schema['jobRole'],
       salary: @schema['salary'],
       benefits: @schema['jobBenefits'],
       education: @schema['educationRequirements'],

--- a/lib/tasks/convert_nqt_to_job_role.rake
+++ b/lib/tasks/convert_nqt_to_job_role.rake
@@ -24,8 +24,8 @@ namespace :data do
         )
       end
 
-      Rails.logger.info("Conversion of salary ranges to strings has been completed for #{updated_count} vacancies")
-      Rollbar.log(:info, "Conversion of salary ranges to strings has been completed for #{updated_count} vacancies")
+      Rails.logger.info("Conversion of NQT fields to job role has been completed for #{updated_count} vacancies")
+      Rollbar.log(:info, "Conversion of NQT fields to job role has been completed for #{updated_count} vacancies")
     end
   end
 end

--- a/lib/tasks/convert_nqt_to_job_role.rake
+++ b/lib/tasks/convert_nqt_to_job_role.rake
@@ -16,11 +16,11 @@ namespace :data do
       Vacancy.where(newly_qualified_teacher: true).in_batches(of: 100).each_record do |vacancy|
         # Some vacancies being updated will have been created prior to certain validations
         # rubocop:disable Rails/SkipsModelValidations
-        vacancy.update_columns(job_role: [I18n.t('jobs.job_role_options.nqt_suitable')])
+        vacancy.update_columns(job_roles: [I18n.t('jobs.job_role_options.nqt_suitable')])
         # rubocop:enable Rails/SkipsModelValidations
         updated_count += 1
         Rails.logger.info(
-          "Updated vacancy: #{vacancy.job_title} with job_role: #{I18n.t('jobs.job_role_options.nqt_suitable')}"
+          "Updated vacancy: #{vacancy.job_title} with job_roles: #{I18n.t('jobs.job_role_options.nqt_suitable')}"
         )
       end
 

--- a/lib/tasks/convert_nqt_to_job_role.rake
+++ b/lib/tasks/convert_nqt_to_job_role.rake
@@ -15,9 +15,8 @@ namespace :data do
 
       Vacancy.where(newly_qualified_teacher: true).in_batches(of: 100).each_record do |vacancy|
         # Some vacancies being updated will have been created prior to certain validations
-        # rubocop:disable Rails/SkipsModelValidations
-        vacancy.update_columns(job_roles: [I18n.t('jobs.job_role_options.nqt_suitable')])
-        # rubocop:enable Rails/SkipsModelValidations
+        vacancy.job_roles.append(I18n.t('jobs.job_role_options.nqt_suitable'))
+        vacancy.save(validate: false)
         updated_count += 1
         Rails.logger.info(
           "Updated vacancy: #{vacancy.job_title} with job_roles: #{I18n.t('jobs.job_role_options.nqt_suitable')}"

--- a/lib/tasks/convert_nqt_to_job_role.rake
+++ b/lib/tasks/convert_nqt_to_job_role.rake
@@ -1,0 +1,31 @@
+namespace :data do
+  desc 'Convert NQT field to job role field'
+  namespace :convert_nqt do
+    task vacancies: :environment do
+      updated_count = 0
+      should_be_updated_count = Vacancy.where(newly_qualified_teacher: true).count
+
+      Rails.logger.info(
+        "Conversion of NQT fields to job role has been started for #{should_be_updated_count} vacancies"
+      )
+      Rollbar.log(
+        :info,
+        "Conversion of NQT fields to job role has been started for #{should_be_updated_count} vacancies"
+      )
+
+      Vacancy.where(newly_qualified_teacher: true).in_batches(of: 100).each_record do |vacancy|
+        # Some vacancies being updated will have been created prior to certain validations
+        # rubocop:disable Rails/SkipsModelValidations
+        vacancy.update_columns(job_role: [I18n.t('jobs.job_role_options.nqt_suitable')])
+        # rubocop:enable Rails/SkipsModelValidations
+        updated_count += 1
+        Rails.logger.info(
+          "Updated vacancy: #{vacancy.job_title} with job_role: #{I18n.t('jobs.job_role_options.nqt_suitable')}"
+        )
+      end
+
+      Rails.logger.info("Conversion of salary ranges to strings has been completed for #{updated_count} vacancies")
+      Rollbar.log(:info, "Conversion of salary ranges to strings has been completed for #{updated_count} vacancies")
+    end
+  end
+end

--- a/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
+++ b/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe HiringStaff::Vacancies::JobSpecificationController, type: :contro
       let(:params) do
         {
           job_specification_form: {
-            job_role: I18n.t('jobs.job_role_options.nqt_suitable')
+            job_roles: I18n.t('jobs.job_role_options.nqt_suitable')
           }
         }
       end
@@ -27,7 +27,7 @@ RSpec.describe HiringStaff::Vacancies::JobSpecificationController, type: :contro
       let(:params) do
         {
           job_specification_form: {
-            job_role: I18n.t('jobs.job_role_options.teacher')
+            job_roles: I18n.t('jobs.job_role_options.teacher')
           }
         }
       end

--- a/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
+++ b/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe HiringStaff::Vacancies::JobSpecificationController, type: :controller do
+  describe '#create' do
+    before do
+      allow(controller).to receive(:session).and_return(double('session').as_null_object)
+      allow(controller).to receive_message_chain(:session, :key?).with(:urn).and_return(true)
+      allow(controller).to receive_message_chain(:current_user, :accepted_terms_and_conditions?).and_return(true)
+    end
+
+    context 'job role is suitable for NQT' do
+      let(:params) do
+        {
+          job_specification_form: {
+            job_role: I18n.t('jobs.job_role_options.nqt_suitable')
+          }
+        }
+      end
+
+      it 'persists the job role in the NQT field' do
+        post :create, params: params
+        expect(controller.params[:job_specification_form][:newly_qualified_teacher]).to eql(true)
+      end
+    end
+
+    context 'job role is NOT suitable for NQT' do
+      let(:params) do
+        {
+          job_specification_form: {
+            job_role: I18n.t('jobs.job_role_options.teacher')
+          }
+        }
+      end
+
+      it 'persists the job role in the NQT field' do
+        post :create, params: params
+        expect(controller.params[:job_specification_form][:newly_qualified_teacher]).to eql(false)
+      end
+    end
+  end
+end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     expiry_time { expires_on&.change(sec: 0) }
     hired_status { nil }
     job_description { Faker::Lorem.paragraph(sentence_count: 4) }
-    job_role { ['Teacher'] }
+    job_roles { ['Teacher'] }
     job_title { Faker::Lorem.sentence[1...30].strip }
     listed_elsewhere { nil }
     minimum_salary { '' }

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     expiry_time { expires_on&.change(sec: 0) }
     hired_status { nil }
     job_description { Faker::Lorem.paragraph(sentence_count: 4) }
+    job_role { ['Teacher'] }
     job_title { Faker::Lorem.sentence[1...30].strip }
     listed_elsewhere { nil }
     minimum_salary { '' }

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -136,6 +136,39 @@ RSpec.feature 'Copying a vacancy' do
     end
   end
 
+  context '#job_roles' do
+    context 'when a copied job has no job role set' do
+      scenario 'it shows the job role field' do
+        original_vacancy = build(:vacancy, :past_publish, job_roles: [], school: school)
+        original_vacancy.save(validate: false)
+
+        visit school_path
+
+        within('table.vacancies') do
+          click_on I18n.t('jobs.copy_link')
+        end
+
+        expect(page).to have_content(I18n.t('jobs.copy_page_title', job_title: original_vacancy.job_title))
+        expect(page).to have_content(I18n.t('jobs.job_roles'))
+      end
+    end
+
+    context 'when a copied job has job role set' do
+      scenario 'it does not show the job role field' do
+        original_vacancy = create(:vacancy, school: school)
+
+        visit school_path
+
+        within('table.vacancies') do
+          click_on I18n.t('jobs.copy_link')
+        end
+
+        expect(page).to have_content(I18n.t('jobs.copy_page_title', job_title: original_vacancy.job_title))
+        expect(page).to_not have_content(I18n.t('jobs.job_roles'))
+      end
+    end
+  end
+
   describe 'validations' do
     let!(:original_vacancy) do
       vacancy = build(:vacancy, :past_publish, school: school)

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -97,6 +97,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         expect(page).to have_content(I18n.t('jobs.job_details'))
         expect(page.find('h2', text: I18n.t('jobs.job_details'))
           .text).to_not include(I18n.t('jobs.notification_labels.new'))
+        expect(page).to_not have_content(I18n.t('messages.jobs.new_sections.message'))
       end
 
       scenario 'ensures the vacancy slug is updated when the title is saved' do
@@ -217,6 +218,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         expect(page).to have_content(I18n.t('jobs.supporting_documents'))
         expect(page.find('h2', text: I18n.t('jobs.supporting_documents'))
           .text).to_not include(I18n.t('jobs.notification_labels.new'))
+        expect(page).to_not have_content(I18n.t('messages.jobs.new_sections.message'))
       end
     end
 

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   context 'editing a published vacancy' do
     let(:vacancy) do
       VacancyPresenter.new(create(:vacancy, :complete,
-                                  job_role: [
+                                  job_roles: [
                                     I18n.t('jobs.job_role_options.teacher'),
                                     I18n.t('jobs.job_role_options.sen_specialist')
                                    ],
@@ -78,7 +78,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
 
       scenario 'can edit job role for a legacy vacancy' do
         # rubocop:disable Rails/SkipsModelValidations
-        vacancy.update_columns(job_role: [])
+        vacancy.update_columns(job_roles: [])
         # rubocop:enable Rails/SkipsModelValidations
 
         visit edit_school_job_path(vacancy.id)
@@ -88,7 +88,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         expect(page.find('h2', text: I18n.t('jobs.job_details'))
           .text).to include(I18n.t('jobs.notification_labels.new'))
 
-        click_link_in_container_with_text(I18n.t('jobs.job_role'))
+        click_link_in_container_with_text(I18n.t('jobs.job_roles'))
 
         fill_in_job_specification_form_fields(vacancy)
 

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -261,7 +261,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
 
         expect(page).to have_content(I18n.t('messages.jobs.updated'))
 
-        verify_all_vacancy_details(VacancyPresenter.new(vacancy))
+        verify_all_vacancy_details(vacancy)
       end
 
       context 'if the job post has already been published' do

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -28,12 +28,22 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   end
 
   context 'editing a published vacancy' do
-    let(:vacancy) { create(:vacancy, :published, school: school) }
+    let(:vacancy) do
+      VacancyPresenter.new(create(:vacancy, :complete,
+                                  job_role: [
+                                    I18n.t('jobs.job_role_options.teacher'),
+                                    I18n.t('jobs.job_role_options.sen_specialist')
+                                   ],
+                                  school: school,
+                                  subject: build(:subject),
+                                  working_patterns: ['full_time', 'part_time'],
+                                  publish_on: Time.zone.today))
+    end
 
     scenario 'shows all vacancy information' do
       visit edit_school_job_path(vacancy.id)
 
-      verify_all_vacancy_details(VacancyPresenter.new(vacancy))
+      verify_all_vacancy_details(vacancy)
     end
 
     scenario 'takes you to the edit page' do
@@ -64,6 +74,29 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
 
         expect(page).to have_content(I18n.t('messages.jobs.updated'))
         expect(page).to have_content('Assistant Head Teacher')
+      end
+
+      scenario 'can edit job role for a legacy vacancy' do
+        # rubocop:disable Rails/SkipsModelValidations
+        vacancy.update_columns(job_role: [])
+        # rubocop:enable Rails/SkipsModelValidations
+
+        visit edit_school_job_path(vacancy.id)
+
+        expect(page).to have_content(I18n.t('jobs.job_details'))
+        expect(page).to have_content(I18n.t('messages.jobs.new_sections.message'))
+        expect(page.find('h2', text: I18n.t('jobs.job_details'))
+          .text).to include(I18n.t('jobs.notification_labels.new'))
+
+        click_link_in_container_with_text(I18n.t('jobs.job_role'))
+
+        fill_in_job_specification_form_fields(vacancy)
+
+        click_on 'Update job'
+
+        expect(page).to have_content(I18n.t('jobs.job_details'))
+        expect(page.find('h2', text: I18n.t('jobs.job_details'))
+          .text).to_not include(I18n.t('jobs.notification_labels.new'))
       end
 
       scenario 'ensures the vacancy slug is updated when the title is saved' do

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Creating a vacancy' do
     let!(:subjects) { create_list(:subject, 3) }
     let(:vacancy) do
       VacancyPresenter.new(build(:vacancy, :complete,
-                                 job_role: [
+                                 job_roles: [
                                    I18n.t('jobs.job_role_options.teacher'),
                                    I18n.t('jobs.job_role_options.sen_specialist')
                                   ],
@@ -53,7 +53,7 @@ RSpec.feature 'Creating a vacancy' do
 
         click_on 'Save and continue'
 
-        mandatory_fields = %w[job_title job_role job_description working_patterns]
+        mandatory_fields = %w[job_title job_roles job_description working_patterns]
 
         within('.govuk-error-summary') do
           expect(page).to have_content(I18n.t('errors.title', count: mandatory_fields.size))

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -25,7 +25,6 @@ RSpec.feature 'Creating a vacancy' do
 
   context 'creating a new vacancy' do
     let!(:subjects) { create_list(:subject, 3) }
-    let!(:leaderships) { create_list(:leadership, 3) }
     let(:vacancy) do
       VacancyPresenter.new(build(:vacancy, :complete,
                                  job_role: [
@@ -36,7 +35,6 @@ RSpec.feature 'Creating a vacancy' do
                                  subject: subjects[0],
                                  first_supporting_subject: subjects[1],
                                  second_supporting_subject: subjects[2],
-                                 leadership: leaderships.sample,
                                  working_patterns: ['full_time', 'part_time'],
                                  publish_on: Time.zone.today))
     end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -28,7 +28,10 @@ RSpec.feature 'Creating a vacancy' do
     let!(:leaderships) { create_list(:leadership, 3) }
     let(:vacancy) do
       VacancyPresenter.new(build(:vacancy, :complete,
-                                 job_role: ['Teacher', 'SEN specialist'],
+                                 job_role: [
+                                   I18n.t('teacher'),
+                                   I18n.t('jobs.job_role_options.sen_specialist')
+                                  ],
                                  school: school,
                                  subject: subjects[0],
                                  first_supporting_subject: subjects[1],

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Creating a vacancy' do
     let(:vacancy) do
       VacancyPresenter.new(build(:vacancy, :complete,
                                  job_role: [
-                                   I18n.t('teacher'),
+                                   I18n.t('jobs.job_role_options.teacher'),
                                    I18n.t('jobs.job_role_options.sen_specialist')
                                   ],
                                  school: school,

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature 'Creating a vacancy' do
     let!(:leaderships) { create_list(:leadership, 3) }
     let(:vacancy) do
       VacancyPresenter.new(build(:vacancy, :complete,
+                                 job_role: ['Teacher', 'SEN specialist'],
                                  school: school,
                                  subject: subjects[0],
                                  first_supporting_subject: subjects[1],
@@ -51,20 +52,16 @@ RSpec.feature 'Creating a vacancy' do
 
         click_on 'Save and continue'
 
+        mandatory_fields = %w[job_title job_role job_description working_patterns]
+
         within('.govuk-error-summary') do
-          expect(page).to have_content(I18n.t('errors.title', count: 3))
+          expect(page).to have_content(I18n.t('errors.title', count: mandatory_fields.size))
         end
 
-        within_row_for(text: I18n.t('jobs.job_title')) do
-          expect(page).to have_content((I18n.t('activerecord.errors.models.vacancy.attributes.job_title.blank')))
-        end
-
-        within_row_for(text: I18n.t('jobs.description')) do
-          expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.job_description.blank'))
-        end
-
-        within_row_for(text: I18n.t('jobs.working_patterns')) do
-          expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.working_patterns.blank'))
+        mandatory_fields.each do |field|
+          within_row_for(text: I18n.t("jobs.#{field}")) do
+            expect(page).to have_content((I18n.t("activerecord.errors.models.vacancy.attributes.#{field}.blank")))
+          end
         end
       end
 

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -157,7 +157,6 @@ RSpec.describe JobSpecificationForm, type: :model do
 
   context 'when all attributes are valid' do
     let(:main_subject) { create(:subject) }
-    let(:leadership) { create(:leadership) }
 
     it 'a JobSpecificationForm can be converted to a vacancy' do
       job_specification_form = JobSpecificationForm.new(job_title: 'English Teacher',
@@ -165,15 +164,14 @@ RSpec.describe JobSpecificationForm, type: :model do
                                                         job_role: [I18n.t('jobs.job_role_options.teacher')],
                                                         working_patterns: ['full_time'],
                                                         subject_id: main_subject.id,
-                                                        leadership_id: leadership.id,
                                                         newly_qualified_teacher: true)
 
       expect(job_specification_form.valid?).to be true
       expect(job_specification_form.vacancy.job_title).to eq('English Teacher')
+      expect(job_specification_form.vacancy.job_role).to eq(I18n.t('jobs.job_role_options.teacher'))
       expect(job_specification_form.vacancy.job_description).to eq('description')
       expect(job_specification_form.vacancy.working_patterns).to eq(['full_time'])
       expect(job_specification_form.vacancy.subject.name).to eq(main_subject.name)
-      expect(job_specification_form.vacancy.leadership.title).to eq(leadership.title)
       expect(job_specification_form.vacancy.newly_qualified_teacher).to eq(true)
     end
   end

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe JobSpecificationForm, type: :model do
 
       expect(job_specification_form.valid?).to be true
       expect(job_specification_form.vacancy.job_title).to eq('English Teacher')
-      expect(job_specification_form.vacancy.job_role).to eq(I18n.t('jobs.job_role_options.teacher'))
+      expect(job_specification_form.vacancy.job_role).to include(I18n.t('jobs.job_role_options.teacher'))
       expect(job_specification_form.vacancy.job_description).to eq('description')
       expect(job_specification_form.vacancy.working_patterns).to eq(['full_time'])
       expect(job_specification_form.vacancy.subject.name).to eq(main_subject.name)

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -161,14 +161,14 @@ RSpec.describe JobSpecificationForm, type: :model do
     it 'a JobSpecificationForm can be converted to a vacancy' do
       job_specification_form = JobSpecificationForm.new(job_title: 'English Teacher',
                                                         job_description: 'description',
-                                                        job_role: [I18n.t('jobs.job_role_options.teacher')],
+                                                        job_roles: [I18n.t('jobs.job_role_options.teacher')],
                                                         working_patterns: ['full_time'],
                                                         subject_id: main_subject.id,
                                                         newly_qualified_teacher: true)
 
       expect(job_specification_form.valid?).to be true
       expect(job_specification_form.vacancy.job_title).to eq('English Teacher')
-      expect(job_specification_form.vacancy.job_role).to include(I18n.t('jobs.job_role_options.teacher'))
+      expect(job_specification_form.vacancy.job_roles).to include(I18n.t('jobs.job_role_options.teacher'))
       expect(job_specification_form.vacancy.job_description).to eq('description')
       expect(job_specification_form.vacancy.working_patterns).to eq(['full_time'])
       expect(job_specification_form.vacancy.subject.name).to eq(main_subject.name)

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe JobSpecificationForm, type: :model do
     it 'a JobSpecificationForm can be converted to a vacancy' do
       job_specification_form = JobSpecificationForm.new(job_title: 'English Teacher',
                                                         job_description: 'description',
+                                                        job_role: [I18n.t('jobs.job_role_options.teacher')],
                                                         working_patterns: ['full_time'],
                                                         subject_id: main_subject.id,
                                                         leadership_id: leadership.id,

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -75,11 +75,16 @@ RSpec.describe VacanciesHelper, type: :helper do
   end
 
   describe '#new_sections' do
-    let(:vacancy) { double('vacancy') }
+    let(:vacancy) { double('vacancy').as_null_object }
 
     it 'should include supporting_documents for legacy listings' do
       allow(vacancy).to receive(:supporting_documents).and_return(nil)
       expect(helper.new_sections(vacancy)).to include('supporting_documents')
+    end
+
+    it 'should include job_role for legacy listings' do
+      allow(vacancy).to receive_message_chain(:job_role, :any?).and_return(false)
+      expect(helper.new_sections(vacancy)).to include('job_role')
     end
   end
 end

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe VacanciesHelper, type: :helper do
     end
 
     it 'should include job_role for legacy listings' do
-      allow(vacancy).to receive_message_chain(:job_role, :any?).and_return(false)
+      allow(vacancy).to receive_message_chain(:job_roles, :any?).and_return(false)
       expect(helper.new_sections(vacancy)).to include('job_role')
     end
   end

--- a/spec/lib/job_posting_spec.rb
+++ b/spec/lib/job_posting_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe JobPosting do
       '@type' => 'JobPosting',
       'title' => 'Teacher of English',
       'jobRoles' => [I18n.t('jobs.job_role_options.nqt_suitable'), I18n.t('jobs.job_role_options.sen_specialist')],
-      'salary' => 'Lots of money',
+      'salary' => 'Pay scale 1 to Pay scale 2',
       'jobBenefits' => '<p>This is an exceptional opportunity to make a difference within a positive environment.</p>',
       'datePosted' => date_posted,
       'description' => '<p>We are seeking an inspirational, dynamic and industrious Teacher of English</p>',

--- a/spec/lib/job_posting_spec.rb
+++ b/spec/lib/job_posting_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe JobPosting do
     {
       '@type' => 'JobPosting',
       'title' => 'Teacher of English',
-      'jobRole' => [I18n.t('jobs.job_role_options.nqt_suitable'), I18n.t('jobs.job_role_options.sen_specialist')],
+      'jobRoles' => [I18n.t('jobs.job_role_options.nqt_suitable'), I18n.t('jobs.job_role_options.sen_specialist')],
       'salary' => 'Lots of money',
       'jobBenefits' => '<p>This is an exceptional opportunity to make a difference within a positive environment.</p>',
       'datePosted' => date_posted,

--- a/spec/lib/job_posting_spec.rb
+++ b/spec/lib/job_posting_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe JobPosting do
     {
       '@type' => 'JobPosting',
       'title' => 'Teacher of English',
+      'jobRole' => [I18n.t('jobs.job_role_options.nqt_suitable'), I18n.t('jobs.job_role_options.sen_specialist')],
       'salary' => 'Lots of money',
       'jobBenefits' => '<p>This is an exceptional opportunity to make a difference within a positive environment.</p>',
       'datePosted' => date_posted,

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Vacancy, type: :model do
   describe 'validations' do
     context 'a new record' do
       it { should validate_presence_of(:job_title) }
-      it { should validate_presence_of(:job_role) }
+      it { should validate_presence_of(:job_roles) }
       it { should validate_presence_of(:job_description) }
       it { should validate_presence_of(:working_patterns) }
       it { should validate_presence_of(:salary) }

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Vacancy, type: :model do
   describe 'validations' do
     context 'a new record' do
       it { should validate_presence_of(:job_title) }
+      it { should validate_presence_of(:job_role) }
       it { should validate_presence_of(:job_description) }
       it { should validate_presence_of(:working_patterns) }
       it { should validate_presence_of(:salary) }

--- a/spec/smoke_test/job_seekers_can_view_homepage_spec.rb
+++ b/spec/smoke_test/job_seekers_can_view_homepage_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Page availability', js: true, smoke_test: true do
       vacancy_page = page.first('.view-vacancy-link')
       unless vacancy_page.nil?
         vacancy_page.click
-        expect(page).to have_content(I18n.t('jobs.description'))
+        expect(page).to have_content(I18n.t('jobs.job_description'))
         expect(page.current_url).to include('https://teaching-vacancies.service.gov.uk/jobs/')
       end
     end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -20,9 +20,9 @@ module VacancyHelpers
             visible: false
     end
 
-    vacancy.job_role.each do |job_role|
+    vacancy.job_roles.each do |job_role|
       check job_role,
-            name: 'job_specification_form[job_role][]',
+            name: 'job_specification_form[job_roles][]',
             visible: false
     end
   end
@@ -90,7 +90,7 @@ module VacancyHelpers
 
   def verify_all_vacancy_details(vacancy)
     expect(page).to have_content(vacancy.job_title)
-    expect(page).to have_content(vacancy.show_job_role)
+    expect(page).to have_content(vacancy.show_job_roles)
     expect(page.html).to include(vacancy.job_description)
     expect(page).to have_content(vacancy.subject.name)
     expect(page).to have_content(vacancy.other_subjects)

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -2,15 +2,17 @@ module VacancyHelpers
   def fill_in_job_specification_form_fields(vacancy)
     fill_in 'job_specification_form[job_title]', with: vacancy.job_title
     fill_in 'job_specification_form[job_description]', with: vacancy.job_description
-    select vacancy.subject.name, from: 'job_specification_form[subject_id]'
-    select vacancy.first_supporting_subject, from: 'job_specification_form[first_supporting_subject_id]'
-    select vacancy.second_supporting_subject, from: 'job_specification_form[second_supporting_subject_id]'
-    fill_in 'job_specification_form[starts_on_dd]', with: vacancy.starts_on.day
-    fill_in 'job_specification_form[starts_on_mm]', with: vacancy.starts_on.strftime('%m')
-    fill_in 'job_specification_form[starts_on_yyyy]', with: vacancy.starts_on.year
-    fill_in 'job_specification_form[ends_on_dd]', with: vacancy.ends_on.day
-    fill_in 'job_specification_form[ends_on_mm]', with: vacancy.ends_on.strftime('%m')
-    fill_in 'job_specification_form[ends_on_yyyy]', with: vacancy.ends_on.year
+    select vacancy.subject.name, from: 'job_specification_form[subject_id]' if vacancy.subject
+    select vacancy.first_supporting_subject,
+      from: 'job_specification_form[first_supporting_subject_id]' if vacancy.first_supporting_subject
+    select vacancy.second_supporting_subject,
+      from: 'job_specification_form[second_supporting_subject_id]' if vacancy.second_supporting_subject
+    fill_in 'job_specification_form[starts_on_dd]', with: vacancy.starts_on.day if vacancy.starts_on
+    fill_in 'job_specification_form[starts_on_mm]', with: vacancy.starts_on.strftime('%m') if vacancy.starts_on
+    fill_in 'job_specification_form[starts_on_yyyy]', with: vacancy.starts_on.year if vacancy.starts_on
+    fill_in 'job_specification_form[ends_on_dd]', with: vacancy.ends_on.day if vacancy.ends_on
+    fill_in 'job_specification_form[ends_on_mm]', with: vacancy.ends_on.strftime('%m') if vacancy.ends_on
+    fill_in 'job_specification_form[ends_on_yyyy]', with: vacancy.ends_on.year if vacancy.ends_on
 
     vacancy.model_working_patterns.each do |working_pattern|
       check Vacancy.human_attribute_name("working_patterns.#{working_pattern}"),
@@ -18,7 +20,7 @@ module VacancyHelpers
             visible: false
     end
 
-    vacancy.model_job_role.each do |job_role|
+    vacancy.job_role.each do |job_role|
       check job_role,
             name: 'job_specification_form[job_role][]',
             visible: false
@@ -88,11 +90,11 @@ module VacancyHelpers
 
   def verify_all_vacancy_details(vacancy)
     expect(page).to have_content(vacancy.job_title)
+    expect(page).to have_content(vacancy.job_role.join(', '))
     expect(page.html).to include(vacancy.job_description)
     expect(page).to have_content(vacancy.subject.name)
     expect(page).to have_content(vacancy.other_subjects)
     expect(page).to have_content(vacancy.working_patterns)
-    expect(page).to have_content(vacancy.newly_qualified_teacher)
     expect(page).to have_content(vacancy.starts_on) if vacancy.starts_on?
     expect(page).to have_content(vacancy.ends_on) if vacancy.ends_on?
 
@@ -100,8 +102,6 @@ module VacancyHelpers
     expect(page.html).to include(vacancy.benefits)
 
     expect(page).to have_content(I18n.t('jobs.supporting_documents'))
-
-    expect(page).to have_content(vacancy.leadership.title)
 
     expect(page).to have_content(vacancy.contact_email)
     expect(page).to have_content(vacancy.application_link)

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -90,7 +90,7 @@ module VacancyHelpers
 
   def verify_all_vacancy_details(vacancy)
     expect(page).to have_content(vacancy.job_title)
-    expect(page).to have_content(vacancy.job_role.join(', '))
+    expect(page).to have_content(vacancy.show_job_role)
     expect(page.html).to include(vacancy.job_description)
     expect(page).to have_content(vacancy.subject.name)
     expect(page).to have_content(vacancy.other_subjects)

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -5,8 +5,6 @@ module VacancyHelpers
     select vacancy.subject.name, from: 'job_specification_form[subject_id]'
     select vacancy.first_supporting_subject, from: 'job_specification_form[first_supporting_subject_id]'
     select vacancy.second_supporting_subject, from: 'job_specification_form[second_supporting_subject_id]'
-    select vacancy.leadership.title, from: 'job_specification_form[leadership_id]'
-    check 'job_specification_form[newly_qualified_teacher]', visible: false if vacancy.newly_qualified_teacher
     fill_in 'job_specification_form[starts_on_dd]', with: vacancy.starts_on.day
     fill_in 'job_specification_form[starts_on_mm]', with: vacancy.starts_on.strftime('%m')
     fill_in 'job_specification_form[starts_on_yyyy]', with: vacancy.starts_on.year
@@ -17,6 +15,12 @@ module VacancyHelpers
     vacancy.model_working_patterns.each do |working_pattern|
       check Vacancy.human_attribute_name("working_patterns.#{working_pattern}"),
             name: 'job_specification_form[working_patterns][]',
+            visible: false
+    end
+
+    vacancy.model_job_role.each do |job_role|
+      check job_role,
+            name: 'job_specification_form[job_role][]',
             visible: false
     end
   end


### PR DESCRIPTION
This PR adds the new job role field to the hiring staff journey.

## In this PR
- Add job role string array
- Add NQT to job role for vacancies where NQT true
- When NQT selected in job role, set NQT boolean to true
- When NQT not selected in job role, set NQT boolean to false
- Don't change search
- Don't drop NQT column yet

## Jira ticket URL
[TEVA-534](https://dfedigital.atlassian.net/browse/TEVA-534)

## Next steps
- Update jobseeker view to display job role info
- Remove leadership from code and database
- Update search to filter roles based on NQT being a job role
