### PR TITLE
Fix bug on production where job_roles.any? throws error

### DIFF
--- a/app/views/vacancies/_job_details_section.html.haml
+++ b/app/views/vacancies/_job_details_section.html.haml
@@ -3,7 +3,7 @@
     = t('jobs.job_details')
   %table.govuk-table{ ariadescribedby: "Job details" }
     %tbody.govuk-table__body
-      - if @vacancy.job_roles.any?
+      - if @vacancy.job_roles.present?
         %tr.govuk-table__row
           %th.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
             = t('jobs.job_roles')


### PR DESCRIPTION
https://rollbar.com/dfe/teacher-vacancies/items/928/
ActionView::Template::Error: undefined method 'any?' for nil:NilClass

I have tested this change (and the unchanged version) locally, with vacancies that have job_roles = nil.