### PR TITLE
Teva 629 bigquery stopping

### DIFF
--- a/db/migrate/20200327125528_drop_pay_scales.rb
+++ b/db/migrate/20200327125528_drop_pay_scales.rb
@@ -1,0 +1,5 @@
+class DropPayScales < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :pay_scales
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_25_121727) do
+ActiveRecord::Schema.define(version: 2020_03_27_125528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -95,13 +95,6 @@ ActiveRecord::Schema.define(version: 2020_03_25_121727) do
   create_table "leaderships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.index ["title"], name: "index_leaderships_on_title", unique: true
-  end
-
-  create_table "pay_scales", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "label", null: false
-    t.string "code"
-    t.integer "index"
-    t.index ["label"], name: "index_pay_scales_on_label", unique: true
   end
 
   create_table "regions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -224,9 +217,9 @@ ActiveRecord::Schema.define(version: 2020_03_25_121727) do
     t.integer "total_get_more_info_clicks"
     t.datetime "total_get_more_info_clicks_updated_at"
     t.integer "working_patterns", array: true
-    t.boolean "pro_rata_salary"
     t.integer "listed_elsewhere"
     t.integer "hired_status"
+    t.boolean "pro_rata_salary"
     t.datetime "stats_updated_at"
     t.uuid "publisher_user_id"
     t.datetime "expiry_time"

--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -69,6 +69,13 @@ class ExportTablesToBigQuery
     Rails.logger.info({ bigquery_export: 'started' }.to_json)
     tables.each do |table|
       bigquery_load(table.constantize)
+    rescue NameError => e
+      # This is to address an edge-case failure when a table, `PayScale`, didn't get dropped from the production db
+      # but its model has been removed from the codebase.
+      #
+      # The `PayScale` table should be removed in a later release, but this rescue will prevent any future oversights
+      # of this nature from breaking the run.
+      Rails.logger.error({ bigquery_export: 'error', status: 'handled', message: e })
     end
     Rails.logger.info({ bigquery_export: 'finished' }.to_json)
   end


### PR DESCRIPTION
This removes the cause of the failure and puts measures in place to keep this type of error from breaking the run again. 