### PR TITLE
Completed step on db

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -2,6 +2,8 @@ require 'auditor'
 require 'indexing'
 
 class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseController
+  before_action :set_vacancy
+
   def school_id
     params.permit![:school_id]
   end
@@ -15,7 +17,11 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
   end
 
   def set_vacancy
-    @vacancy = params[:job_id] ? current_school.vacancies.find(params[:job_id]) : nil
+    if params[:job_id]
+      @vacancy = current_school.vacancies.find(params[:job_id])
+    elsif session_vacancy_id
+      @vacancy = current_school.vacancies.find(session_vacancy_id)
+    end
   end
 
   def current_step

--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -1,5 +1,5 @@
 class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacancies::ApplicationController
-  before_action :redirect_unless_vacancy_session_id, only: %i[new create]
+  before_action :redirect_unless_vacancy
 
   def new
     @application_details_form = ApplicationDetailsForm.new(session[:vacancy_attributes].with_indifferent_access)

--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -3,7 +3,7 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
 
   def new
     @application_details_form = ApplicationDetailsForm.new(session[:vacancy_attributes].with_indifferent_access)
-    @application_details_form.valid? if %i[step_3 review].include?(session[:current_step])
+    @application_details_form.valid? if %i[step_4 review].include?(session[:current_step])
   end
 
   def create
@@ -15,7 +15,7 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
       vacancy = update_vacancy(@application_details_form.params_to_save)
       redirect_to next_step(vacancy)
     else
-      session[:current_step] = :step_3 unless session[:current_step].eql?(:review)
+      session[:current_step] = :step_4 unless session[:current_step].eql?(:review)
       redirect_to application_details_school_job_path(anchor: 'errors')
     end
   end
@@ -49,10 +49,11 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
   private
 
   def application_details_form_params
-    params.require(:application_details_form).permit(:application_link, :contact_email, :expiry_time,
-                                                     :expires_on_dd, :expires_on_mm, :expires_on_yyyy,
-                                                     :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
-                                                     :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem)
+    params.require(:application_details_form)
+          .permit(:application_link, :contact_email, :expiry_time,
+                  :expires_on_dd, :expires_on_mm, :expires_on_yyyy,
+                  :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
+                  :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem).merge(completed_step: current_step)
   end
 
   def next_step(vacancy)

--- a/app/controllers/hiring_staff/vacancies/documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/documents_controller.rb
@@ -3,8 +3,6 @@ require 'google/apis/drive_v3'
 class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::ApplicationController
   FILE_SIZE_LIMIT = 10.megabytes
 
-  before_action :set_vacancy
-
   before_action :redirect_unless_vacancy
   before_action :redirect_unless_supporting_documents
   before_action :redirect_to_next_step_if_save_and_continue, only: %i[create]

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -14,7 +14,6 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
     if @job_specification_form.valid?
       vacancy = session_vacancy_id ? update_vacancy(job_specification_form_params) : save_vacancy_without_validation
       store_vacancy_attributes(@job_specification_form.vacancy.attributes)
-      session[:completed_step] = current_step
       redirect_to_next_step(vacancy)
     else
       session[:current_step] = :step_1 if session[:current_step].blank?
@@ -56,7 +55,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
                                                    :starts_on_yyyy, :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
                                                    :flexible_working, :newly_qualified_teacher,
                                                    :first_supporting_subject_id, :second_supporting_subject_id,
-                                                   working_patterns: [])
+                                                   working_patterns: []).merge(completed_step: current_step)
   end
 
   def save_vacancy_without_validation

--- a/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
@@ -1,5 +1,4 @@
 class HiringStaff::Vacancies::PayPackageController < HiringStaff::Vacancies::ApplicationController
-  before_action :set_vacancy
   before_action :redirect_unless_vacancy
 
   def show

--- a/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
@@ -9,7 +9,6 @@ class HiringStaff::Vacancies::PayPackageController < HiringStaff::Vacancies::App
     @pay_package_form = PayPackageForm.new(pay_package_form_params)
 
     if @pay_package_form.valid?
