### PR TITLE
Add conditional display logic for 'About school'

### DIFF
--- a/app/views/vacancies/_school_overview_section.html.haml
+++ b/app/views/vacancies/_school_overview_section.html.haml
@@ -44,10 +44,11 @@
           %td.govuk-table__cell
             = mail_to @vacancy.contact_email, @vacancy.contact_email, class: 'govuk-link link-wrap', subject: t('jobs.contact_email_subject', job: @vacancy.job_title), body: t('jobs.contact_email_body', url: url_for(only_path: false))
   
-  %h4.govuk-heading-s
-    = t('schools.about')
-    = @vacancy.school.name
-  %p= @vacancy.school.description
+  - if @vacancy.school.description.present?
+    %h4.govuk-heading-s
+      = t('schools.about')
+      = @vacancy.school.name
+    %p= @vacancy.school.description
 
   %h4.govuk-heading-s
     = t('schools.school_location')

--- a/app/views/vacancies/_school_overview_section.html.haml
+++ b/app/views/vacancies/_school_overview_section.html.haml
@@ -46,8 +46,7 @@
   
   - if @vacancy.school.description.present?
     %h4.govuk-heading-s
-      = t('schools.about')
-      = @vacancy.school.name
+      = t('schools.info', school: @vacancy.school.name)
     %p= @vacancy.school.description
 
   %h4.govuk-heading-s

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -384,7 +384,6 @@ en:
     user_interested_email_text: "We'll only use this to tell you about opportunities to take part in user research that helps us improve Department for Education services."
   schools:
     school_overview: 'School overview'
-    about: 'About'
     address: 'Address'
     school_location: 'School location'
     phase: 'Education phase'


### PR DESCRIPTION
We only want to display the 'About school' section if there is
information to display.

This section is now hidden if the description field is nil or an empty string.

## Jira ticket URL:

https://dfedigital.atlassian.net/browse/TEVA-597?atlOrigin=eyJpIjoiNzcxMzI4ZDY4NzJjNDAwZTg3NDgxNThjYWRjNDU1YTYiLCJwIjoiaiJ9

## Screenshots of UI changes:

### Before

<img width="689" alt="Screenshot 2020-03-30 at 17 30 38" src="https://user-images.githubusercontent.com/60350599/77937407-35285b00-72ac-11ea-94b8-483fbbecc763.png">

### After

<img width="689" alt="Screenshot 2020-03-30 at 17 32 30" src="https://user-images.githubusercontent.com/60350599/77937602-79b3f680-72ac-11ea-804d-aa712f8b9e07.png">

## Next steps:

- [x] To be reviewed by product on staging
