### PR TITLE
Update convert NQT rake task 

### DIFF
--- a/lib/tasks/convert_nqt_to_job_role.rake
+++ b/lib/tasks/convert_nqt_to_job_role.rake
@@ -15,8 +15,11 @@ namespace :data do
 
       Vacancy.where(newly_qualified_teacher: true).in_batches(of: 100).each_record do |vacancy|
         # Some vacancies being updated will have been created prior to certain validations
-        vacancy.job_roles.append(I18n.t('jobs.job_role_options.nqt_suitable'))
-        vacancy.save(validate: false)
+        job_roles = vacancy.job_roles.presence || []
+        job_roles.append(I18n.t('jobs.job_role_options.nqt_suitable'))
+        # rubocop:disable Rails/SkipsModelValidations
+        vacancy.update_columns(job_roles: job_roles)
+        # rubocop:enable Rails/SkipsModelValidations
         updated_count += 1
         Rails.logger.info(
           "Updated vacancy: #{vacancy.job_title} with job_roles: #{I18n.t('jobs.job_role_options.nqt_suitable')}"


### PR DESCRIPTION
- All vacancies on production have nil set on the job_roles field. 

- This PR addresses this oversight so that NQT fields can be converted to the job_roles field.