-      session[:completed_step] = current_step
       update_vacancy(pay_package_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
       return redirect_to_next_step_if_save_and_continue
@@ -21,7 +20,7 @@ class HiringStaff::Vacancies::PayPackageController < HiringStaff::Vacancies::App
   private
 
   def pay_package_form_params
-    (params[:pay_package_form] || params).permit(:salary, :benefits)
+    (params[:pay_package_form] || params).permit(:salary, :benefits).merge(completed_step: current_step)
   end
 
   def next_step

--- a/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
@@ -1,7 +1,5 @@
 class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacancies::ApplicationController
-  before_action :set_vacancy
-
-  before_action :redirect_unless_vacancy, only: %i[new create]
+  before_action :redirect_unless_vacancy
 
   def new
     @supporting_documents_form = SupportingDocumentsForm.new(session[:vacancy_attributes])

--- a/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
@@ -12,7 +12,7 @@ class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacan
 
     if @supporting_documents_form.valid?
       update_vacancy(supporting_documents_form_params, @vacancy)
-      return redirect_to_next_step(@vacancy)
+      return redirect_to next_step
     end
 
     session[:current_step] = :step_3_intro unless session[:current_step].eql?(:review)

--- a/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
@@ -11,9 +11,8 @@ class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacan
     store_vacancy_attributes(@supporting_documents_form.vacancy.attributes)
 
     if @supporting_documents_form.valid?
-      session[:completed_step] = current_step
-      vacancy = update_vacancy(supporting_documents_form_params)
-      return redirect_to_next_step(vacancy)
+      update_vacancy(supporting_documents_form_params, @vacancy)
+      return redirect_to_next_step(@vacancy)
     end
 
     session[:current_step] = :step_3_intro unless session[:current_step].eql?(:review)
@@ -23,7 +22,7 @@ class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacan
   private
 
   def supporting_documents_form_params
-    (params[:supporting_documents_form] || params).permit(:supporting_documents)
+    (params[:supporting_documents_form] || params).permit(:supporting_documents).merge(completed_step: current_step)
   end
 
   def next_step

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -1,5 +1,6 @@
 class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationController
   before_action :set_vacancy, only: %i[review]
+  before_action :set_completed_step, only: %i[review]
 
   def show
     vacancy = find_active_vacancy_by_id
@@ -88,8 +89,8 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
     session[:current_step] = ''
   end
 
-  def set_vacancy
-    @vacancy = current_school.vacancies.active.find(vacancy_id)
+  def set_completed_step
+    @vacancy.update(completed_step: current_step)
   end
 
   def find_active_vacancy_by_id

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -1,6 +1,5 @@
 class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationController
   before_action :set_vacancy, only: %i[review]
-  before_action :set_completed_step, only: %i[review]
 
   def show
     vacancy = find_active_vacancy_by_id
@@ -31,6 +30,8 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
 
     unless @vacancy.valid?
       redirect_to_incomplete_step
+    else
+      set_completed_step
     end
 
     session[:current_step] = :review
@@ -69,6 +70,12 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
     valid
   end
 
+  def step_3_valid?
+    valid = SupportingDocumentsForm.new(@vacancy.attributes).valid?
+    clear_cache_and_step unless valid
+    valid
+  end
+
   def step_4_valid?
     valid = ApplicationDetailsForm.new(@vacancy.attributes).completed?
     clear_cache_and_step unless valid
@@ -77,6 +84,7 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
 
   def redirect_to_incomplete_step
     return redirect_to school_job_pay_package_path(@vacancy.id) unless step_2_valid?
+    return redirect_to supporting_documents_school_job_path unless step_3_valid?
     return redirect_to application_details_school_job_path unless step_4_valid?
   end
 

--- a/app/helpers/hiring_staff/job_creation_helper.rb
+++ b/app/helpers/hiring_staff/job_creation_helper.rb
@@ -19,10 +19,12 @@ module HiringStaff::JobCreationHelper
     return 'app-step-nav__step--active' if current_step == step_number
   end
 
-  def set_visited_step_class(step_number)
-    completed_step = session[:completed_step] ? session[:completed_step] : 0
+  def set_visited_step_class(step_number, vacancy)
+    completed_step = 0
+    if vacancy.present?
+      completed_step = vacancy.completed_step.presence || 0
+    end
     return 'app-step-nav__step--visited' if
-      current_step != step_number &&
-      (current_step > step_number || step_number <= completed_step)
+      step_number != current_step && step_number <= completed_step
   end
 end

--- a/app/views/hiring_staff/vacancies/_sidebar.html.erb
+++ b/app/views/hiring_staff/vacancies/_sidebar.html.erb
@@ -10,7 +10,7 @@
     <% @steps_to_display.each do |step| -%>
       <li class="app-step-nav__step js-step
       <%= set_active_step_class(step[:number]) -%>
-      <%= set_visited_step_class(step[:number]) -%>"
+      <%= set_visited_step_class(step[:number], @vacancy) -%>"
           aria-current="step"
           data-show=""
           >

--- a/db/migrate/20200401125329_add_completed_step_to_vacancies.rb
+++ b/db/migrate/20200401125329_add_completed_step_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddCompletedStepToVacancies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :vacancies, :completed_step, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_27_125528) do
+ActiveRecord::Schema.define(version: 2020_04_01_125329) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -225,6 +225,7 @@ ActiveRecord::Schema.define(version: 2020_03_27_125528) do
     t.datetime "expiry_time"
     t.string "supporting_documents"
     t.string "salary"
