### PR TITLE
Update govuk header container colour across site.

### DIFF
--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -98,3 +98,7 @@ p {
     display: none;
   }
 }
+
+.govuk-header__container {
+  border-bottom: 10px solid govuk-colour("orange");
+}

--- a/app/frontend/styles/components/hiring-staff.scss
+++ b/app/frontend/styles/components/hiring-staff.scss
@@ -9,10 +9,6 @@ body.hiring-staff {
     }
   }
 
-  .govuk-header__container {
-    border-bottom: 10px solid govuk-colour("yellow");
-  }
-
   &.vacancies_index,
   &.vacancies_show {
     .govuk-main-wrapper {


### PR DESCRIPTION
Service colour band within heading to be changed to match marketing material “orange”.

Inconsistent width broken out into separate ticket.

## Jira ticket URL:

https://dfedigital.atlassian.net/secure/RapidBoard.jspa?rapidView=21&projectKey=TEVA&modal=detail&selectedIssue=TEVA-592

## Changes in this PR:

Colour change of govuk header container.

## Screenshots of UI changes:

### Before

<img width="1179" alt="Screenshot 2020-03-27 at 09 32 12" src="https://user-images.githubusercontent.com/60350599/77742172-f2e1ee00-700d-11ea-842c-939e204ff556.png">

### After

<img width="1179" alt="Screenshot 2020-03-27 at 09 33 03" src="https://user-images.githubusercontent.com/60350599/77742213-07be8180-700e-11ea-9186-f9f884d6a350.png">

<img width="1350" alt="Screenshot 2020-03-27 at 11 41 16" src="https://user-images.githubusercontent.com/60350599/77752793-23cb1e80-7020-11ea-951c-a7b48ff72536.png">

## Next steps:

- [x] Reviewed by design
