### PR TITLE
Index Vacancy to Algolia 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'rails', '~> 5.2.4'
 
 gem 'activerecord-session_store'
 gem 'addressable'
+gem 'algoliasearch-rails'
 gem 'array_enum'
 gem 'breasal', '~> 0.0.1'
 gem 'browser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,12 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.0.1)
+    algoliasearch (1.27.1)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
+    algoliasearch-rails (1.24.0)
+      algoliasearch (>= 1.26.0, < 2.0.0)
+      json (>= 1.5.1)
     ansi (1.5.0)
     arel (9.0.0)
     array_enum (1.2.0)
@@ -221,6 +227,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.3.0)
     json-jwt (1.11.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -514,6 +521,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-session_store
   addressable
+  algoliasearch-rails
   array_enum
   breasal (~> 0.0.1)
   browser

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -33,7 +33,7 @@ class Vacancy < ApplicationRecord
 
   include AlgoliaSearch
 
-  algoliasearch do
+  algoliasearch per_environment: true do
     attributes :first_supporting_subject, :job_roles, :job_title, :second_supporting_subject, :working_patterns
 
     attribute :expiry_date do

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -41,7 +41,8 @@ class Vacancy < ApplicationRecord
     end
 
     attribute :last_updated_at do
-      convert_date_to_unix_time(self.updated_at)
+      # Convert from ActiveSupport::TimeWithZone object to Unix time
+      self.updated_at.to_i
     end
 
     attribute :listing_status do
@@ -316,9 +317,10 @@ class Vacancy < ApplicationRecord
   private
 
   def convert_date_to_unix_time(date)
-    date_as_unix = date&.strftime('%s').to_i
-    # nil.to_i returns 0, so if strftime('%s') returns nil we should return nil.
-    date_as_unix > 0 ? date_as_unix : nil
+    # nil.to_i returns 0 in unix time (1970-01-01), so if date is nil we should return nil.
+    return nil if date == nil
+    # Convert to unix time via DateTime object in order to use correct time zone
+    Time.zone.at(date.to_time).to_datetime.midday.to_i
   end
 
   def slug_candidates

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -35,7 +35,6 @@ class Vacancy < ApplicationRecord
 
   algoliasearch do
     attributes :first_supporting_subject,
-      :job_description,
       :job_roles,
       :job_title,
       :newly_qualified_teacher,
@@ -43,6 +42,10 @@ class Vacancy < ApplicationRecord
       :slug,
       :status,
       :working_patterns
+
+    attribute :job_description do
+      self.job_description.truncate(256)
+    end
 
     attribute :school do
       {

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -34,17 +34,30 @@ class Vacancy < ApplicationRecord
   include AlgoliaSearch
 
   algoliasearch do
-    attributes :first_supporting_subject,
-      :job_roles,
-      :job_title,
-      :newly_qualified_teacher,
-      :second_supporting_subject,
-      :slug,
-      :status,
-      :working_patterns
+    attributes :first_supporting_subject, :job_roles, :job_title, :second_supporting_subject, :working_patterns
 
-    attribute :job_description do
-      self.job_description.truncate(256)
+    attribute :expiry_date do
+      convert_date_to_unix_time(self.expires_on)
+    end
+
+    attribute :last_updated_at do
+      convert_date_to_unix_time(self.updated_at)
+    end
+
+    attribute :listing_status do
+      self.status
+    end
+
+    attribute :newly_qualified_teacher_status do
+      self.newly_qualified_teacher
+    end
+
+    attribute :permalink do
+      self.slug
+    end
+
+    attribute :publication_date do
+      convert_date_to_unix_time(self.publish_on)
     end
 
     attribute :school do
@@ -55,29 +68,17 @@ class Vacancy < ApplicationRecord
         local_authority: self.school.local_authority,
         phase: self.school.phase,
         postcode: self.school.postcode,
-        region_name: self.school.region.name,
+        region: self.school.region.name,
         town: self.school.town
       }
     end
 
-    attribute :subject do
-      self.subject&.name
-    end
-
-    attribute :expires_on do
-      convert_date_to_unix_time(self.expires_on)
-    end
-
-    attribute :publish_on do
-      convert_date_to_unix_time(self.publish_on)
-    end
-
-    attribute :starts_on do
+    attribute :start_date do
       convert_date_to_unix_time(self.starts_on)
     end
 
-    attribute :updated_at do
-      convert_date_to_unix_time(self.updated_at)
+    attribute :subject do
+      self.subject&.name
     end
 
     geoloc :lat, :lng

--- a/config/initializers/algoliasearch.rb
+++ b/config/initializers/algoliasearch.rb
@@ -1,0 +1,2 @@
+AlgoliaSearch.configuration = { application_id: ENV['ALGOLIA_APP_ID'], api_key: ENV['ALGOLIA_WRITE_API_KEY'] }
+


### PR DESCRIPTION
##  Jira ticket URL:

https://dfedigital.atlassian.net/browse/TEVA-615

## Changes in this PR:

This PR includes the necessary code for indexing Vacancy (sending our data to Algolia). The code was done as part of the spike described in the ticket, but we are merging it now as it is demonstrated to work.

To see the Vacancy index, including examples of records: https://www.algolia.com/apps/QM2YE0HRBW/explorer/browse/Vacancy

You will need to be invited to Todd's Algolia team. One record copied below.

```ruby
{
      "first_supporting_subject": null,
      "job_roles": null,
      "job_title": "Business Studies Teacher",
      "second_supporting_subject": null,
      "working_patterns": [
        "full_time"
      ],
      "expiry_date": 1585267200,
      "last_updated_at": 1585274468,
      "listing_status": "published",
      "newly_qualified_teacher_status": false,
      "permalink": "business-studies-teacher-whitley-academy",
      "publication_date": 1583884800,
      "school": {
        "name": "Whitley Academy",
        "address": "Abbey Road",
        "county": "West Midlands",
        "local_authority": "Coventry",
        "phase": "secondary",
        "postcode": "CV3 4BD",
        "region": "West Midlands",
        "town": "Coventry"
      },
      "start_date": 1598918400,
      "subject": "Business Studies",
      "_geoloc": {
        "lat": 52.38614499118846,
        "lng": -1.486365476684278
      },
      "objectID": "fff5bc2f-7b7e-48f1-b7bf-c80f85a1d399",
}
```

To index Vacancy attributes for consumption by Algolia:

    To index Vacancy for the first time, run this in the console:
    Vacancy.reindex

    To reindex Vacancy (without deleting removed objects):
    Vacancy.reindex!


## Next steps:

- [x] Put the necessary API keys on production and staging.