+    t.integer "completed_step"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["expiry_time"], name: "index_vacancies_on_expiry_time"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"

--- a/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
@@ -1,57 +1,124 @@
 require 'rails_helper'
 RSpec.feature 'Hiring staff can edit a draft vacancy' do
   let(:school) { create(:school) }
+  let!(:vacancy) do
+    VacancyPresenter.new(build(:vacancy, :complete,
+                               job_title: 'Draft vacancy',
+                               school: school,
+                               working_patterns: ['full_time', 'part_time']))
+  end
+  let(:draft_vacancy) { Vacancy.find_by(job_title: vacancy.job_title) }
 
   before do
     stub_hiring_staff_auth(urn: school.urn)
+    visit new_school_job_path
+    fill_in_job_specification_form_fields(vacancy)
+    click_on I18n.t('buttons.save_and_continue')
   end
 
-  context 'with job specification completed' do
-    let!(:vacancy) do
-      VacancyPresenter.new(build(:vacancy, :complete,
-                                 job_title: 'Draft vacancy',
-                                 school: school,
-                                 working_patterns: ['full_time', 'part_time']))
-    end
-    let(:draft_vacancy) { Vacancy.find_by(job_title: vacancy.job_title) }
-
-    before do
-      visit new_school_job_path
-      fill_in_job_specification_form_fields(vacancy)
-      click_on I18n.t('buttons.save_and_continue')
-    end
-
-    scenario 'redirects to incomplete pay package step, with fields pre-populated' do
-      draft_vacancy.benefits = 'Lots of benefits'
-      draft_vacancy.save(validate: false)
-
+  context '#redirects_to' do
+    scenario 'incomplete pay package step' do
       visit edit_school_job_path(id: draft_vacancy.id)
 
       expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 5))
-      expect(page).to have_content(draft_vacancy.benefits)
+      expect(page).to have_content(I18n.t('jobs.pay_package'))
     end
 
-    context 'when editing a different vacancy' do
-      # We use the session to store vacancy attributes, make sure it doesn't leak between edits.
-      before do
-        edit_a_published_vacancy
-      end
+    scenario 'incomplete supporting documents step' do
+      visit edit_school_job_path(id: draft_vacancy.id)
 
-      scenario 'then editing the draft redirects to incomplete step' do
-        visit school_job_path(id: draft_vacancy.id)
-        expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 5))
-      end
+      draft_vacancy.salary = 'Pay scale 1 to Pay scale 2'
+      draft_vacancy.benefits = 'Gym, health insurance'
 
-      def edit_a_published_vacancy
-        published_vacancy = create(:vacancy, :published, school: school)
-        visit edit_school_job_path(published_vacancy.id)
-        click_link_in_container_with_text(I18n.t('jobs.application_link'))
+      fill_in_pay_package_form_fields(draft_vacancy)
+      click_on I18n.t('buttons.save_and_continue')
 
-        fill_in 'application_details_form[application_link]', with: 'https://example.com'
-        click_on I18n.t('buttons.update_job')
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 5))
+      expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+    end
 
