### PR TITLE
Show job role to jobseeker

### DIFF
--- a/app/views/vacancies/_job_details_section.html.haml
+++ b/app/views/vacancies/_job_details_section.html.haml
@@ -3,6 +3,12 @@
     = t('jobs.job_details')
   %table.govuk-table{ ariadescribedby: "Job details" }
     %tbody.govuk-table__body
+      - if @vacancy.job_roles.any?
+        %tr.govuk-table__row
+          %th.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
+            = t('jobs.job_roles')
+          %td.govuk-table__cell
+            = @vacancy.show_job_roles
       - if @vacancy.any_subjects?
         %tr.govuk-table__row
           %th.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
@@ -24,18 +30,6 @@
           = t('jobs.salary')
         %td.govuk-table__cell
           = @vacancy.salary
-      - if @vacancy.newly_qualified_teacher?
-        %tr.govuk-table__row
-          %th.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
-            = t('jobs.newly_qualified_teacher')
-          %td.govuk-table__cell
-            = @vacancy.newly_qualified_teacher
-      - if @vacancy.leadership.present?
-        %tr.govuk-table__row
-          %th.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
-            = t('jobs.leadership_level')
-          %td.govuk-table__cell
-            = @vacancy.leadership.title
 
   %h4.govuk-heading-s= t('jobs.job_description')
   %p= @vacancy.job_description

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -111,11 +111,11 @@ module VacancyHelpers
 
   def verify_vacancy_show_page_details(vacancy)
     expect(page).to have_content(vacancy.job_title)
+    expect(page).to have_content(vacancy.show_job_roles)
     expect(page.html).to include(vacancy.job_description)
     expect(page).to have_content(vacancy.subject.name)
     expect(page).to have_content(vacancy.other_subjects)
     expect(page).to have_content(vacancy.working_patterns)
-    expect(page).to have_content(vacancy.newly_qualified_teacher)
     expect(page).to have_content(vacancy.starts_on) if vacancy.starts_on?
     expect(page).to have_content(vacancy.ends_on) if vacancy.ends_on?
 
@@ -131,8 +131,6 @@ module VacancyHelpers
       expect(page.html).to include(vacancy.qualifications)
       expect(page.html).to include(vacancy.experience)
     end
-
-    expect(page).to have_content(vacancy.leadership.title)
 
     expect(page).to have_link(I18n.t('jobs.apply'), href: new_job_interest_path(vacancy.id))
     expect(page).to have_content(vacancy.expires_on.to_s.strip)


### PR DESCRIPTION
## Jira ticket URL:
[TEVA-535](https://dfedigital.atlassian.net/browse/TEVA-535)
## Changes in this PR:
- Remove NQT and Leadership fields from the jobseeker view
- Add job role to the jobseeker view
## Screenshots of UI changes:
### Before
![image](https://user-images.githubusercontent.com/25187547/78245583-9f751180-74df-11ea-828e-fafc5b41eac5.png)

### After
![image](https://user-images.githubusercontent.com/25187547/78245531-879d8d80-74df-11ea-845f-15e03b473127.png)

## Next steps:
- Search still uses the NQT boolean, jobseekers cannot search job title and match based on job role (signed off by Product)
- When Algolia is implemented, index the job_roles field as part of the improved search