-        expect(page).to have_content(I18n.t('messages.jobs.updated'))
-      end
+    scenario 'documents step if YES selected for supporting documents' do
+      visit edit_school_job_path(id: draft_vacancy.id)
+
+      draft_vacancy.salary = 'Pay scale 1 to Pay scale 2'
+      draft_vacancy.benefits = 'Gym, health insurance'
+
+      fill_in_pay_package_form_fields(draft_vacancy)
+      click_on I18n.t('buttons.save_and_continue')
+
+      find('label[for="supporting-documents-form-supporting-documents-field-error"]').click
+      click_on I18n.t('buttons.save_and_continue')
+
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 5))
+      expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+    end
+
+    scenario 'application details step if NO selected for supporting documents' do
+      visit edit_school_job_path(id: draft_vacancy.id)
+
+      draft_vacancy.salary = 'Pay scale 1 to Pay scale 2'
+      draft_vacancy.benefits = 'Gym, health insurance'
+
+      fill_in_pay_package_form_fields(draft_vacancy)
+      click_on I18n.t('buttons.save_and_continue')
+
+      select_no_for_supporting_documents
+      click_on I18n.t('buttons.save_and_continue')
+
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+      expect(page).to have_content(I18n.t('jobs.application_details'))
+    end
+
+    scenario 'incomplete application details step' do
+      visit edit_school_job_path(id: draft_vacancy.id)
+
+      draft_vacancy.salary = 'Pay scale 1 to Pay scale 2'
+      draft_vacancy.benefits = 'Gym, health insurance'
+
+      fill_in_pay_package_form_fields(draft_vacancy)
+      click_on I18n.t('buttons.save_and_continue')
+
+      find('label[for="supporting-documents-form-supporting-documents-field-error"]').click
+      click_on I18n.t('buttons.save_and_continue')
+
+      click_on I18n.t('buttons.save_and_continue')
+
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+      expect(page).to have_content(I18n.t('jobs.application_details'))
+    end
+  end
+
+  context 'after editing a different vacancy' do
+    # We use the session to store vacancy attributes, make sure it doesn't leak between edits.
+    before do
+      visit edit_school_job_path(id: draft_vacancy.id)
+
+      draft_vacancy.salary = 'Pay scale 1 to Pay scale 2'
+      draft_vacancy.benefits = 'Gym, health insurance'
+
+      fill_in_pay_package_form_fields(draft_vacancy)
+      click_on I18n.t('buttons.save_and_continue')
+
+      select_no_for_supporting_documents
+      click_on I18n.t('buttons.save_and_continue')
+
+      edit_a_published_vacancy
+    end
+
+    scenario 'then editing the draft redirects to incomplete step' do
+      visit school_job_path(id: draft_vacancy.id)
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+    end
+
+    def edit_a_published_vacancy
+      published_vacancy = create(:vacancy, :published, school: school)
+      visit edit_school_job_path(published_vacancy.id)
+      click_link_in_container_with_text(I18n.t('jobs.application_link'))
+
+      fill_in 'application_details_form[application_link]', with: 'https://example.com'
+      click_on I18n.t('buttons.update_job')
+
+      expect(page).to have_content(I18n.t('messages.jobs.updated'))
     end
   end
 end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -633,7 +633,7 @@ RSpec.feature 'Creating a vacancy' do
 
           activity = vacancy.activities.last
           expect(activity.session_id).to eq(session_id)
-          expect(activity.parameters.symbolize_keys).to eq(contact_email: [contact_email, 'an@email.com'])
+          expect(activity.parameters.symbolize_keys).to include(contact_email: [contact_email, 'an@email.com'])
         end
       end
 

--- a/spec/helpers/hiring_staff/job_creation_helper_spec.rb
+++ b/spec/helpers/hiring_staff/job_creation_helper_spec.rb
@@ -136,6 +136,8 @@ RSpec.describe HiringStaff::JobCreationHelper do
   end
 
   describe '#set_visited_step_class' do
+    let(:vacancy) { instance_double('Vacancy') }
+
     context 'when subsequent steps have been completed' do
       around do |example|
         # Rubocop mistakes the verb-based route definitions for the identically named commands used to interact with
@@ -155,12 +157,13 @@ RSpec.describe HiringStaff::JobCreationHelper do
 
       it 'returns the visited class for step 1, active class for step 2, visited class for step 3' do
         allow(params).to receive(:[]).with(:create_step).and_return(2)
-        allow(session).to receive(:[]).with(:completed_step).and_return(3)
+        allow(vacancy).to receive_message_chain(:completed_step, :present?).and_return(true)
+        allow(vacancy).to receive(:completed_step).and_return(3)
 
-        expect(helper.set_visited_step_class(1)).to eql('app-step-nav__step--visited')
+        expect(helper.set_visited_step_class(1, vacancy)).to eql('app-step-nav__step--visited')
         expect(helper.set_active_step_class(2)).to eql('app-step-nav__step--active')
-        expect(helper.set_visited_step_class(2)).to eql(nil)
-        expect(helper.set_visited_step_class(3)).to eql('app-step-nav__step--visited')
+        expect(helper.set_visited_step_class(2, vacancy)).to eql(nil)
+        expect(helper.set_visited_step_class(3, vacancy)).to eql('app-step-nav__step--visited')
       end
     end
   end


### PR DESCRIPTION
This PR addresses inconsistencies in the application of the visited class to the sidebar circles which are arising as a result of using the session to store the completed step.

**In this PR**
- Create a completed step field on the vacancy model as a more robust method of determining whether or not a section in the hiring staff journey has been completed

**Next steps** ([TEVA-647](https://dfedigital.atlassian.net/browse/TEVA-647))
- Only use session where strictly necessary
- Refactor job spec and application details forms to use GOVUKDesignSystemFormBuilder
- Implement simpler form logic
    - Currently edit/new/create/update and review/edit involves a lot of unnecessary complexity and duplication in the code
    - A vacancy has been created in the model as soon as the first section of the hiring staff journey has been completed (everything after this is an update of the vacancy)
    - See Pay Package section as an example

