### PR TITLE
Job summary page

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -13,7 +13,7 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
     if @application_details_form.valid?
       session[:completed_step] = current_step
       vacancy = update_vacancy(@application_details_form.params_to_save)
-      redirect_to next_step(vacancy)
+      redirect_to_next_step(vacancy)
     else
       session[:current_step] = :step_4 unless session[:current_step].eql?(:review)
       redirect_to application_details_school_job_path(anchor: 'errors')
@@ -56,7 +56,7 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
                   :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem).merge(completed_step: current_step)
   end
 
-  def next_step(vacancy)
-    review_path(vacancy)
+  def next_step
+    school_job_job_summary_path(@vacancy.id)
   end
 end

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -55,7 +55,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   def job_specification_form_params
     persist_nqt_job_role_to_nqt_attribute(:job_specification_form)
     params.require(:job_specification_form)
-          .permit(:job_title, :job_summary, :leadership_id,
+          .permit(:job_title, :leadership_id,
                   :subject_id,
                   :starts_on_dd, :starts_on_mm,
                   :starts_on_yyyy, :ends_on_dd, :ends_on_mm, :ends_on_yyyy,

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -55,7 +55,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   def job_specification_form_params
     persist_nqt_job_role_to_nqt_attribute(:job_specification_form)
     params.require(:job_specification_form)
-          .permit(:job_title, :job_description, :leadership_id,
+          .permit(:job_title, :job_summary, :leadership_id,
                   :subject_id,
                   :starts_on_dd, :starts_on_mm,
                   :starts_on_yyyy, :ends_on_dd, :ends_on_mm, :ends_on_yyyy,

--- a/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
@@ -1,0 +1,34 @@
+class HiringStaff::Vacancies::JobSummaryController < HiringStaff::Vacancies::ApplicationController
+  before_action :redirect_unless_vacancy
+
+  def show
+    @job_summary_form = JobSummaryForm.new(@vacancy.attributes)
+  end
+
+  def update
+    @job_summary_form = JobSummaryForm.new(job_summary_form_params)
+
+    if @job_summary_form.valid?
+      update_vacancy(job_summary_form_params, @vacancy)
+      update_google_index(@vacancy) if @vacancy.listed?
+      return redirect_to_next_step_if_save_and_continue
+    end
+
+    render :show
+  end
+
+  private
+
+  def job_summary_form_params
+    (params[:job_summary_form] || params).permit(:job_summary, :about_school)
+                                         .merge(completed_step: current_step)
+  end
+
+  def redirect_to_next_step_if_save_and_continue
+    if params[:commit] == I18n.t('buttons.save_and_continue')
+      redirect_to school_job_review_path(@vacancy.id)
+    elsif params[:commit] == I18n.t('buttons.update_job')
+      redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')
+    end
+  end
+end

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -88,10 +88,17 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
     valid
   end
 
+  def step_5_valid?
+    valid = JobSummaryForm.new(@vacancy.attributes).valid?
+    clear_cache_and_step unless valid
+    valid
+  end
+
   def redirect_to_incomplete_step
     return redirect_to school_job_pay_package_path(@vacancy.id) unless step_2_valid?
     return redirect_to supporting_documents_school_job_path unless step_3_valid?
     return redirect_to application_details_school_job_path unless step_4_valid?
+    return redirect_to school_job_job_summary_path(@vacancy.id) unless step_5_valid?
   end
 
   def already_published_message

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -70,35 +70,20 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
     params.require(:job_id)
   end
 
-  def step_2_valid?
-    valid = PayPackageForm.new(@vacancy.attributes).valid?
-    clear_cache_and_step unless valid
-    valid
-  end
-
-  def step_3_valid?
-    valid = SupportingDocumentsForm.new(@vacancy.attributes).valid?
-    clear_cache_and_step unless valid
-    valid
-  end
-
-  def step_4_valid?
-    valid = ApplicationDetailsForm.new(@vacancy.attributes).completed?
-    clear_cache_and_step unless valid
-    valid
-  end
-
-  def step_5_valid?
-    valid = JobSummaryForm.new(@vacancy.attributes).valid?
-    clear_cache_and_step unless valid
-    valid
+  def step_valid?(step_form)
+    validation = step_form.new(@vacancy.attributes)
+    if step_form == ApplicationDetailsForm
+      (validation&.completed?).tap { |valid| clear_cache_and_step unless valid }
+    else
+      (validation&.valid?).tap { |valid| clear_cache_and_step unless valid }
+    end
   end
 
   def redirect_to_incomplete_step
-    return redirect_to school_job_pay_package_path(@vacancy.id) unless step_2_valid?
-    return redirect_to supporting_documents_school_job_path unless step_3_valid?
-    return redirect_to application_details_school_job_path unless step_4_valid?
-    return redirect_to school_job_job_summary_path(@vacancy.id) unless step_5_valid?
+    return redirect_to school_job_pay_package_path(@vacancy.id) unless step_valid?(PayPackageForm)
+    return redirect_to supporting_documents_school_job_path unless step_valid?(SupportingDocumentsForm)
+    return redirect_to application_details_school_job_path unless step_valid?(ApplicationDetailsForm)
+    return redirect_to school_job_job_summary_path(@vacancy.id) unless step_valid?(JobSummaryForm)
   end
 
   def already_published_message

--- a/app/form_models/job_summary_form.rb
+++ b/app/form_models/job_summary_form.rb
@@ -1,0 +1,3 @@
+class JobSummaryForm < VacancyForm
+  include VacancyJobSummaryValidations
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,10 +2,6 @@ module ApplicationHelper
   include ActionView::Helpers::NumberHelper
   include ActionView::Helpers::SanitizeHelper
 
-  def sanitize(text, options = {})
-    super(text, options)&.gsub('&amp;', '&')
-  end
-
   def body_class
     auth_class = authenticated? ? 'hiring-staff' : ''
     action_class = controller_name + '_' + action_name

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -3,12 +3,12 @@ module VacancyJobSpecificationValidations
   include ApplicationHelper
 
   included do
-    validates :job_title, :job_description, presence: true
+    validates :job_title, :job_summary, presence: true
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
 
     validates :job_roles, presence: true
 
-    validates :job_description, length: { minimum: 10, maximum: 50_000 }, if: :job_description?
+    validates :job_summary, length: { minimum: 10, maximum: 50_000 }, if: :job_summary?
 
     validates :working_patterns, presence: true
 
@@ -61,7 +61,7 @@ module VacancyJobSpecificationValidations
     I18n.t('activerecord.errors.models.vacancy.attributes.ends_on.past')
   end
 
-  def job_description=(value)
+  def job_summary=(value)
     super(sanitize(value))
   end
 

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -5,6 +5,7 @@ module VacancyJobSpecificationValidations
   included do
     validates :job_title, presence: true
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
+    validate :job_title_has_no_tags?, if: :job_title?
 
     validates :job_roles, presence: true
 
@@ -59,7 +60,9 @@ module VacancyJobSpecificationValidations
     I18n.t('activerecord.errors.models.vacancy.attributes.ends_on.past')
   end
 
-  def job_title=(value)
-    super(sanitize(value, tags: []))
+  def job_title_has_no_tags?
+    errors.add(
+      :job_title, I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.invalid_characters')
+    ) unless job_title == sanitize(job_title, tags: [])
   end
 end

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -3,12 +3,10 @@ module VacancyJobSpecificationValidations
   include ApplicationHelper
 
   included do
-    validates :job_title, :job_summary, presence: true
+    validates :job_title, presence: true
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
 
     validates :job_roles, presence: true
-
-    validates :job_summary, length: { minimum: 10, maximum: 50_000 }, if: :job_summary?
 
     validates :working_patterns, presence: true
 
@@ -59,10 +57,6 @@ module VacancyJobSpecificationValidations
 
   def ends_on_past_error
     I18n.t('activerecord.errors.models.vacancy.attributes.ends_on.past')
-  end
-
-  def job_summary=(value)
-    super(sanitize(value))
   end
 
   def job_title=(value)

--- a/app/models/concerns/vacancy_job_summary_validations.rb
+++ b/app/models/concerns/vacancy_job_summary_validations.rb
@@ -6,12 +6,4 @@ module VacancyJobSummaryValidations
     validates :job_summary, presence: true
     validates :about_school, presence: true
   end
-
-  def job_summary=(value)
-    super(sanitize(value))
-  end
-
-  def about_school=(value)
-    super(sanitize(value))
-  end
 end

--- a/app/models/concerns/vacancy_job_summary_validations.rb
+++ b/app/models/concerns/vacancy_job_summary_validations.rb
@@ -1,6 +1,5 @@
 module VacancyJobSummaryValidations
   extend ActiveSupport::Concern
-  include ApplicationHelper
 
   included do
     validates :job_summary, presence: true

--- a/app/models/concerns/vacancy_job_summary_validations.rb
+++ b/app/models/concerns/vacancy_job_summary_validations.rb
@@ -1,0 +1,17 @@
+module VacancyJobSummaryValidations
+  extend ActiveSupport::Concern
+  include ApplicationHelper
+
+  included do
+    validates :job_summary, presence: true
+    validates :about_school, presence: true
+  end
+
+  def job_summary=(value)
+    super(sanitize(value))
+  end
+
+  def about_school=(value)
+    super(sanitize(value))
+  end
+end

--- a/app/models/concerns/vacancy_pay_package_validations.rb
+++ b/app/models/concerns/vacancy_pay_package_validations.rb
@@ -5,13 +5,12 @@ module VacancyPayPackageValidations
   included do
     validates :salary, presence: true
     validates :salary, length: { minimum: 1, maximum: 256 }, if: :salary?
+    validate :salary_has_no_tags?, if: :salary?
   end
 
-  def salary=(value)
-    super(sanitize(value, tags: []))
-  end
-
-  def benefits=(value)
-    super(sanitize(value))
+  def salary_has_no_tags?
+    errors.add(
+      :salary, I18n.t('activemodel.errors.models.pay_package_form.attributes.salary.invalid_characters')
+    ) unless salary == sanitize(salary, tags: [])
   end
 end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -54,7 +54,7 @@ class Vacancy < ApplicationRecord
   } do
     mappings dynamic: 'false' do
       indexes :job_title, type: :text, analyzer: :stopwords
-      indexes :job_description, analyzer: 'english'
+      indexes :job_summary, analyzer: 'english'
 
       indexes :school do
         indexes :name, analyzer: 'english'

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -26,6 +26,7 @@ class Vacancy < ApplicationRecord
   include VacancyJobSpecificationValidations
   include VacancyPayPackageValidations
   include VacancyApplicationDetailValidations
+  include VacancyJobSummaryValidations
 
   include Elasticsearch::Model
   include Redis::Objects

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -95,7 +95,7 @@ class VacanciesPresenter < BasePresenter
   # rubocop:disable Metrics/AbcSize
   def to_csv_row(vacancy)
     [vacancy.job_title,
-     vacancy.job_description,
+     vacancy.job_summary,
      vacancy.salary,
      vacancy.benefits,
      vacancy.publish_on.to_time.iso8601,

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -18,8 +18,8 @@ class VacancyPresenter < BasePresenter
     Rails.application.routes.url_helpers.job_url(model, params)
   end
 
-  def job_description
-    simple_format(model.job_description)
+  def job_summary
+    simple_format(model.job_summary)
   end
 
   def education

--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -5,7 +5,7 @@ json.title vacancy.job_title
 json.salary vacancy.salary
 json.jobBenefits vacancy.benefits
 json.datePosted vacancy.publish_on.to_time.iso8601
-json.description vacancy.job_description
+json.description vacancy.job_summary
 
 json.educationRequirements vacancy.education
 json.qualifications vacancy.qualifications

--- a/app/views/hiring_staff/vacancies/_show.html.haml
+++ b/app/views/hiring_staff/vacancies/_show.html.haml
@@ -19,7 +19,7 @@
           .og_text
             .og_url= t('app.title')
             .og_title #{@vacancy.job_title} - #{@vacancy.school_name}
-            .og_description= truncate(strip_tags(@vacancy.job_description), length: 76, separator: ' ')
+            .og_description= truncate(strip_tags(@vacancy.job_summary), length: 76, separator: ' ')
         .og-caption
           Your job listing will appear on Facebook in a format similar to the above.
 

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -9,3 +9,4 @@
       %li= render 'hiring_staff/vacancies/edit_vacancy_sections/edit_pay_package'
       %li= render 'hiring_staff/vacancies/edit_vacancy_sections/edit_supporting_documents'
       %li= render 'hiring_staff/vacancies/edit_vacancy_sections/edit_application_details'
+      %li= render 'hiring_staff/vacancies/edit_vacancy_sections/edit_job_summary'

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -23,11 +23,6 @@
     %dd.app-check-your-answers__answer= @vacancy.show_job_roles
 
   .app-check-your-answers__contents
-    %dt.app-check-your-answers__question#job_summary
-      %h4.govuk-heading-s= t('jobs.job_summary')
-    %dd.app-check-your-answers__answer= @vacancy.job_summary
-
-  .app-check-your-answers__contents
     %dt.app-check-your-answers__question#subject
       %h4.govuk-heading-s= t('jobs.subjects')
     %dd.app-check-your-answers__answer= @vacancy.all_subjects

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -23,9 +23,9 @@
     %dd.app-check-your-answers__answer= @vacancy.show_job_roles
 
   .app-check-your-answers__contents
-    %dt.app-check-your-answers__question#job_description
-      %h4.govuk-heading-s= t('jobs.job_description')
-    %dd.app-check-your-answers__answer= @vacancy.job_description
+    %dt.app-check-your-answers__question#job_summary
+      %h4.govuk-heading-s= t('jobs.job_summary')
+    %dd.app-check-your-answers__answer= @vacancy.job_summary
 
   .app-check-your-answers__contents
     %dt.app-check-your-answers__question#subject

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_summary.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_summary.html.haml
@@ -1,0 +1,16 @@
+%h2.govuk-heading-m.app-task-list__section#job_summary_heading
+  %span.app-task-list__section-number 5.
+  = t('jobs.job_summary')
+  = link_to t('buttons.change'), school_job_job_summary_path(@vacancy.id), class: 'govuk-link change-button', 'aria-label': t('jobs.aria_labels.change_job_summary')
+
+%dl.app-check-your-answers.app-check-your-answers--short
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question.first-question#job_summary
+      %h4.govuk-heading-s= t('jobs.job_summary')
+    %dd.app-check-your-answers__answer.first-question= @vacancy.job_summary
+
+  .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#about_school
+      %h4.govuk-heading-s= t('jobs.about_school', school: current_school.name)
+    %dd.app-check-your-answers__answer= @vacancy.about_school

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -27,14 +27,6 @@
                 wrapper_html: { id: 'job_role' },
                 collection: job_role_options,
                 required: true
-      = f.input :job_summary,
-                wrapper: 'textarea',
-                as: :text,
-                label: t('jobs.job_summary'),
-                hint: t('jobs.form_hints.description'),
-                input_html: { rows: 10 },
-                wrapper_html: { id: 'job_summary' },
-                required: true
       = f.input :subject_id,
                 wrapper: 'select',
                 label: t('jobs.main_subject'),

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -27,13 +27,13 @@
                 wrapper_html: { id: 'job_role' },
                 collection: job_role_options,
                 required: true
-      = f.input :job_description,
+      = f.input :job_summary,
                 wrapper: 'textarea',
                 as: :text,
-                label: t('jobs.job_description'),
+                label: t('jobs.job_summary'),
                 hint: t('jobs.form_hints.description'),
                 input_html: { rows: 10 },
-                wrapper_html: { id: 'job_description' },
+                wrapper_html: { id: 'job_summary' },
                 required: true
       = f.input :subject_id,
                 wrapper: 'select',

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -27,14 +27,6 @@
                 wrapper_html: { id: 'job_role' },
                 collection: job_role_options,
                 required: true
-      = f.input :job_summary,
-                wrapper: 'textarea',
-                as: :text,
-                label: t('jobs.job_summary'),
-                hint: t('jobs.form_hints.description'),
-                input_html: { rows: 10 },
-                wrapper_html: { id: 'job_summary' },
-                required: true
       = f.input :subject_id,
                 wrapper: 'select',
                 label: t('jobs.main_subject'),

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -27,13 +27,13 @@
                 wrapper_html: { id: 'job_role' },
                 collection: job_role_options,
                 required: true
-      = f.input :job_description,
+      = f.input :job_summary,
                 wrapper: 'textarea',
                 as: :text,
-                label: t('jobs.job_description'),
+                label: t('jobs.job_summary'),
                 hint: t('jobs.form_hints.description'),
                 input_html: { rows: 10 },
-                wrapper_html: { id: 'job_description' },
+                wrapper_html: { id: 'job_summary' },
                 required: true
       = f.input :subject_id,
                 wrapper: 'select',

--- a/app/views/hiring_staff/vacancies/job_summary/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_summary/show.html.haml
@@ -22,7 +22,7 @@
       = f.govuk_text_area :about_school,
         label: { text: t('helpers.fieldset.job_summary_form.about_school_html', school: current_school.name), size: 's' },
         hint_text: t('helpers.hint.job_summary_form.about_school'),
-        value: @vacancy.about_school.presence || (@vacancy.school.description.presence || ''),
+        value: @vacancy.about_school.presence || @vacancy.school.description.presence.to_s,
         rows: 10,
         required: true
 

--- a/app/views/hiring_staff/vacancies/job_summary/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_summary/show.html.haml
@@ -1,0 +1,29 @@
+- if @vacancy.published?
+  - content_for :page_title_prefix, "#{@job_summary_form.errors.present? ? 'Error: ' : ''}Edit the #{t('jobs.job_summary')}"
+- else
+  - content_for :page_title_prefix, "#{@job_summary_form.errors.present? ? 'Error: ' : ''}#{t('jobs.job_summary')} — #{t('jobs.create_a_job', school: current_school.name)}"
+
+= render 'hiring_staff/vacancies/vacancy_form_partials/title'
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = form_for @job_summary_form, url: school_job_job_summary_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+      = render 'hiring_staff/vacancies/error_messages', errors: @job_summary_form.errors
+
+      %h2.govuk-heading-l
+        = t('jobs.job_summary')
+
+      = f.govuk_text_area :job_summary,
+        label: { text: t('helpers.fieldset.job_summary_form.job_summary_html'), size: 's' },
+        hint_text: t('helpers.hint.job_summary_form.job_summary'),
+        required: true
+
+      = f.govuk_text_area :about_school,
+        label: { text: t('helpers.fieldset.job_summary_form.about_school_html', school: current_school.name), size: 's' },
+        hint_text: t('helpers.hint.job_summary_form.about_school'),
+        required: true
+
+      = render 'hiring_staff/vacancies/vacancy_form_partials/submit', f: f
+  .govuk-grid-column-one-third
+    - unless @vacancy.published?
+      = render 'hiring_staff/vacancies/sidebar'

--- a/app/views/hiring_staff/vacancies/job_summary/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_summary/show.html.haml
@@ -21,6 +21,7 @@
       = f.govuk_text_area :about_school,
         label: { text: t('helpers.fieldset.job_summary_form.about_school_html', school: current_school.name), size: 's' },
         hint_text: t('helpers.hint.job_summary_form.about_school'),
+        value: @vacancy.about_school.presence || (@vacancy.school.description.presence || ''),
         required: true
 
       = render 'hiring_staff/vacancies/vacancy_form_partials/submit', f: f

--- a/app/views/hiring_staff/vacancies/job_summary/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_summary/show.html.haml
@@ -16,12 +16,14 @@
       = f.govuk_text_area :job_summary,
         label: { text: t('helpers.fieldset.job_summary_form.job_summary_html'), size: 's' },
         hint_text: t('helpers.hint.job_summary_form.job_summary'),
+        rows: 10,
         required: true
 
       = f.govuk_text_area :about_school,
         label: { text: t('helpers.fieldset.job_summary_form.about_school_html', school: current_school.name), size: 's' },
         hint_text: t('helpers.hint.job_summary_form.about_school'),
         value: @vacancy.about_school.presence || (@vacancy.school.description.presence || ''),
+        rows: 10,
         required: true
 
       = render 'hiring_staff/vacancies/vacancy_form_partials/submit', f: f

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -18,6 +18,7 @@
       %li= render 'hiring_staff/vacancies/edit_vacancy_sections/edit_pay_package'
       %li= render 'hiring_staff/vacancies/edit_vacancy_sections/edit_supporting_documents'
       %li= render 'hiring_staff/vacancies/edit_vacancy_sections/edit_application_details'
+      %li= render 'hiring_staff/vacancies/edit_vacancy_sections/edit_job_summary'
 
     %h3.govuk-heading-m= t('jobs.preview_listing.heading')
     %p= t('jobs.preview_listing.message')

--- a/app/views/vacancies/_job_details_section.html.haml
+++ b/app/views/vacancies/_job_details_section.html.haml
@@ -31,8 +31,8 @@
         %td.govuk-table__cell
           = @vacancy.salary
 
-  %h4.govuk-heading-s= t('jobs.job_description')
-  %p= @vacancy.job_description
+  %h4.govuk-heading-s= t('jobs.job_summary')
+  %p= @vacancy.job_summary
 
   - if @vacancy.documents.none? && @vacancy.any_candidate_specification?
     - if @vacancy.education?

--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -2,7 +2,7 @@
   #{@vacancy.job_title} - #{@vacancy.school_name}
 
 - content_for :page_description do
-  = strip_tags(@vacancy.job_description)
+  = strip_tags(@vacancy.job_summary)
 
 .vacancy
   = render '/shared/vacancy/jobseeker_view'

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -6,18 +6,15 @@ en:
       too_long: Job title must not be more than %{count} characters
     job_roles:
       blank: Select a job role
-    job_summary:
-      blank: Enter a job summary
-      too_short: Job summary must be at least %{count} characters
-      too_long: Job summary must not be more than %{count} characters
     working_patterns:
       blank: Select a working pattern
-    salary:
-      more_than_maxiumum: "%{salary} must be less than %{count}"
   pay_package_errors: &pay_package_errors
     salary:
       blank: Enter a salary
       too_long: Salary must not be more than %{count} characters
+  supporting_documents_errors: &supporting_documents_errors
+    supporting_documents:
+      inclusion: "Please indicate if you'd like to attach supporting documents"
   application_details_errors: &application_details_errors
     contact_email:
       blank: Enter a contact email
@@ -33,9 +30,11 @@ en:
       blank: Enter the date the role will be listed
       before_today: Date role will be listed must be either today or in the future
       invalid: Use the correct format for the date the role will be listed
-  supporting_documents_errors: &supporting_documents_errors
-    supporting_documents:
-      inclusion: "Please indicate if you'd like to attach supporting documents"
+  job_summary_errors: &job_summary_errors
+    job_summary:
+      blank: Enter a job summary
+    about_school:
+      blank: Enter a description of the school
   errors:
     format: "%{message}"
     title: 
@@ -53,12 +52,15 @@ en:
         pay_package_form:
           attributes:
             <<: *pay_package_errors
-        application_details_form:
-          attributes:
-            <<: *application_details_errors
         supporting_documents_form:
           attributes:
             <<: *supporting_documents_errors
+        application_details_form:
+          attributes:
+            <<: *application_details_errors
+        job_summary_form:
+          attributes:
+            <<: *job_summary_errors
   activerecord:
     attributes:
       vacancy/expiry_time: Application deadline (time)
@@ -71,8 +73,9 @@ en:
           attributes:
             <<: *job_specification_errors
             <<: *pay_package_errors
-            <<: *application_details_errors
             <<: *supporting_documents_errors
+            <<: *application_details_errors
+            <<: *job_summary_errors
             expiry_time:
               blank: Enter the time the application is due
               wrong_format: Use the correct format for the time the application is due

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -6,7 +6,7 @@ en:
       too_long: Job title must not be more than %{count} characters
     job_roles:
       blank: Select a job role
-    job_description:
+    job_summary:
       blank: Enter a job description
       too_short: Job description must be at least %{count} characters
       too_long: Job description must not be more than %{count} characters

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -7,9 +7,9 @@ en:
     job_roles:
       blank: Select a job role
     job_summary:
-      blank: Enter a job description
-      too_short: Job description must be at least %{count} characters
-      too_long: Job description must not be more than %{count} characters
+      blank: Enter a job summary
+      too_short: Job summary must be at least %{count} characters
+      too_long: Job summary must not be more than %{count} characters
     working_patterns:
       blank: Select a working pattern
     salary:

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -4,6 +4,7 @@ en:
       blank: Enter a job title
       too_short: Job title must be at least %{count} characters
       too_long: Job title must not be more than %{count} characters
+      invalid_characters: Job title must not contain any HTML tags
     job_roles:
       blank: Select a job role
     working_patterns:
@@ -12,6 +13,7 @@ en:
     salary:
       blank: Enter a salary
       too_long: Salary must not be more than %{count} characters
+      invalid_characters: Salary must not contain any HTML tags
   supporting_documents_errors: &supporting_documents_errors
     supporting_documents:
       inclusion: "Please indicate if you'd like to attach supporting documents"
@@ -37,7 +39,7 @@ en:
       blank: Enter a description of the school
   errors:
     format: "%{message}"
-    title: 
+    title:
       one: "Please correct the following error in your listing"
       other: "Please correct the following %{count} errors in your listing"
     messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,7 +22,11 @@ en:
       new:
         page_description: If you already have a Teaching Vacancies account you can sign in to the service here.
         request_account_title: Request an account
-        request_account_html: Don't have an account? You can get one if you work at a publicly funded school or trust in England, but you'll need your headteacher or senior leader to authorise you. Just ask them to send your full name and email address to %{mail_to}. Or email your details directly to that address, copying in your headteacher or senior leader.
+        request_account_html: >-
+          Don't have an account? You can get one if you work at a publicly funded school or trust in England, \
+          but you'll need your headteacher or senior leader to authorise you. Just ask them to send your full name
+          and email address to %{mail_to}. Or email your details directly to that address, copying in your headteacher
+          or senior leader.
         some_of_our_users: >-
           Some of our users are having having trouble signing in. We're working on the problem now. If you can't sign
           in, try again soon.
@@ -36,7 +40,8 @@ en:
     back: 'Back'
   pages:
     accessibility:
-      page_description: Find out which areas of Teaching Vacancies are not yet fully accessible and when we plan to correct each issue.
+      page_description:
+        Find out which areas of Teaching Vacancies are not yet fully accessible and when we plan to correct each issue.
     cookies:
       page_description: Find out what cookies Teaching Vacancies stores on your computer and what they are for.
     home:
@@ -54,14 +59,20 @@ en:
         manage_link: Manage jobs
         description: You're signed in as
     privacy_policy:
-      page_description: Find out what personal information Teaching Vacancies collects, how it is used, how long it is kept and what your data protection rights are.
+      page_description: >-
+        Find out what personal information Teaching Vacancies collects,
+        how it is used, how long it is kept and what your data protection rights are.
     terms-and-conditions:
-      page_description: Read Teaching Vacancies' terms of use for jobseekers and schools. You must agree to these to use the service.
+      page_description:
+        Read Teaching Vacancies' terms of use for jobseekers and schools. You must agree to these to use the service.
   sign_in:
     title: 'Sign in to Teaching Vacancies'
     link: 'Sign in'
     intro: You must have an account to sign into this service.
-    guidance: 'You can get one if you work at a publicly funded school or trust providing primary or secondary education in England and have been authorised by your headteacher or CEO. Just ask them to send your full name and email address to %{email}. Or email us your details directly, copying in your headteacher or CEO.'
+    guidance: >-
+      You can get one if you work at a publicly funded school or trust providing primary or secondary education in
+      England and have been authorised by your headteacher or CEO. Just ask them to send your full name and
+      email address to %{email}. Or email us your details directly, copying in your headteacher or CEO.
     organisation:
       title: 'Select your organisation'
       legend: 'You are associated with more than one organisation, please select the one you wish to sign-in with.'
@@ -84,7 +95,8 @@ en:
       pay_package_form:
         salary_html: "Salary (<span class='text-red'>Required</span>)"
       supporting_documents_form:
-        supporting_documents_html: "Would you like to attach supporting documents? (<span class='text-red'>Required</span>)"
+        supporting_documents_html:
+          "Would you like to attach supporting documents? (<span class='text-red'>Required</span>)"
       job_summary_form:
         job_summary_html: "Job summary (<span class='text-red'>Required</span>)"
         about_school_html: "About %{school} (<span class='text-red'>Required</span>)"
@@ -93,8 +105,12 @@ en:
         starts_on: 'For example, 01 01 2020'
         ends_on: 'For example, 01 08 2020'
       pay_package_form:
-        salary: 'Enter the annual salary or salary range, and/or pay scale range. Where relevant, state if the salary is full-time equivalent'
-        benefits: 'Include special educational needs (SEN) allowances and teaching and learning responsibility (TLR) payments, for example'
+        salary: >-
+          Enter the annual salary or salary range, and/or pay scale range.
+          Where relevant, state if the salary is full-time equivalent
+        benefits: >-
+          Include special educational needs (SEN) allowances and teaching and learning responsibility (TLR) payments,
+          for example
       application_details_form:
         publish_on: 'For example, 01 01 2020'
         expires_on: 'For example, 01 08 2020'
@@ -104,26 +120,37 @@ en:
         publish_on: 'For example, 01 01 2020'
         expires_on: 'For example, 01 08 2020'
       supporting_documents_form:
-        supporting_documents: 'These could include, for example, a job description, person specification or application pack'
+        supporting_documents:
+          'These could include, for example, a job description, person specification or application pack'
       job_summary_form:
-        job_summary: 'Give a brief summary of the job that job seekers can quickly scan. This will be the first thing they see on the listing or in search engine results'
+        job_summary: >-
+          Give a brief summary of the job that job seekers can quickly scan.
+          This will be the first thing they see on the listing or in search engine results
         about_school: "This will appear next to the job details under 'School overview'. Feel free to adapt this text"
   jobs:
     current_step: "Step %{step} of %{total}"
     notification_labels:
       new: 'new'
     heading: 'Find a job in teaching'
-    location_description: 'Find teaching jobs in %{location} on Teaching Vacancies, the free national job site for teachers, with no recruitment fees for schools.'
+    location_description: >-
+      Find teaching jobs in %{location} on Teaching Vacancies, the free national job site for teachers,
+      with no recruitment fees for schools.
     location_search_heading: 'Teaching jobs in %{location}'
     sort_by: 'Sort by:'
     sort_submit: 'Sort'
     key_info: 'Contents'
-    awaiting_feedback_intro: 'Please tell us if you filled these expired jobs through Teaching Vacancies, and whether you listed them elsewhere. Your feedback will help us improve the service.'
+    awaiting_feedback_intro: >-
+      Please tell us if you filled these expired jobs through Teaching Vacancies,
+      and whether you listed them elsewhere. Your feedback will help us improve the service.
     no_awaiting_feedback: 'There are no jobs waiting for your feedback at the moment.'
     feedback_submitted_html: '<b>Feedback submitted</b> for %{title}'
-    feedback_error: There was a problem submitting your feedback. Please make sure you have selected an answer for both questions.
+    feedback_error:
+      There was a problem submitting your feedback. Please make sure you have selected an answer for both questions.
     inline_feedback_error: Please select an option.
-    feedback_all_submitted: 'You have provided feedback on all your expired jobs. Thank you for sharing this information, which will help us to improve the service. If you have general comments on the service you can share them with us using <a href="/feedback/new">this feedback form.</a>'
+    feedback_all_submitted: >-
+      You have provided feedback on all your expired jobs. Thank you for sharing this information,
+      which will help us to improve the service. If you have general comments on the service you can share them with us
+      using <a href="/feedback/new">this feedback form.</a>
     days_to_apply:
       remaining: '%{days_remaining} days remaining to apply'
       today: 'Deadline is today'
@@ -153,7 +180,8 @@ en:
     experience: 'Essential skills and experience'
     ref_no: 'Reference number'
     subjects: 'Subject(s)'
-    subject: 
+    subject:
+    subject:
       one: 'Subject'
       other: 'Subjects'
     main_subject: 'Main subject'
@@ -184,7 +212,7 @@ en:
       leadership: 'Leadership'
       sen_specialist: 'SEN specialist'
       nqt_suitable: 'Suitable for NQTs'
-    job_summary: 'Job summary'    
+    job_summary: 'Job summary'
     salary: 'Salary'
     benefits: 'Employee benefits'
     salary_range_html: "Salary range (<span class='text-red'>Required</span>)"
@@ -235,7 +263,8 @@ en:
     job_summary: 'Job summary'
     about_school: 'About %{school}'
     review: 'Review your entries for each section below, making any changes needed before you publish the listing.'
-    review_future: 'Review your entries for each section below, making any changes before you submit the listing for publication.'
+    review_future:
+      'Review your entries for each section below, making any changes before you submit the listing for publication.'
     edit: 'Edit the job details.'
     copy_of: 'Copy of'
     preview_listing:
@@ -244,10 +273,16 @@ en:
       button: 'Preview job listing'
       page_title: 'Preview job listing for %{school}'
       summary:
-        heading: 'Preview of %{title} job listing'
-        body_html: 
-          zero: "This is how your job listing will appear to jobseekers visiting Teaching Vacancies. You can make changes or, if you are happy with it and agree to our <a href='/pages/terms-and-conditions' class='govuk-link' target='blank'>terms and conditions</a>, you can submit it for publication now (%{date})."
-          one: "This is how your job listing will appear to jobseekers visiting Teaching Vacancies. You can make changes or, if you are happy with it and agree to our <a href='/pages/terms-and-conditions' class='govuk-link' target='blank'>terms and conditions</a>, you can submit it for publication on %{date}."
+        heading: 'Preview of %{title}'
+        body_html:
+          zero: >-
+            This is how your job listing will appear to jobseekers visiting Teaching Vacancies.
+            You can make changes or, if you are happy with it and agree to our <a href='/pages/terms-and-conditions'
+            class='govuk-link' target='blank'>terms and conditions</a>, you can submit it for publication now (%{date})
+          one: >-
+            This is how your job listing will appear to jobseekers visiting Teaching Vacancies.
+            You can make changes or, if you are happy with it and agree to our <a href='/pages/terms-and-conditions'
+            class='govuk-link' target='blank'>terms and conditions</a>, you can submit it for publication on %{date}
         buttons:
           submit: 'Submit for publication'
           make_changes: 'Make changes'
@@ -255,11 +290,17 @@ en:
       heading:
         zero: 'Submit this listing for publication now (%{date})'
         one: 'Submit this listing for publication on %{date}'
-      message_html: "By publishing this job you agree to our <a href='/pages/terms-and-conditions' class='govuk-link' target='blank'>terms and conditions</a>  for schools and confirm that the details you have provided are, to the best of your knowledge, correct."
+      message_html: >-
+        By publishing this job you agree to our <a href='/pages/terms-and-conditions'
+        class='govuk-link' target='blank'>terms and conditions</a>  for schools and confirm that the details you have
+        provided are, to the best of your knowledge, correct
       button: 'Confirm and submit job'
     publish_for: 'Publish this listing for '
     publish_for_future: 'Submit this listing for publication on '
-    confirmation_summary_html: "By publishing this job you agree to our <a href='/pages/terms-and-conditions' class='govuk-link' target='blank'>terms and conditions</a> for schools and confirm that the details you have provided are, to the best of your knowledge, correct."
+    confirmation_summary_html: >-
+      By publishing this job you agree to our <a href='/pages/terms-and-conditions' class='govuk-link'
+      target='blank'>terms and conditions</a> for schools and confirm that the details you have provided are,
+      to the best of your knowledge, correct.
     submit: 'Publish now'
     submit_future: 'Confirm and submit job'
     apply: 'Get more information'
@@ -307,7 +348,9 @@ en:
       dashboard_link: 'You can also view, amend or delete it on %{link}'
       next_step: 'What happens next'
       date_posted: 'Your job listing will be posted on %{date}.'
-      date_expires: 'The listing will appear on the service until %{application_deadline}, after which it will no longer be visible to jobseekers.'
+      date_expires: >-
+        The listing will appear on the service until %{application_deadline},
+        after which it will no longer be visible to jobseekers.
       feedback_link: 'What did you think of this service?'
       feedback_time: '(takes 30 seconds)'
     aria_labels:
@@ -319,31 +362,44 @@ en:
       change_job_summary: 'Change job summary'
       apply_link: 'Learn more about this role and how to apply for it (link opens external website in a new window)'
       contact_email_link: 'Email link for job contact email — %{email}'
-      application_link_url: 'Link for jobseekers to learn more and apply (link opens external website in a new window) — %{url}'
+      application_link_url: >-
+        Link for jobseekers to learn more and apply (link opens external website in a new window) — %{url}
       flexible_working: 'Flexible working'
       newly_qualified_teacher: 'Newly qualified teacher'
       sort_by_link: Sort jobs by %{column} in %{order}ending order
     form_hints:
-      job_title: "For secondary school roles include subject and, if relevant, level of seniority ('Subject leader for science', for example)."
+      job_title: >-
+        For secondary school roles include subject and, if relevant,
+        level of seniority ('Subject leader for science', for example).
       job_role: 'Select all that describe the role'
       description: 'Briefly describe the duties and responsibilities involved in the role (minimum 10 characters)'
       subject: 'What subject will the teacher focus on?'
-      salary_range: 'Enter full-time equivalent annual salary, before tax (for example, 30,000 for a half-time role that pays £15,000 per year)'
+      salary_range: >-
+        Enter full-time equivalent annual salary, before tax (for example,
+        30,000 for a half-time role that pays £15,000 per year)
       supporting_subject: 'What other subject will the teacher focus on?'
-      working_patterns: Select all working patterns you will consider for the role. Flexible working options may attract more candidates.
+      working_patterns: >-
+        Select all working patterns you will consider for the role.
+        Flexible working options may attract more candidates.
       newly_qualified_teacher: 'Tick this box if it is suitable for newly qualified teachers.'
       start_date: 'For example, %{date}'
       end_date: 'For example, %{date}'
       education: 'State any formal education needed for the role (undergraduate degree, for example)'
-      qualifications: 'List any qualifications needed for this role (<span arial-label="Qualified Teacher Status">QTS</span>, for example)'
+      qualifications: >-
+        List any qualifications needed for this role
+        (<span arial-label="Qualified Teacher Status">QTS</span>, for example)
       experience: 'Expected teaching or other experience'
       deadline_date: 'For example, %{date}'
       publication_date: 'For example, %{date}'
       contact_email: 'This email address will be shown publicly as a point of contact'
-      application_link: 'Enter the URL for the page on your school or trust’s website that gives further details on the job and how to apply.'
+      application_link: >-
+        Enter the URL for the page on your school or trust’s website that gives further details on the job
+        and how to apply.
       application_deadline_time: 'For example, 9:00 am or 5:00 pm'
     form_warnings:
-      working_pattern: If you select flexible working patterns (anything other than 'full-time') candidates will be asked to email you for details.
+      working_pattern: >-
+        If you select flexible working patterns (anything other than 'full-time')
+        candidates will be asked to email you for details.
     filters:
       title: 'Search job listings'
       location: 'Location'
@@ -387,23 +443,30 @@ en:
     rating4_option: Satisfied
     rating5_option: Very satisfied
     comment_label_html: "How could we improve this service? (<span class='text-red'>Required</span>)"
-    comment_hint_text: '<p>Please do not include any information that could identify you personally (such as your name or the name of your school).</p><p>(Limit is 1,200 characters)</p>'
+    comment_hint_text: >-
+      <p>Please do not include any information that could identify you personally
+      (such as your name or the name of your school).</p><p>(Limit is 1,200 characters)</p>
     submit: 'Submit feedback'
   general_feedback:
     new:
       page_description: Tell us how we can improve Teaching Vacancies and volunteer as a user research participant.
     visit_purpose_legend_html: "What did you come to Teaching Vacancies to do? (<span class='text-red'>Required</span>)"
-    visit_purpose_hint_text: '<p>Please tell us what you came here to do. Do not include any information that could identify you personally (such as your name or the name of your school).</p><p>(Limit is 1,200 characters)</p>'
+    visit_purpose_hint_text: >-
+      <p>Please tell us what you came here to do. Do not include any information that could identify you personally
+      (such as your name or the name of your school).</p><p>(Limit is 1,200 characters)</p>
     visit_purpose_options:
       find_teaching_job: Find a job in teaching
       list_teaching_job: List a teaching job on the service
       other_purpose: Something else (tell us in the box below)
-    user_participation_legend_html: "Would you like to participate in our research? (<span class='text-red'>Required</span>)"
+    user_participation_legend_html:
+      "Would you like to participate in our research? (<span class='text-red'>Required</span>)"
     user_participation_options:
       interested: 'Yes'
       not_interested: 'No'
     user_interested_email_heading: 'What is your email address?'
-    user_interested_email_text: "We'll only use this to tell you about opportunities to take part in user research that helps us improve Department for Education services."
+    user_interested_email_text: >-
+      We'll only use this to tell you about opportunities to take part in user research that helps us improve
+      Department for Education services.
   schools:
     school_overview: 'School overview'
     address: 'Address'
@@ -462,7 +525,8 @@ en:
     location_radius_text: Within %{radius} miles of %{location}
     location_category_text: In %{location}
     reference: 'for'
-    next_steps: "You'll receive a single job alert email at the end of any day when 1 or more matching jobs are first published."
+    next_steps:
+      "You'll receive a single job alert email at the end of any day when 1 or more matching jobs are first published."
     confirmation:
       header: 'Your email subscription has started'
       receipt_confirmation: We have sent a confirmation email to %{email}.
@@ -504,7 +568,9 @@ en:
           unsubscribe: Don’t want to receive these email alerts? %{unsubscribe_link}
   terms_and_conditions:
     page_title: 'Terms and Conditions'
-    intro: 'Before listing any role at your school on Teaching Vacancies you must first read our Terms and Conditions and agree to abide by them.'
+    intro: >-
+      Before listing any role at your school on Teaching Vacancies you must first read our Terms and Conditions and
+      agree to abide by them.
     intro_link: 'Of particular importance is the section %{link} which includes:'
     summary_list:
       - 'Using the Service'
@@ -515,7 +581,10 @@ en:
     label: 'I agree to all of the Terms and Conditions of the Teaching Vacancies service.'
   stats:
     title: Statistics
-    intro: This page is an event log used by the service team to measure and monitor the stability and performance of Teaching Vacancies. It keeps a live count of key user interactions with the service since 20 April 2018 (the date we began recording statistics).
+    intro: >-
+      This page is an event log used by the service team to measure and monitor the stability and performance of
+      Teaching Vacancies. It keeps a live count of key user interactions with the service since 20 April 2018
+      (the date we began recording statistics).
   buttons:
     accept_and_continue: 'Accept and continue'
     apply_filters: 'Search'
@@ -577,26 +646,38 @@ en:
       title: The email you're signed in with isn't authorised to list jobs for this school
       without_email:
         text:
-          - You can register your interest to use the service by emailing %{mailto_url}. It is currently open to schools in Cambridgeshire and the North East but will be rolled out in phases to other areas across England.
+          - You can register your interest to use the service by emailing %{mailto_url}.
+            It is currently open to schools in Cambridgeshire and the North East but will be rolled out in
+            phases to other areas across England.
 
-          - If your Teaching Vacancies account has already been set up but you are unable to sign in, email the same address with "help" in the subject line.
+          - If your Teaching Vacancies account has already been set up but you are unable to sign in,
+            email the same address with "help" in the subject line.
       with_email:
         text:
-          - You've tried to sign in with %{email}, which is not authorised to list jobs for this school. If you have an authorised account associated with another email, you must sign %{email} out of DfE Sign-in, then sign into Teaching Vacancies with your authorised email. You can do this at %{signin_url}
+          - You've tried to sign in with %{email}, which is not authorised to list jobs for this school.
+            If you have an authorised account associated with another email, you must sign %{email} out of DfE Sign-in,
+            then sign into Teaching Vacancies with your authorised email. You can do this at %{signin_url}
 
           - <h2 class="govuk-heading-m">If you are signing in with an authorised email</h2>
 
-          - If you know the email you’ve signed in with is authorised then there could be a technical issue. Please try using a different web browser to sign in or, if this fails, email %{mailto_url} with 'help' in the subject line.
+          - If you know the email you’ve signed in with is authorised then there could be a technical issue.
+            Please try using a different web browser to sign in or, if this fails, email %{mailto_url} with 'help'
+            in the subject line.
 
           - <h2 class="govuk-heading-m">If you need an account</h2>
 
-          - If you don’t have an authorised Teaching Vacancies account, you can get one if you work at a publicly funded school or trust providing primary or secondary education in England and have your headteacher or CEO’s approval. Just ask them to send your full name and email address to %{mailto_url}. Or email us your details directly, copying in your headteacher or CEO.
+          - If you don’t have an authorised Teaching Vacancies account, you can get one if you work at a publicly
+            funded school or trust providing primary or secondary education in England and have your headteacher or
+            CEO’s approval. Just ask them to send your full name and email address to %{mailto_url}. Or email us your
+            details directly, copying in your headteacher or CEO.
     cookies:
       title: Cookies
       name: Name
       purpose: Purpose
       expires: Expires
-      explainer: "'Teaching Vacancies' puts small files (known as 'cookies') onto your computer to collect information about how you use the service."
+      explainer: >-
+        "'Teaching Vacancies' puts small files (known as 'cookies') onto your computer to collect information about
+        how you use the service."
       cookies_are_used_to:
         title: 'Cookies are used to:'
         list:
@@ -610,14 +691,19 @@ en:
         title: How we use cookies
         analytics:
           title: Measuring website usage (Google Analytics)
-          line_1: We use Google Analytics software to collect information about how you use 'Teaching Vacancies'. We do this to help make sure the service is meeting the needs of its users and to help us make improvements.
+          line_1: >-
+            We use Google Analytics software to collect information about how you use 'Teaching Vacancies'.
+            We do this to help make sure the service is meeting the needs of its users and to help us make improvements.
           line_2: 'Google Analytics stores information about:'
           list:
             - the pages you visit on 'Teaching Vacancies'
             - how long you spend on each page
             - how you got to the site
             - what you click on while you're visiting the site
-          share_data_with_gds: We also share anonymised Google Analytics data with the Government Digital Service for the purpose of improving the user's experience across the government’s digital services. This data does not contain any information that could reveal the identity of individual users of the service.
+          share_data_with_gds: >-
+            We also share anonymised Google Analytics data with the Government Digital Service for the purpose of
+            improving the user's experience across the government’s digital services. This data does not contain any
+            information that could reveal the identity of individual users of the service.
           line_3: We don't allow Google to use or share our analytics data.
           line_4: 'Google Analytics sets the following cookies:'
           you_can_opt_out: You can %{opt_out_url}
@@ -627,13 +713,19 @@ en:
         about: A cookie is set to record your session activity.
       introductory_message:
         title: Our introductory message
-        about: You may see a pop-up welcome message when you first visit 'Teaching Vacancies'. We'll store a cookie so that your computer knows you've seen it and knows not to show it again.
+        about: >-
+          You may see a pop-up welcome message when you first visit 'Teaching Vacancies'.
+          We'll store a cookie so that your computer knows you've seen it and knows not to show it again.
       types:
         ga:
-          purpose: This helps us count how many people visit teaching-vacancies.service.gov.uk by tracking if you've visited before
+          purpose: >-
+            This helps us count how many people visit teaching-vacancies.service.gov.uk by tracking if
+            you've visited before
           expires: After 2 years
         gid:
-          purpose: This helps us count how many people visit teaching-vacancies.service.gov.uk by tracking if you've visited before
+          purpose: >-
+            This helps us count how many people visit teaching-vacancies.service.gov.uk by tracking if
+            you've visited before
           expires: After 24 hours
         gat:
           purpose: This helps us limit the number of page view requests that Google records per minute
@@ -658,13 +750,18 @@ en:
       title: 'Privacy Notice: Teaching Vacancies'
       who_we_are:
         title: Who we are
-        about: This work is being carried out by the Department for Education (DfE) Digital, which is a part of DfE. DfE engages the private company Made Tech to help improve and provide the service. For the purpose of data protection legislation, DfE is the data controller for the personal data processed as part of Teaching Vacancies. Teaching Vacancies is a free and optional service for schools to list teaching roles.
+        about: >-
+          This work is being carried out by the Department for Education (DfE) Digital, which is a part of DfE.
+          DfE engages the private company Made Tech to help improve and provide the service. For the purpose of data
+          protection legislation, DfE is the data controller for the personal data processed as part of
+          Teaching Vacancies. Teaching Vacancies is a free and optional service for schools to list teaching roles.
       when_we_collect:
         title: When we collect personal information
         about: 'We receive your personal data when you submit it:'
         list:
           - when contacting us for support using the service, to leave feedback or for any other matters
-          - as a headteacher or other authorised person at a school when selecting which hiring staff can create Teaching Vacancies accounts
+          - as a headteacher or other authorised person at a school when selecting which hiring staff can create
+            Teaching Vacancies accounts
           - as hiring staff in order to create a Teaching Vacancies account
           - as a contact person for a job that has been listed on Teaching Vacancies
           - as a jobseeker signing up to emailed job alerts
@@ -674,34 +771,62 @@ en:
         list:
           - your name, email and (if applicable) your phone number when you contact us
           - your email address when you sign up for a job alert
-          - your email address if you include it with feedback to us on the service or agree to be contacted for user research purposes
-          - email addresses that are shared with us by schools for the purposes of creating a Teaching Vacancies account and posting jobs
-          - personal information such as the name and email of a contact person at your school, if you choose to share this in a job listing you post to Teaching Vacancies
+          - your email address if you include it with feedback to us on the service or agree to be
+            contacted for user research purposes
+          - email addresses that are shared with us by schools for the purposes of creating a Teaching Vacancies
+            account and posting jobs
+          - personal information such as the name and email of a contact person at your school, if you choose to share
+            this in a job listing you post to Teaching Vacancies
       how_we_use:
         title: How we will use your information
         text:
-          - If you contact us, DfE and (where applicable) Made Tech will use your name and contact information for the purpose of responding to you and providing support. We will not share this information with any other parties.
-          - If you sign up for a job alert your email address will be used exclusively for the purpose of sending you an email when a job meeting your chosen search criteria is published to the service.
-          - To list jobs on the service, hiring staff at schools need a Teaching Vacancies account, which requires them to supply their name and email address. Names and email addresses shared with us for this purpose are not shared by us with other parties.
-          - Information published in job listings may be used by third party job listing sites that use our job listing data via an application programming interface (API), as described in our Terms and Conditions. We are not responsible for how a third party handles any personal information you choose to include in a job listing.
-          - If you indicate in the feedback form that we can contact you for user research then we may use your email for that purpose. It will not be shared with third parties.
+          - If you contact us, DfE and (where applicable) Made Tech will use your name and contact information for the
+            purpose of responding to you and providing support. We will not share this information with any other
+            parties.
+          - If you sign up for a job alert your email address will be used exclusively for the purpose of sending you
+            an email when a job meeting your chosen search criteria is published to the service.
+          - To list jobs on the service, hiring staff at schools need a Teaching Vacancies account, which requires them
+            to supply their name and email address. Names and email addresses shared with us for this purpose are not
+            shared by us with other parties.
+          - Information published in job listings may be used by third party job listing sites that use our job listing
+            data via an application programming interface (API), as described in our Terms and Conditions. We are not
+            responsible for how a third party handles any personal information you choose to include in a job listing.
+          - If you indicate in the feedback form that we can contact you for user research then we may use your email
+            for that purpose. It will not be shared with third parties.
       why_its_lawful:
         title: Why our use of your personal data is lawful
-        about: In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation. For the purpose of this project, your consent forms the basis of this as stated under GDPR Article 6 (1)(a).
+        about: >-
+          In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data
+          protection legislation. For the purpose of this project, your consent forms the basis of this as stated under
+          GDPR Article 6 (1)(a).
       who_we_make_available_to:
         title: Who we will make your personal data available to
-        line_1: We sometimes need to make personal data available to other organisations. These might include contracted partners (who we have employed to process your personal data on our behalf) and/or other organisations (with whom we need to share your personal data for specific purposes).
-        line_2: Where we need to share your personal data with others, we ensure that this data sharing complies with data protection legislation. We share specific types of personal data with dxw and Made Tech, who have been contracted by DfE to manage the delivery and hosting of the digital service.
+        line_1: >-
+          We sometimes need to make personal data available to other organisations. These might include contracted
+          partners (who we have employed to process your personal data on our behalf) and/or other organisations
+          (with whom we need to share your personal data for specific purposes).
+        line_2: >-
+          Where we need to share your personal data with others, we ensure that this data sharing complies with data
+          protection legislation. We share specific types of personal data with dxw and Made Tech, who have been
+          contracted by DfE to manage the delivery and hosting of the digital service.
         line_3: 'The firms dxw and Made Tech use your data:'
         list:
-          - 'for security purposes: collecting part of the IP addresses of people visiting the Teaching Vacancies website (for example, if we were receiving continuous direct denial of service attacks from an IP address range then we could block it)'
-          - 'to enable users to use the service and receive updates: collecting the emails of those publishing job listings on Teaching Vacancies and those signing up to job alerts'
+          - 'for security purposes: collecting part of the IP addresses of people visiting the Teaching Vacancies
+            website (for example, if we were receiving continuous direct denial of service attacks from an IP address
+            range then we could block it)'
+          - 'to enable users to use the service and receive updates: collecting the emails of those publishing job
+            listings on Teaching Vacancies and those signing up to job alerts'
       how_long:
         title: How long we will keep your personal data
         text:
-          - Neither DfE nor its delivery partners will keep your personal data longer than we need it for the purpose(s) of research, security and/or delivery of the service, and in any case not longer than 7 years. Your data will be deleted when DfE and its delivery partners no longer need it for these purposes, or when 7 years have passed, whichever comes first.
-          - Partial IP addresses will be deleted after 7 days unless their request caused an error, in which case they remain in our logs for 30 days.
-          - If you share personal information in a job listing we will retain this while the job vacancy is live and for one year after it has expired.
+          - Neither DfE nor its delivery partners will keep your personal data longer than we need it for the purpose(s)
+            of research, security and/or delivery of the service, and in any case not longer than 7 years. Your data
+            will be deleted when DfE and its delivery partners no longer need it for these purposes, or when 7 years
+            have passed, whichever comes first.
+          - Partial IP addresses will be deleted after 7 days unless their request caused an error, in which case they
+            remain in our logs for 30 days.
+          - If you share personal information in a job listing we will retain this while the job vacancy is live and
+            for one year after it has expired.
       your_rights:
         title: Your data protection rights
         line_1: 'You have the right:'
@@ -710,20 +835,31 @@ en:
           - to have your personal data rectified, if it is inaccurate or incomplete
           - to ask us to delete your personal data unless there is a legal reason to continue to store and process it
           - to restrict our processing of your personal data (i.e. permitting its storage but no further processing)
-          - to object to direct marketing (including profiling) and processing for the purposes of scientific/historical research and statistics
-          - not to be subject to decisions based purely on automated processing where it produces a legal or similarly significant effect on you
-        line_2: If you need to contact us regarding any of the above, or have any other questions about how your personal information will be used, please %{contact_the_dfe_url}.
-        line_3: The Information Commissioner's Office makes further information about your data protection rights available in their %{gdpr_url}.
+          - to object to direct marketing (including profiling) and processing for the purposes of scientific/historical
+            research and statistics
+          - not to be subject to decisions based purely on automated processing where it produces a legal or similarly
+            significant effect on you
+        line_2: >-
+          If you need to contact us regarding any of the above, or have any other questions about how your
+          personal information will be used, please %{contact_the_dfe_url}.
+        line_3: >-
+          The Information Commissioner's Office makes further information about your data protection rights available
+          in their %{gdpr_url}.
         contact_the_dfe: contact the DfE
         gdpr: Guide to the General Data Protection Regulation (GDPR)
       withdrawal_of_consent:
         title: Withdrawal of consent and the right to lodge a complaint
-        line_1: Where we are processing your personal data with your consent, you have the right to withdraw that consent. If you change your mind, or you are unhappy with our use of your personal data, please let us know by emailing %{mailto}.
+        line_1: >-
+          Where we are processing your personal data with your consent, you have the right to withdraw that consent.
+          If you change your mind, or you are unhappy with our use of your personal data, please let us know by emailing
+          %{mailto}.
         line_2: You also have the right to raise any concerns with the %{ico_url}.
         ico: Information Commissioner’s Office (ICO)
       last_updated:
         title: Last updated
-        line_1: We may need to update this privacy notice periodically so we recommend that you revisit this information from time to time. This version was last updated on 18 June 2019.
+        line_1: >-
+          We may need to update this privacy notice periodically so we recommend that you revisit this information from
+          time to time. This version was last updated on 18 June 2019.
     terms_and_conditions:
       title: Terms and Conditions
       all_users:
@@ -731,168 +867,316 @@ en:
         using_the_website:
           title: Using the Service
           text:
-            - Access and use by you of the Teaching Vacancies website (the "Service") constitutes your acceptance of these Terms and Conditions ("General Terms"). This takes effect from the date on which you first use the Service. If you do not agree to these General Terms, you must not use this website.
+            - Access and use by you of the Teaching Vacancies website (the "Service") constitutes your acceptance of
+              these Terms and Conditions ("General Terms"). This takes effect from the date on which you first use the
+              Service. If you do not agree to these General Terms, you must not use this website.
             - By using Teaching Vacancies you agree to abide by the following terms and conditions.
-            - If we change these General Terms we will post the revised document here with an updated effective date. If we make significant changes to these terms, we may notify you by other means such as sending an email or posting a notice on our home page.
+            - If we change these General Terms we will post the revised document here with an updated effective date.
+              If we make significant changes to these terms, we may notify you by other means such as sending an email
+              or posting a notice on our home page.
         information_about_us:
           title: Information About Us
           text:
-            - This Service is operated by [the Department for Education] (“<strong>we</strong>”, “<strong>our</strong>”, or “<strong>us</strong>”). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
-            - "You can contact us using the following email address: <a href='mailto: %{help_email}' class='govuk-link'>%{help_email}</a>"
+            - This Service is operated by [the Department for Education] (“<strong>we</strong>”, “<strong>our</strong>”,
+              or “<strong>us</strong>”). We are a central government department and have our registered office at
+              Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
+            - "You can contact us using the following email address: <a href='mailto: %{help_email}'
+              class='govuk-link'>%{help_email}</a>"
         access_to_the_site:
           title: Access to the Site
           text:
-            - We shall not be liable if for any reason the Site is unavailable at any time or for any period. From time to time, we may restrict access to all or some parts of the Site to users who have registered with us.
-            - If you choose, or are provided with, a user identification code, password or any other piece of information as part of our security procedures, you must treat such information as confidential, and you must not disclose it to any third party.
-            - We reserve the right to restrict or deny you access to all or some part of the Site if in our opinion, you have failed to comply with these General Terms.
+            - We shall not be liable if for any reason the Site is unavailable at any time or for any period.
+              From time to time, we may restrict access to all or some parts of the Site to users who have
+              registered with us.
+            - If you choose, or are provided with, a user identification code, password or any other piece of
+              information as part of our security procedures, you must treat such information as confidential,
+              and you must not disclose it to any third party.
+            - We reserve the right to restrict or deny you access to all or some part of the Site if in our opinion,
+              you have failed to comply with these General Terms.
         hyperlinking:
           title: Hyperlinking to the Teaching Vacancies website
           text:
-            - We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The Teaching Vacancies pages must be displayed in the user's entire browser window.
+            - We do not object to you linking directly to pages on this site and you do not need to ask permission to
+              do so. However, we do not permit our pages to be loaded into frames on your site. \
+              The Teaching Vacancies pages must be displayed in the user's entire browser window.
             - You may not charge your website's users to click on a link to any page on the Service.
         third_party_content:
           title: Third Party Content and Hyperlinking from the Service
           text:
-            - We are not liable or responsible for the third party content on the Service. Third party content includes, for example, material posted by other users of the Service, job listings and display advertising.
-            - Where the Service contains links to other sites and resources, we are not liable or responsible for the content or reliability of those websites and resources and do not necessarily endorse the views expressed within them.
-            - We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.
+            - We are not liable or responsible for the third party content on the Service. Third party content includes,
+              for example, material posted by other users of the Service, job listings and display advertising.
+            - Where the Service contains links to other sites and resources, we are not liable or responsible for the
+              content or reliability of those websites and resources and do not necessarily endorse the views expressed within them.
+            - We aim to replace broken links to other sites but cannot guarantee that these links will always work as
+              we have no control over the availability of other sites.
         virus_protection:
           title: Virus protection
           text:
-            - We make every effort to check and test material at all stages of production. It is always wise for you to run an anti-virus program on all material downloaded from the Internet as we do not guarantee our service will be secure or free from bugs or viruses. We cannot accept any responsibility for any loss, disruption or damage to your data or your computer system which may occur whilst using material derived from this website.
-            - You must not misuse our service by knowingly introducing viruses, trojans, worms, logic bombs or other material that is malicious or technologically harmful. You must not attempt to gain unauthorised access to our service, the server on which our service is stored or any server, computer or database connected to our service. You must not attack our site via a denial-of-service attack or a distributed denial-of service attack. Each of these acts is a criminal offence. We will report any such offence to the relevant law enforcement authorities and co-operate with them to determine your identity.
+            - We make every effort to check and test material at all stages of production. It is always wise for you to
+              run an anti-virus program on all material downloaded from the Internet as we do not guarantee our service
+              will be secure or free from bugs or viruses. We cannot accept any responsibility for any loss, disruption
+              or damage to your data or your computer system which may occur whilst using material derived from this
+              website.
+            - You must not misuse our service by knowingly introducing viruses, trojans, worms, logic bombs or other
+              material that is malicious or technologically harmful. You must not attempt to gain unauthorised access
+              to our service, the server on which our service is stored or any server, computer or database connected
+              to our service. You must not attack our site via a denial-of-service attack or a distributed denial-of
+              service attack. Each of these acts is a criminal offence. We will report any such offence to the relevant
+              law enforcement authorities and co-operate with them to determine your identity.
         disclaimer_and_liability:
           title: Disclaimer and Liability
-          line_1: 'The content of this Service includes both content created by us (included but not limited to content that helps you use the Service) and third-party content (included but not limited to job listings). We do not:'
+          line_1: >-
+            The content of this Service includes both content created by us (included but not limited to content that
+            helps you use the Service) and third-party content (included but not limited to job listings). We do not:
           list_1:
             - endorse third-party content
             - vouch for its accuracy
             - guarantee that the views, instructions and/or assertions expressed in it are our own
-          line_2: The content we create for the Service is not advice. You should verify any information on the Service yourself and use your own judgement before doing or not doing anything on the basis of the content.
-          line_3: Unless expressly stated in writing by us, the Service and material relating to government information, products and services (or to third party information, products and services), is provided 'as is', without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.
-          line_4: We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials.
+          line_2: >-
+            The content we create for the Service is not advice. You should verify any information on the Service
+            yourself and use your own judgement before doing or not doing anything on the basis of the content.
+          line_3: >-
+            Unless expressly stated in writing by us, the Service and material relating to government information,
+            products and services (or to third party information, products and services), is provided 'as is',
+            without any representation or endorsement made and without warranty of any kind whether express or implied,
+            including but not limited to the implied warranties of satisfactory quality, fitness for a particular
+            purpose, non-infringement, compatibility, security and accuracy.
+          line_4: >-
+            We do not warrant that the functions contained in the material contained in this site will be uninterrupted
+            or error free, that defects will be corrected, or that this site or the server that makes it available are
+            free of viruses or represent the full functionality, accuracy, reliability of the materials.
           line_5: 'In no event will we be liable for:'
           list_2:
-            - any action you may take as a result of relying on any information/materials provided on the Service or for any loss or damage suffered by you as a result of you taking such action  including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from or in connection with the use of the Service
-            - any dealings you have with third parties (e.g. other users or advertisers) that take place using or facilitated by the Service
+            - any action you may take as a result of relying on any information/materials provided on the Service or for
+              any loss or damage suffered by you as a result of you taking such action  including, without limitation,
+              indirect or consequential loss or damage, or any loss or damages whatsoever arising from or in connection
+              with the use of the Service
+            - any dealings you have with third parties (e.g. other users or advertisers) that take place using or
+              facilitated by the Service
         validity:
           title: Validity of these General Terms
-          line_1: If any of these terms and conditions are held to be invalid, unenforceable or illegal for any reason, the remaining terms and conditions will still apply.
+          line_1: >-
+            If any of these terms and conditions are held to be invalid, unenforceable or illegal for any reason,
+            the remaining terms and conditions will still apply.
         applicable_law:
           title: Applicable Law and Jurisdiction
-          line_1: These General Terms are governed by the laws of England and Wales. Any dispute arising under these General Terms will be subject to the exclusive jurisdiction of the courts of England and Wales.
+          line_1: >-
+            These General Terms are governed by the laws of England and Wales. Any dispute arising under these
+            General Terms will be subject to the exclusive jurisdiction of the courts of England and Wales.
       for_schools:
         title: Terms and Conditions for Schools and Trusts
         approving_user_accounts:
           title: Approving user accounts
           text:
-            - Users must be approved before they are given a Teaching Vacancies account for the purposes of publishing or managing job listings for a school or trust. Each school or trust must have a nominated 'approver' who is responsible for approving Teaching Vacancies accounts for users at that school or trust. An approver must only allow someone working for their school or trust to publish or manage job listings for their school or trust. Approvers must not create accounts for or allow third parties to publish or manage job listings on behalf of their school or trust. If the Teaching Vacancies team detects or is alerted to any account held by or used by third parties then that account will be deleted immediately.
+            - Users must be approved before they are given a Teaching Vacancies account for the purposes of publishing
+              or managing job listings for a school or trust. Each school or trust must have a nominated 'approver' who
+              is responsible for approving Teaching Vacancies accounts for users at that school or trust. An approve
+              must only allow someone working for their school or trust to publish or manage job listings for their
+              school or trust. Approvers must not create accounts for or allow third parties to publish or manage job
+              listings on behalf of their school or trust. If the Teaching Vacancies team detects or is alerted to any
+              account held by or used by third parties then that account will be deleted immediately.
         using_the_service:
           title: Using the Service
           text:
-            - Access and use by you of this Service constitutes your acceptance of these Terms and Conditions. This takes effect from the date on which you first use this website. If you do not agree to these terms, you must not use this website.
+            - Access and use by you of this Service constitutes your acceptance of these Terms and Conditions.
+              This takes effect from the date on which you first use this website. If you do not agree to these terms,
+              you must not use this website.
             - By using Teaching Vacancies you agree to abide by the following terms and conditions.
         unacceptable_use:
           title: Unacceptable Use
           line_1: 'You must not publish:'
           list:
-            - listings for teaching vacancies that aren’t relevant to the service, such as but not limited to non-teaching roles, supply teaching roles and unpaid positions
+            - listings for teaching vacancies that aren’t relevant to the service, such as but not limited to
+              non-teaching roles, supply teaching roles and unpaid positions
             - listings for unconfirmed or non-existent vacancies
-            - listings for any school or trust that is not state funded, that is not in England or that does not teach primary or secondary pupils
-            - offensive or inappropriate language, including but not limited to profanities or language pejorative of any group, such as racist, sexist or homophobic comments
-            - "discriminatory content: you must not state or imply in a job advert that you will discriminate against anyone (subject to certain exceptions under the Equality Act 2010 particularly those applying to schools with a religious character); for further information see GOV.UK’s <a href='https://www.gov.uk/employer-preventing-discrimination/recruitment' target='_blank' class='govuk-link'>guidance on discrimination in job adverts</a>"
-            - material that infringes any intellectual property rights, such as copyright and trademarks (this means generally that you must own the rights in everything you submit or must obtain permission from the rights owner to submit the material)
-            - material that is technically harmful (including, without limitation, computer viruses, logic bombs, Trojan horses, worms, harmful components, corrupted data or other malicious software or harmful data)
-            - material that encourages or teaches conduct that is a criminal offence, gives rise to civil liability, or is otherwise unlawful
+            - listings for any school or trust that is not state funded, that is not in England or that does not teach
+              primary or secondary pupils
+            - offensive or inappropriate language, including but not limited to profanities or language pejorative of
+              any group, such as racist, sexist or homophobic comments
+            - "discriminatory content: you must not state or imply in a job advert that you will discriminate against
+              anyone (subject to certain exceptions under the Equality Act 2010 particularly those applying to schools
+              with a religious character); for further information see GOV.UK’s
+              <a href='https://www.gov.uk/employer-preventing-discrimination/recruitment' target='_blank'
+              class='govuk-link'>guidance on discrimination in job adverts</a>"
+            - material that infringes any intellectual property rights, such as copyright and trademarks (this means
+              generally that you must own the rights in everything you submit or must obtain permission from the rights
+              owner to submit the material)
+            - material that is technically harmful (including, without limitation, computer viruses, logic bombs,
+              Trojan horses, worms, harmful components, corrupted data or other malicious software or harmful data)
+            - material that encourages or teaches conduct that is a criminal offence, gives rise to civil liability,
+              or is otherwise unlawful
         access_to_the_service:
           title: Access to the Service
           text:
-            - We will not be liable if for any reason the Service is unavailable at any time or for any period. From time to time, we may restrict access to all or some parts of the Service to users who have registered with us.
-            - If you choose, or are provided with, a user identification code, password or any other piece of information as part of our security procedures, you must treat such information as confidential, and you must not disclose it to any third party.
-            - We reserve the right to restrict or deny you access to all or some part of the Service if in our opinion you have failed to comply with these Terms and Conditions.
-            - The Department for Education withholds the right to withdraw without notice listings that breach these terms and to withdraw the access of users who breach them.
+            - We will not be liable if for any reason the Service is unavailable at any time or for any period.
+              From time to time, we may restrict access to all or some parts of the Service to users who have
+              registered with us.
+            - If you choose, or are provided with, a user identification code, password or any other piece of
+              information as part of our security procedures, you must treat such information as confidential,
+              and you must not disclose it to any third party.
+            - We reserve the right to restrict or deny you access to all or some part of the Service if in our opinion
+              you have failed to comply with these Terms and Conditions.
+            - The Department for Education withholds the right to withdraw without notice listings that breach these
+              terms and to withdraw the access of users who breach them.
         listing_data:
           title: Listing Data
           text:
-            - "Application Programming Interface (API) use: listings are published under the <a href='http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/' target='_blank' class='govuk-link'>Open Government License</a> (OGL), which permits a wide range of information in the public sector to be reused free of charge. This means the listing data on Teaching Vacancies will be available to third parties to publish on external sites after the pilot phase, aside from where <a href='http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/exceptions-to-ogl/' target='_blank' class='govuk-link'>exceptions to the OGL</a> prohibit it."
-            - "Data ownership: schools have sole responsibility for maintaining the accuracy and appropriateness of the data contained in their listings."
+            - "Application Programming Interface (API) use: listings are published under the
+              <a href='http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk\n
+              -government-licensing-framework/open-government-licence/' target='_blank'
+              class='govuk-link'>Open Government License</a> (OGL), which permits a wide range of information in the
+              public sector to be reused free of charge. This means the listing data on Teaching Vacancies will be
+              available to third parties to publish on external sites after the pilot phase, aside from where
+              <a href='http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk\n
+              -government-licensing-framework/open-government-licence/exceptions-to-ogl/' target='_blank'
+              class='govuk-link'>exceptions to the OGL</a> prohibit it."
+            - "Data ownership: schools have sole responsibility for maintaining the accuracy and appropriateness of the
+              data contained in their listings."
         for_api_users:
           title: Terms and Conditions for API users
-          line_1: "You are free to reuse job listing data under the terms of the <a href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/' target='_blank' class='govuk-link'>Open Government Licence</a> for public sector information with the following exception:"
-          list: you may not charge a school any fee or commission for contacting, interviewing or hiring a respondent to your advertisement or listing if it is based on Teaching Vacancies data that you have reused.
+          line_1: >-
+            You are free to reuse job listing data under the terms of the
+            <a href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'
+            target='_blank' class='govuk-link'>Open Government Licence</a> for public sector information with the
+            following exception:
+          list: >-
+            you may not charge a school any fee or commission for contacting, interviewing or hiring a respondent to
+            your advertisement or listing if it is based on Teaching Vacancies data that you have reused.
     accessibility:
       page_title: Accessibility
       title: Accessibility statement for Teaching Vacancies
       mission:
-        opening_text: "Teaching Vacancies is run by the Department for Education. We want as many people as possible to be able to use the service. For example, that means users should be able to:"
+        opening_text: >-
+          Teaching Vacancies is run by the Department for Education. We want as many people as possible to be able to
+          use the service. For example, that means users should be able to:
         list:
           - change colours, contrast levels and fonts
           - zoom in up to 300% without the text spilling off the screen
           - navigate most of the service using just a keyboard
           - navigate most of the service using speech recognition software
-          - listen to most of the content on Teaching Vacancies using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+          - listen to most of the content on Teaching Vacancies using a screen reader (including the most recent
+            versions of JAWS, NVDA and VoiceOver)
         closing_text: "We’ve also made the text on the service as simple as possible to understand."
       how_accessible:
         title: How accessible Teaching Vacancies is
-        text: "Teaching Vacancies is currently designated as 'partially accessible' according to the <a href='https://www.w3.org/TR/WCAG21/' target='_blank' class='govuk-link'>Web Content Accessibility Guidelines version (WCAG) 2.1</a> AA standard. All significant issues with accessibility are detailed in the Non-accessible content section, below."
+        text: >-
+          Teaching Vacancies is currently designated as 'partially accessible' according to the
+          <a href='https://www.w3.org/TR/WCAG21/' target='_blank' class='govuk-link'>Web Content Accessibility
+          Guidelines version (WCAG) 2.1</a> AA standard. All significant issues with accessibility are detailed in the
+          Non-accessible content section, below.
       reporting_accessibility_problems:
         title: Reporting accessibility problems with Teaching Vacancies
-        text: "We’re always looking to improve the accessibility of this service. If you find any problems that aren’t listed on this page or think we’re not meeting accessibility requirements, please email <a href='mailto: %{help_email}' class='govuk-link'>%{help_email}</a> with 'Accessibility issues' in the subject line of the email."
+        text: >-
+          "We’re always looking to improve the accessibility of this service. If you find any problems that aren’t
+          listed on this page or think we’re not meeting accessibility requirements, please email
+          <a href='mailto: %{help_email}' class='govuk-link'>%{help_email}</a> with 'Accessibility issues' in the
+          subject line of the email."
       enforcement_procedure:
         title: Enforcement procedure
-        text: "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <a href='https://www.equalityadvisoryservice.com/' class='govuk-link'>contact the Equality Advisory and Support Service (EASS)</a>."
+        text: >-
+          The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies
+          (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
+          If you’re not happy with how we respond to your complaint,
+          <a href='https://www.equalityadvisoryservice.com/' class='govuk-link'>contact the Equality Advisory and
+          Support Service (EASS)</a>.
       technical_information:
         title: "Technical information about Teaching Vacancies' accessibility"
         text:
-          - The Department for Education is committed to making its digital services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
-          - "This website is at present partially compliant with the <a href='https://www.w3.org/TR/WCAG21/' target='_blank' class='govuk-link'>WCAG 2.1</a> AA standard, due to those non-compliance issues listed below that are marked with (A) or (AA)."
+          - The Department for Education is committed to making its digital services accessible, in accordance with the
+            Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+          - "This website is at present partially compliant with the
+            <a href='https://www.w3.org/TR/WCAG21/' target='_blank' class='govuk-link'>WCAG 2.1</a> AA standard,
+            due to those non-compliance issues listed below that are marked with (A) or (AA)."
       non_accesssible:
         title: Non-accessible content
-        text: A number of issues related to the accessibility of Teaching Vacancies were raised in an accessibility audit conducted in May 2019. Most of these have been corrected but there are still a number of issues the Teaching Vacancies team is working to resolve. When these issues have been resolved we will update this statement and the compliance status of Teaching Vacancies.
+        text: >-
+          A number of issues related to the accessibility of Teaching Vacancies were raised in an accessibility audit
+          conducted in May 2019. Most of these have been corrected but there are still a number of issues the Teaching
+          Vacancies team is working to resolve. When these issues have been resolved we will update this statement and
+          the compliance status of Teaching Vacancies.
       non_compliance:
         title: Non-compliance with the accessibility regulations
-        text: The following accessibility issues have been identified and are grouped here according to which principle of accessibility criteria they fall under in the WCAG 2.1 guidelines.
+        text: >-
+          The following accessibility issues have been identified and are grouped here according to which principle of
+          accessibility criteria they fall under in the WCAG 2.1 guidelines.
         perceivable:
           heading: "'Perceivable'"
-          principle: "Principle: Information and user interface components must be presentable to users in ways they can perceive."
+          principle: >-
+            Principle: Information and user interface components must be presentable to users in ways they can
+            perceive.
           issue:
             text:
-            - "<strong class='strong'>Issue</strong>: Some images don’t have a text alternative, so the information in them isn’t available to people using a screen reader.<br /><strong class='strong'>Criterion failed</strong>: 1.1.1 Text Alternatives: Non-text content (AA)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
-            - "<strong class='strong'>Issue</strong>: The colour contrast ratio between text and its background colour on certain pages makes text difficult for visually impaired users to read. Increasing the text size will resolve this issue.<br /><strong class='strong'>Criterion failed</strong>: 1.4.3 Distinguishable: Contrast (Minimum) (AA)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
+            - "<strong class='strong'>Issue</strong>: Some images don’t have a text alternative, so the information
+              in them isn’t available to people using a screen reader.<br /><strong class='strong'>Criterion failed
+              </strong>: 1.1.1 Text Alternatives: Non-text content (AA)<br /><strong class='strong'>Will be
+              resolved</strong>: October/November 2019"
+            - "<strong class='strong'>Issue</strong>: The colour contrast ratio between text and its background colour
+              on certain pages makes text difficult for visually impaired users to read. Increasing the text size will
+              resolve this issue.<br /><strong class='strong'>Criterion failed</strong>: 1.4.3 Distinguishable:
+              Contrast (Minimum) (AA)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
         operable:
           heading: "'Operable'"
           principle: "Principle: User interface components and navigation must be operable."
           issue:
             text:
-              - "<strong class='strong'>Issue</strong>: The 'skip to content' link that allows users of assistive technology to skip navigation links and go straight to the main content isn't working in Internet Explorer.<br /><strong class='strong'>Criterion failed</strong>: 2.4.1 Navigable: Bypass Blocks (A)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
-              - "<strong class='strong'>Issue</strong>: Some hyperlinks on the service need more useful descriptions for users of screen readers, who require context for each link.<br /><strong class='strong'>Criterion failed</strong>: 2.4.9 Navigable: Link Purpose (Link Only) (AAA)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
-              - "<strong class='strong'>Issue</strong>: Header text on the page confirming to a user that they've signed up for a job alert skips a heading level (for example, jumping from an h2 level to an h4 level), which can cause confusion for users navigating pages with a screen reader.<br /><strong class='strong'>Criterion failed</strong>: 2.4.10 Navigable: Section headings (AAA)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
+              - "<strong class='strong'>Issue</strong>: The 'skip to content' link that allows users of assistive
+                technology to skip navigation links and go straight to the main content isn't working in Internet
+                Explorer.<br /><strong class='strong'>Criterion failed</strong>: 2.4.1 Navigable: Bypass Blocks (A)
+                <br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
+              - "<strong class='strong'>Issue</strong>: Some hyperlinks on the service need more useful descriptions
+                for users of screen readers, who require context for each link.<br /><strong class='strong'>Criterion
+                failed</strong>: 2.4.9 Navigable: Link Purpose (Link Only) (AAA)<br /><strong class='strong'>Will be
+                resolved</strong>: October/November 2019"
+              - "<strong class='strong'>Issue</strong>: Header text on the page confirming to a user that they've signed
+                up for a job alert skips a heading level (for example, jumping from an h2 level to an h4 level), which
+                can cause confusion for users navigating pages with a screen reader.<br /><strong class='strong'>
+                Criterion failed</strong>: 2.4.10 Navigable: Section headings (AAA)<br /><strong class='strong'>
+                Will be resolved</strong>: October/November 2019"
         robust:
           heading: "'Robust'"
-          principle: "Principle: Content must be robust enough that it can be interpreted by a wide variety of user agents, including assistive technologies."
+          principle: >-
+            Principle: Content must be robust enough that it can be interpreted by a wide variety of user agents,
+            including assistive technologies.
           issue:
             text:
-              - "<strong class='strong'>Issue</strong>: Users of screen readers aren't reliably notified when a page is loading or when jobs have been sorted by date. This leads to the focus remaining stationary.<br /><strong class='strong'>Criterion failed</strong>:  4.1.3 Compatible: Status messages (AA)<br /><strong class='strong'>Will be resolved</strong>: October/November 2019"
+              - "<strong class='strong'>Issue</strong>: Users of screen readers aren't reliably notified when a page is
+                loading or when jobs have been sorted by date. This leads to the focus remaining stationary.<br />
+                <strong class='strong'>Criterion failed</strong>:  4.1.3 Compatible: Status messages (AA)<br />
+                <strong class='strong'>Will be resolved</strong>: October/November 2019"
         not_in_scope:
           heading: "Content that’s not within the scope of the accessibility regulations"
-          text: The following accessibility issues have been identified but do not fall within the scope of the WCAG 2.1 guidelines for the reasons stated.
+          text: >-
+            The following accessibility issues have been identified but do not fall within the scope of the WCAG 2.1\
+            guidelines for the reasons stated.
           issue:
             text:
-              - "<strong class='strong'>Issue</strong>: The colour used to indicate when an element such as a radio button has received focus does not meet the expected ratio.  This is a GDS Design System issue, however, so is not within our scope to correct. Note that a subtle movement effect also helps convey the focus state of a button, for example, so colour contrast is not the only tactic we use for improving distinguishability.<br /><strong class='strong'>Criterion failed</strong>:  1.4.11 Distinguishable: Non-text contrast"
+              - "<strong class='strong'>Issue</strong>: The colour used to indicate when an element such as a radio
+                button has received focus does not meet the expected ratio.  This is a GDS Design System issue, however,
+                so is not within our scope to correct. Note that a subtle movement effect also helps convey the focus
+                state of a button, for example, so colour contrast is not the only tactic we use for improving
+                distinguishability.<br /><strong class='strong'>Criterion failed</strong>:  1.4.11 Distinguishable:
+                Non-text contrast"
       how_we_tested:
         title: How we tested this website
         opening_text:
-          - This website was last tested on 28 May 2019. The test was carried out by the Digital Accessibility Centre (DAC).
+          - This website was last tested on 28 May 2019. The test was carried out by the Digital Accessibility Centre
+            (DAC).
           - "DAC tested various combinations of the following for both desktop and mobile/tablet users:"
         list:
-          - assistive technologies (eg Jaws 16, NVDA, VoiceOver, Dragon Voice Activation, Keyboard, System inverted colours, Screen Magnification, Colour blind checks, Resizing content)
+          - assistive technologies (eg Jaws 16, NVDA, VoiceOver, Dragon Voice Activation, Keyboard, System inverted
+            colours, Screen Magnification, Colour blind checks, Resizing content)
           - browser environments (IE11, Firefox, Safari, Chrome)
-          - accessibility user groups (Blind, Deaf, Mobility, Colour blind, Dyslexia, Low Vision, Aspergers, Cognitive Impaired/Panic/Anxiety)
+          - accessibility user groups (Blind, Deaf, Mobility, Colour blind, Dyslexia, Low Vision, Aspergers,
+            Cognitive Impaired/Panic/Anxiety)
         closing_text:
           text: "DAC tested:"
           list:
-            - the hiring staff journey for listing a job on the service, available at <a href='https://teaching-vacancies.service.gov.uk/identifications/new' target='_blank' class='govuk-link'>https://teaching-vacancies.service.gov.uk/identifications/new</a>
-            - the jobseeker journey for searching for a teaching job and signing up for a job alert, available at <a href='https://teaching-vacancies.service.gov.uk/' target='_blank' class='govuk-link'>https://teaching-vacancies.service.gov.uk/</a>
+            - the hiring staff journey for listing a job on the service, available at
+              <a href='https://teaching-vacancies.service.gov.uk/identifications/new' target='_blank'
+              class='govuk-link'>https://teaching-vacancies.service.gov.uk/identifications/new</a>
+            - the jobseeker journey for searching for a teaching job and signing up for a job alert, available at
+              <a href='https://teaching-vacancies.service.gov.uk/' target='_blank'
+              class='govuk-link'>https://teaching-vacancies.service.gov.uk/</a>
       date_reviewed: This statement was prepared on 12 September 2019. It was last updated on 12 September 2019.
   shared:
     file_remove_confirmation_dialogue:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,7 +178,7 @@ en:
       leadership: 'Leadership'
       sen_specialist: 'SEN specialist'
       nqt_suitable: 'Suitable for NQTs'
-    job_description: 'Job description'    
+    job_summary: 'Job description'    
     salary: 'Salary'
     benefits: 'Employee benefits'
     salary_range_html: "Salary range (<span class='text-red'>Required</span>)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,7 +178,7 @@ en:
       leadership: 'Leadership'
       sen_specialist: 'SEN specialist'
       nqt_suitable: 'Suitable for NQTs'
-    job_summary: 'Job description'    
+    job_summary: 'Job summary'    
     salary: 'Salary'
     benefits: 'Employee benefits'
     salary_range_html: "Salary range (<span class='text-red'>Required</span>)"
@@ -422,7 +422,7 @@ en:
       bullets:
         mandatory:
           - 'a job title'
-          - 'a job description'
+          - 'a job summary'
           - 'working patterns'
           - 'a salary range'
           - 'educational requirements'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -226,6 +226,7 @@ en:
     deadline_time_html: "Time application is due (<span class='text-red'>Required</span>)"
     time_at: ' at '
     publication_date: 'Date role will be listed'
+    job_summary: 'Job summary'
     review: 'Review your entries for each section below, making any changes needed before you publish the listing.'
     review_future: 'Review your entries for each section below, making any changes before you submit the listing for publication.'
     edit: 'Edit the job details.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,9 @@ en:
         salary_html: "Salary (<span class='text-red'>Required</span>)"
       supporting_documents_form:
         supporting_documents_html: "Would you like to attach supporting documents? (<span class='text-red'>Required</span>)"
+      job_summary_form:
+        job_summary_html: "Job summary (<span class='text-red'>Required</span>)"
+        about_school_html: "About %{school} (<span class='text-red'>Required</span>)"
     hint:
       job_specification_form:
         starts_on: 'For example, 01 01 2020'
@@ -102,6 +105,9 @@ en:
         expires_on: 'For example, 01 08 2020'
       supporting_documents_form:
         supporting_documents: 'These could include, for example, a job description, person specification or application pack'
+      job_summary_form:
+        job_summary: 'Give a brief summary of the job that job seekers can quickly scan. This will be the first thing they see on the listing or in search engine results'
+        about_school: "This will appear next to the job details under 'School overview'. Feel free to adapt this text"
   jobs:
     current_step: "Step %{step} of %{total}"
     notification_labels:
@@ -227,6 +233,7 @@ en:
     time_at: ' at '
     publication_date: 'Date role will be listed'
     job_summary: 'Job summary'
+    about_school: 'About %{school}'
     review: 'Review your entries for each section below, making any changes needed before you publish the listing.'
     review_future: 'Review your entries for each section below, making any changes before you submit the listing for publication.'
     edit: 'Edit the job details.'
@@ -309,6 +316,7 @@ en:
       change_pay_package: 'Change pay package'
       change_supporting_documents: 'Change supporting documents'
       change_application_details: 'Change application details'
+      change_job_summary: 'Change job summary'
       apply_link: 'Learn more about this role and how to apply for it (link opens external website in a new window)'
       contact_email_link: 'Email link for job contact email — %{email}'
       application_link_url: 'Link for jobseekers to learn more and apply (link opens external website in a new window) — %{url}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
       resource :job_specification,
         only: %i[edit update],
         controller: 'hiring_staff/vacancies/job_specification',
-        defaults: { create_step: 1, step_title: I18n.t('jobs.job_specification') }
+        defaults: { create_step: 1, step_title: I18n.t('jobs.job_details') }
       resource :pay_package,
         only: %i[show update],
         controller: 'hiring_staff/vacancies/pay_package',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
     end
     resources :jobs, only: %i[new edit destroy delete show], controller: 'hiring_staff/vacancies' do
       get 'review',
-        defaults: { create_step: 5, step_title: I18n.t('jobs.review_heading') }
+        defaults: { create_step: 6, step_title: I18n.t('jobs.review_heading') }
       get 'preview'
       get 'summary'
       post :publish, to: 'hiring_staff/vacancies/publish#create'
@@ -77,6 +77,10 @@ Rails.application.routes.draw do
         only: %i[edit update],
         controller: 'hiring_staff/vacancies/application_details',
         defaults: { create_step: 4, step_title: I18n.t('jobs.application_details') }
+      resource :job_summary,
+        only: %i[show update],
+        controller: 'hiring_staff/vacancies/job_summary',
+        defaults: { create_step: 5, step_title: I18n.t('jobs.job_summary') }
       resource :feedback, controller: 'hiring_staff/vacancies/vacancy_publish_feedback', only: %i[new create]
       resource :statistics, controller: 'hiring_staff/vacancies/statistics', only: %i[update]
       resource :copy, only: %i[new create],

--- a/db/migrate/20200405081133_change_job_description_to_job_summary.rb
+++ b/db/migrate/20200405081133_change_job_description_to_job_summary.rb
@@ -1,0 +1,5 @@
+class ChangeJobDescriptionToJobSummary < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :vacancies, :job_description, :job_summary
+  end
+end

--- a/db/migrate/20200405090140_add_about_school_to_vacancies.rb
+++ b/db/migrate/20200405090140_add_about_school_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddAboutSchoolToVacancies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :vacancies, :about_school, :text
+  end
+end

--- a/db/migrate/20200406102653_change_job_summary_to_nullable_column.rb
+++ b/db/migrate/20200406102653_change_job_summary_to_nullable_column.rb
@@ -1,0 +1,5 @@
+class ChangeJobSummaryToNullableColumn < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :vacancies, :job_summary, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_05_090140) do
+ActiveRecord::Schema.define(version: 2020_04_06_102653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -184,7 +184,7 @@ ActiveRecord::Schema.define(version: 2020_04_05_090140) do
   create_table "vacancies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "job_title", null: false
     t.string "slug", null: false
-    t.text "job_summary", null: false
+    t.text "job_summary"
     t.string "minimum_salary", null: false
     t.string "maximum_salary"
     t.text "benefits"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_05_081133) do
+ActiveRecord::Schema.define(version: 2020_04_05_090140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -227,6 +227,7 @@ ActiveRecord::Schema.define(version: 2020_04_05_081133) do
     t.string "salary"
     t.integer "completed_step"
     t.string "job_roles", array: true
+    t.text "about_school"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["expiry_time"], name: "index_vacancies_on_expiry_time"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_01_125329) do
+ActiveRecord::Schema.define(version: 2020_04_05_081133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -184,7 +184,7 @@ ActiveRecord::Schema.define(version: 2020_04_01_125329) do
   create_table "vacancies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "job_title", null: false
     t.string "slug", null: false
-    t.text "job_description", null: false
+    t.text "job_summary", null: false
     t.string "minimum_salary", null: false
     t.string "maximum_salary"
     t.text "benefits"

--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -22,7 +22,7 @@ class ExportTablesToBigQuery
     frequency
     geolocation
     gias_data
-    job_description
+    job_summary
     qualifications
     supporting_documents
   ].freeze

--- a/lib/job_posting.rb
+++ b/lib/job_posting.rb
@@ -12,7 +12,7 @@ class JobPosting
   def map_schema_to_vacancy_fields
     {
       job_title: @schema['title'],
-      job_description: @schema['description'],
+      job_summary: @schema['description'],
       job_roles: @schema['jobRoles'],
       salary: @schema['salary'],
       benefits: @schema['jobBenefits'],

--- a/lib/job_posting.rb
+++ b/lib/job_posting.rb
@@ -12,7 +12,6 @@ class JobPosting
   def map_schema_to_vacancy_fields
     {
       job_title: @schema['title'],
-      job_summary: @schema['description'],
       job_roles: @schema['jobRoles'],
       salary: @schema['salary'],
       benefits: @schema['jobBenefits'],
@@ -25,6 +24,8 @@ class JobPosting
       contact_email: 'recruitment@school.invalid',
       publish_on: publish_on_or_today,
       expires_on: expires_on_or_future,
+      job_summary: @schema['description'],
+      about_school: @schema['aboutSchool'],
       school: school_by_urn_or_random
     }
   end

--- a/lib/tasks/vacancies_to_update.yaml
+++ b/lib/tasks/vacancies_to_update.yaml
@@ -8,9 +8,18 @@ vacancies:
     -
       slug: 'teacher-of-science-the-english-martyrs-school-and-sixth-form-college-hartlepool'
       job_title: 'Teacher of Science (2 posts)'
-      job_summary: "<p>Required from January 2019 – two ambitious, creative and enthusiastic teachers of Science.  The posts would suit either a new entrant to the profession or someone seeking to broaden their experience in our thriving 11-18 school. The ability to teach A-level Chemistry or Physics would be an advantage but is not essential.</p>
-      <p>It is an exciting time to join The English Martyrs School and Sixth Form College, following significant success during the Summer examinations, both in Science and across the school. We hope the successful candidate will play a significant role in the future as we strive to achieve excellence. We are also looking forward to moving into our new school with brand new facilities from September 2019.</p>
-      <p>The Directors and Local Governing Body are committed to safeguarding and promoting the welfare of children and young people and vulnerable adults. The successful candidate will be subject to an enhanced disclosure through the Disclosure and Barring Service, Prohibition Check and additional pre-employment checks.</p>
+      job_summary: >
+      "<p>Required from January 2019 – two ambitious, creative and enthusiastic teachers of Science.
+      The posts would suit either a new entrant to the profession or someone seeking to broaden their experience in our
+      thriving 11-18 school. The ability to teach A-level Chemistry or Physics would be an advantage
+      but is not essential.</p>
+      <p>It is an exciting time to join The English Martyrs School and Sixth Form College,
+      following significant success during the Summer examinations, both in Science and across the school.
+      We hope the successful candidate will play a significant role in the future as we strive to achieve excellence.
+      We are also looking forward to moving into our new school with brand new facilities from September 2019.</p>
+      <p>The Directors and Local Governing Body are committed to safeguarding and promoting the welfare of children and
+      young people and vulnerable adults. The successful candidate will be subject to an enhanced disclosure through the
+      Disclosure and Barring Service, Prohibition Check and additional pre-employment checks.</p>
       <p>Application forms should be returned to the Headteacher’s P.A. Lisa Foster lfoster@ems.hartlepool.sch.uk</p>
       <p>Shortlisting 15th October 2018</p>
       <p>Interviews w/c 22nd October 2018</p>
@@ -26,37 +35,70 @@ vacancies:
     -
       slug: 'teacher-of-english-norham-high-school'
       job_title: 'Teacher of English'
-      job_summary: "<p>Norham High school is seeking to appoint a Teacher of English who will join and strengthen the Department on a maternity cover contract. We are looking to appoint a dynamic and enthusiastic teacher with high expectations, who will be passionate about their subject, able to inspire and motivate young people, they must be committed to the highest standards of teaching and learning, through lesson planning, and high quality assessment.</p>
-      <p>The school is committed to safeguarding and promoting the welfare of children and young people and expects all staff and volunteers to share this commitment.  This post will require the successful applicant to apply for an enhanced disclosure with the Disclosure and Barring Service.</p>
-      <p>Norham High School is an 11 – 16 comprehensive school serving part of the South East locality of North Shields. The school is pupil-centred and enables pupils to have a real voice in our current and future improvements.</p>
-      <p>Applications for this post are invited from people who are keen to join an organisation that is recognised for the high quality care and support it provides for its pupils and staff, its committed staff team and the drive to raise standards at all levels.</p>
-      <p>For further information and to download an application form please visit our website (Join Us Section) at www.norhamhigh.com or, alternatively, to receive an application pack, telephone the school on 0191 2005062 or email the school at: norham.high@northtyneside.gov.uk.  The closing date for completed applications, to be addressed to Ms S Lennox, is 12 noon Friday 12 October 2018.</p>"
+      job_summary: >
+      "<p>Norham High school is seeking to appoint a Teacher of English who will join and strengthen the Department on a
+      maternity cover contract. We are looking to appoint a dynamic and enthusiastic teacher with high expectations,
+      who will be passionate about their subject, able to inspire and motivate young people, they must be committed to
+      the highest standards of teaching and learning, through lesson planning, and high quality assessment.</p>
+      <p>The school is committed to safeguarding and promoting the welfare of children and young people and expects all
+      staff and volunteers to share this commitment.  This post will require the successful applicant to apply for an
+      enhanced disclosure with the Disclosure and Barring Service.</p>
+      <p>Norham High School is an 11 – 16 comprehensive school serving part of the South East locality of North Shields.
+      The school is pupil-centred and enables pupils to have a real voice in our current and future improvements.</p>
+      <p>Applications for this post are invited from people who are keen to join an organisation that is recognised for
+      the high quality care and support it provides for its pupils and staff, its committed staff team and the drive to
+      raise standards at all levels.</p>
+      <p>For further information and to download an application form please visit our website (Join Us Section) at
+      www.norhamhigh.com or, alternatively, to receive an application pack, telephone the school on 0191 2005062 or
+      email the school at: norham.high@northtyneside.gov.uk.  The closing date for completed applications, to be
+      addressed to Ms S Lennox, is 12 noon Friday 12 October 2018.</p>"
       experience: "<p>To be successful, you will:</p>
-      <ul><li>be an excellent practitioner who thinks creatively and has the potential and desire to continue to improve</li>
-      <li>have a passion for English along with excellent subject knowledge and be able to communicate this to students, with particular strength in teaching the AQA English Language and English Literature courses.</li>
-      <li>be an effective and committed team player who values the opportunity to take risks and who relishes challenge</li></ul>"
-      benefits: "<p>The school is working with Churchill Community College, a local outstanding teaching school, to accelerate progress. This partnership provides excellent CPD opportunities.</p>
-      <p>The school recognises that its staff are its greatest asset and this is highlighted through our innovative CPD programme and recognition for our work in Investors in People.</p>"
+      <ul><li>be an excellent practitioner who thinks creatively and has the potential and desire to continue to
+      improve</li>
+      <li>have a passion for English along with excellent subject knowledge and be able to communicate this to students,
+      with particular strength in teaching the AQA English Language and English Literature courses.</li>
+      <li>be an effective and committed team player who values the opportunity to take risks and who relishes
+      challenge</li></ul>"
+      benefits: "<p>The school is working with Churchill Community College, a local outstanding teaching school,
+      to accelerate progress. This partnership provides excellent CPD opportunities.</p>
+      <p>The school recognises that its staff are its greatest asset and this is highlighted through our
+      innovative CPD programme and recognition for our work in Investors in People.</p>"
     -
       slug: 'home-school-support-worker'
       job_title: 'Home School Support Worker'
-      job_summary: "<p>37 hours per week</p>
+      job_summary: >
+      "<p>37 hours per week</p>
       <p>Term time plus one week</p>
       <p>Grade M point 25 – 29</p>
-      <p>The successful candidate will undertake casework working alongside school and locality staff to address the needs of the children, who need support to overcome barriers to learn both inside and outside school; this will including assessment and appropriate management of attendance.</p>
-      <p>Application forms and further details for the above position are available from our website www.educationvillage.org.uk Applicants are encouraged to visit The Education Village by contacting Helen Blanchard-Wynne on 01325 248173 to arrange an appointment.</p>
+      <p>The successful candidate will undertake casework working alongside school and locality staff to address the
+      needs of the children, who need support to overcome barriers to learn both inside and outside school; this will
+      including assessment and appropriate management of attendance.</p>
+      <p>Application forms and further details for the above position are available from our website
+      www.educationvillage.org.uk Applicants are encouraged to visit The Education Village by contacting Helen
+      Blanchard-Wynne on 01325 248173 to arrange an appointment.</p>
       <p>Closing Date: 5.00pm on Friday 2nd November 2018</p>
       <p>Interviews will be held w/c Monday 5th November 2018</p>
-      <p>The Education Village Academy Trust (EVAT) is committed to safeguarding the welfare of children and young people. You will be required to undertake an enhanced Disclosure check and Disqualification declaration.</p>"
+      <p>The Education Village Academy Trust (EVAT) is committed to safeguarding the welfare of children and
+      young people. You will be required to undertake an enhanced Disclosure check and Disqualification declaration.</p>"
     -
-      slug: 'teacher-with-phase-leader-responsibility-for-pupils-with-special-educational-needs-mainly-to-teach-in-ks3-ks4'
-      job_title: 'Teacher with Phase Leader responsibility for pupils with Special Educational Needs (mainly to teach in KS3-KS4)'
-      job_summary: "<p>Cleaswell Hill School is a day community Special School for 181 children (designated age range 2-19). Some pupils have additional physical difficulties and medical needs while many are identified as being within the autistic spectrum.</p>
-      <p>We are committed to safeguarding and promoting the welfare of children and young people and expect all staff to share this commitment.  An enhanced criminal records check is required for this post.</p>
+      slug:
+        'teacher-with-phase-leader-responsibility-for-pupils-with-special-educational-needs-mainly-to-teach-in-ks3-ks4'
+      job_title: >
+        'Teacher with Phase Leader responsibility for pupils with Special Educational Needs
+        (mainly to teach in KS3-KS4)'
+      job_summary: >
+      "<p>Cleaswell Hill School is a day community Special School for 181 children (designated age range 2-19).
+      Some pupils have additional physical difficulties and medical needs while many are identified as being within
+      the autistic spectrum.</p>
+      <p>We are committed to safeguarding and promoting the welfare of children and young people and expect all staff to
+      share this commitment.  An enhanced criminal records check is required for this post.</p>
       <p>Further information about the school can be found on our website.</p>
-      <p>An application pack, including an application form, is available to download from the school’s website at  http://www.cleaswellhill.northumberland.sch.uk/site</p>
-      <p>Visits to school are encouraged and can be obtained by contacting Anne Carruthers, School Business Leader on 01670 823182.</p>
-      <p>Completed application forms should be returned directly to the school by post or e-mail, no later than midday on Monday 22 October 2019.  Interviews will be held on Thursday 25 October 2018.</p>
+      <p>An application pack, including an application form, is available to download from the school’s website at
+      http://www.cleaswellhill.northumberland.sch.uk/site</p>
+      <p>Visits to school are encouraged and can be obtained by contacting Anne Carruthers, School Business Leader on
+      01670 823182.</p>
+      <p>Completed application forms should be returned directly to the school by post or e-mail,
+      no later than midday on Monday 22 October 2019.  Interviews will be held on Thursday 25 October 2018.</p>
       <p>School Name: Cleaswell Hill School<br>
       Full address: School Avenue, Guidepost, Choppington, Northumberland<br>
       Postcode: NE62 5DJ<br>
@@ -67,38 +109,56 @@ vacancies:
       <ul><li>the ability to think and act strategically at whole school level;</li>
       <li>the ability to inspire and motivate others;</li>
       <li>successful line management of key areas of responsibility and holding others to account;</li>
-      <li>understanding of and empathy with the complex learning difficulties of our pupils and ensure that each one of them continues to achieve their full potential;</li>
+      <li>understanding of and empathy with the complex learning difficulties of our pupils and ensure
+      that each one of them continues to achieve their full potential;</li>
       <li>being an enthusiastic and inspiring teacher with excellent communication skills;</li>
-      <li>a passion for helping children and young people develop, learn and achieve their best – whatever their starting point.</li></ul>"
+      <li>a passion for helping children and young people develop,
+      learn and achieve their best – whatever their starting point.</li></ul>"
       benefits: "<p>In return we offer you:</p>
       <ul><li>career progression;</li>
       <li>an opportunity to work with inspirational children who have complex difficulties;</li>
       <li>the support of experienced, enthusiastic and dedicated staff;</li>
       <li>the opportunity for on-going personal and professional development;</li>
-      <li>a strong and effective governing body, which is both supportive and challenging and wholly committed to working in partnership</li></ul>"
+      <li>a strong and effective governing body,
+      which is both supportive and challenging and wholly committed to working in partnership</li></ul>"
       expires_on: '22/10/2018'
     -
       slug: 'teacher-of-chemistry-bede-academy'
       job_title: 'Teacher of Chemistry'
-      job_summary: "<p>We require from January 2019 a motivated and passionate graduate qualified to teach Chemistry at all levels, including ‘A’ level. The ability to demonstrate excellent subject knowledge and to consistently teach inspirational lessons is essential.</p>
-      <p>If you believe you have the vision and commitment to work in an Academy which seeks to raise achievement as well as set and maintain high standards and expectations, please contact Bede Academy.</p>
-      <p>For an application pack and further information, please visit www.bedeacademy.org.uk Alternatively, please call Mrs Hogg on 01670 545111, option 2 or email recruitment@bedeacademy.org.uk</p>
+      job_summary: >
+      "<p>We require from January 2019 a motivated and passionate graduate qualified to teach Chemistry at all levels,
+      including ‘A’ level. The ability to demonstrate excellent subject knowledge and to consistently teach
+      inspirational lessons is essential.</p>
+      <p>If you believe you have the vision and commitment to work in an Academy which seeks to raise achievement as
+      well as set and maintain high standards and expectations, please contact Bede Academy.</p>
+      <p>For an application pack and further information, please visit www.bedeacademy.org.uk Alternatively,
+      please call Mrs Hogg on 01670 545111, option 2 or email recruitment@bedeacademy.org.uk</p>
       <p>Interviews w/c: 26 November 2018</p>
-      <p>Bede Academy takes its responsibility for safeguarding children very seriously and successful applications will be subject to an Enhanced Disclosure and Barring Service Disclosure along with standard pre-employment safeguarding checks.</p>"
+      <p>Bede Academy takes its responsibility for safeguarding children very seriously and successful applications will
+      be subject to an Enhanced Disclosure and Barring Service Disclosure along with standard pre-employment
+      safeguarding checks.</p>"
     -
       slug: 'cover-supervisor-st-michael-s-catholic-academy'
       job_title: 'Cover Supervisor'
-      job_summary: "<p>St Michael’s Catholic Academy is a warmly welcoming and inclusive community with a determination to achieve the highest standards. We have strong expectations and an unswerving dedication to ensure that every student achieves their very best. Our Academy is a vibrant, forward thinking and Christ-centred place to work and we are looking to appoint a passionate and committed individual to join the Academy in the role of Cover Supervisor.</p>
+      job_summary: >
+      "<p>St Michael’s Catholic Academy is a warmly welcoming and inclusive community with a determination to achieve
+      the highest standards. We have strong expectations and an unswerving dedication to ensure that every student
+      achieves their very best. Our Academy is a vibrant, forward thinking and Christ-centred place to work and we are
+      looking to appoint a passionate and committed individual to join the Academy in the role of Cover Supervisor.</p>
       <p>Duties will include:</p>
       <ul><li>Supervising classes during the short term absence of teachers</li>
-      <li>Supervising students using the Learning Resource Centre for the first half hour of lunchtime and also after school for study/homework purposes</li>
+      <li>Supervising students using the Learning Resource Centre for the first half hour of lunchtime and also after
+      school for study/homework purposes</li>
       <li>Working under the guidance of the teaching staff and within an agreed system of supervision</li>
       <li>Implementing work programmes with individuals/groups in or out of the classroom</li>
       <li>Managing the behaviour of students being supervised</li>
       <li>Reporting to the Assistant Principal at the beginning and the end of the school day</li>
       <li>Following school policies and procedures</li></ul>
-      <p>The school is committed to safer recruitment practice and pre-employment checks will be undertaken before any appointment is confirmed. This post is subject to Enhanced Debarring Service disclosure.</p>
-      <p>For further information please contact Mrs F Magog on 01642 870003 or by email to recruitment@stmichaelsacademy.org.uk. Alternatively you can download an application pack for this post from our website, http://www.stmichaelsacademy.org.uk/</p>
+      <p>The school is committed to safer recruitment practice and pre-employment checks will be undertaken before any
+      appointment is confirmed. This post is subject to Enhanced Debarring Service disclosure.</p>
+      <p>For further information please contact Mrs F Magog on 01642 870003 or by email to
+      recruitment@stmichaelsacademy.org.uk. Alternatively you can download an application pack for this post from our
+      website, http://www.stmichaelsacademy.org.uk/</p>
       <p>The closing date for applications is 12 noon on Friday 2 November 2018.</p>"
       benefits: "<p>We will offer you:</p>
       <ul><li>Staff collaboration across Carmel Education Trust</li>
@@ -107,9 +167,15 @@ vacancies:
     -
       slug: 'teacher-of-music-maternity-cover-0-6'
       job_title: 'Teacher of Music / maternity cover 0.6'
-      job_summary: "<p>Required to start in January 2019 an enthusiastic, well-qualified Music specialist with the ability to teach Music up to GCSE and ‘A’ level. The Music Department is very successful and has a strong tradition of extra-curricular provision.</p>
-      <p>The post would suit either an experienced teacher wishing to extend their experience in our successful environment or a newly qualified teacher.</p>
-      <p>The Directors and Local Governing Body are committed to safeguarding and promoting the welfare of children and young people and vulnerable adults. The successful candidate will be subject to an enhanced disclosure through the Disclosure and Barring Service and additional recruitment checks.</p>
+      job_summary: >
+      "<p>Required to start in January 2019 an enthusiastic, well-qualified Music specialist with the ability to teach
+      Music up to GCSE and ‘A’ level. The Music Department is very successful and has a strong tradition of
+      extra-curricular provision.</p>
+      <p>The post would suit either an experienced teacher wishing to extend their experience in our successful
+      environment or a newly qualified teacher.</p>
+      <p>The Directors and Local Governing Body are committed to safeguarding and promoting the welfare of children and
+      young people and vulnerable adults. The successful candidate will be subject to an enhanced disclosure through
+      the Disclosure and Barring Service and additional recruitment checks.</p>
       <p>For further details and application form please visit our school website www.emshartlepool.org</p>
       <p>Closing Date: 7 November 2018 at 12 noon<br/>
       Shortlisting: 7 November 2018<br/>

--- a/lib/tasks/vacancies_to_update.yaml
+++ b/lib/tasks/vacancies_to_update.yaml
@@ -8,7 +8,7 @@ vacancies:
     -
       slug: 'teacher-of-science-the-english-martyrs-school-and-sixth-form-college-hartlepool'
       job_title: 'Teacher of Science (2 posts)'
-      job_description: "<p>Required from January 2019 – two ambitious, creative and enthusiastic teachers of Science.  The posts would suit either a new entrant to the profession or someone seeking to broaden their experience in our thriving 11-18 school. The ability to teach A-level Chemistry or Physics would be an advantage but is not essential.</p>
+      job_summary: "<p>Required from January 2019 – two ambitious, creative and enthusiastic teachers of Science.  The posts would suit either a new entrant to the profession or someone seeking to broaden their experience in our thriving 11-18 school. The ability to teach A-level Chemistry or Physics would be an advantage but is not essential.</p>
       <p>It is an exciting time to join The English Martyrs School and Sixth Form College, following significant success during the Summer examinations, both in Science and across the school. We hope the successful candidate will play a significant role in the future as we strive to achieve excellence. We are also looking forward to moving into our new school with brand new facilities from September 2019.</p>
       <p>The Directors and Local Governing Body are committed to safeguarding and promoting the welfare of children and young people and vulnerable adults. The successful candidate will be subject to an enhanced disclosure through the Disclosure and Barring Service, Prohibition Check and additional pre-employment checks.</p>
       <p>Application forms should be returned to the Headteacher’s P.A. Lisa Foster lfoster@ems.hartlepool.sch.uk</p>
@@ -26,7 +26,7 @@ vacancies:
     -
       slug: 'teacher-of-english-norham-high-school'
       job_title: 'Teacher of English'
-      job_description: "<p>Norham High school is seeking to appoint a Teacher of English who will join and strengthen the Department on a maternity cover contract. We are looking to appoint a dynamic and enthusiastic teacher with high expectations, who will be passionate about their subject, able to inspire and motivate young people, they must be committed to the highest standards of teaching and learning, through lesson planning, and high quality assessment.</p>
+      job_summary: "<p>Norham High school is seeking to appoint a Teacher of English who will join and strengthen the Department on a maternity cover contract. We are looking to appoint a dynamic and enthusiastic teacher with high expectations, who will be passionate about their subject, able to inspire and motivate young people, they must be committed to the highest standards of teaching and learning, through lesson planning, and high quality assessment.</p>
       <p>The school is committed to safeguarding and promoting the welfare of children and young people and expects all staff and volunteers to share this commitment.  This post will require the successful applicant to apply for an enhanced disclosure with the Disclosure and Barring Service.</p>
       <p>Norham High School is an 11 – 16 comprehensive school serving part of the South East locality of North Shields. The school is pupil-centred and enables pupils to have a real voice in our current and future improvements.</p>
       <p>Applications for this post are invited from people who are keen to join an organisation that is recognised for the high quality care and support it provides for its pupils and staff, its committed staff team and the drive to raise standards at all levels.</p>
@@ -40,7 +40,7 @@ vacancies:
     -
       slug: 'home-school-support-worker'
       job_title: 'Home School Support Worker'
-      job_description: "<p>37 hours per week</p>
+      job_summary: "<p>37 hours per week</p>
       <p>Term time plus one week</p>
       <p>Grade M point 25 – 29</p>
       <p>The successful candidate will undertake casework working alongside school and locality staff to address the needs of the children, who need support to overcome barriers to learn both inside and outside school; this will including assessment and appropriate management of attendance.</p>
@@ -51,7 +51,7 @@ vacancies:
     -
       slug: 'teacher-with-phase-leader-responsibility-for-pupils-with-special-educational-needs-mainly-to-teach-in-ks3-ks4'
       job_title: 'Teacher with Phase Leader responsibility for pupils with Special Educational Needs (mainly to teach in KS3-KS4)'
-      job_description: "<p>Cleaswell Hill School is a day community Special School for 181 children (designated age range 2-19). Some pupils have additional physical difficulties and medical needs while many are identified as being within the autistic spectrum.</p>
+      job_summary: "<p>Cleaswell Hill School is a day community Special School for 181 children (designated age range 2-19). Some pupils have additional physical difficulties and medical needs while many are identified as being within the autistic spectrum.</p>
       <p>We are committed to safeguarding and promoting the welfare of children and young people and expect all staff to share this commitment.  An enhanced criminal records check is required for this post.</p>
       <p>Further information about the school can be found on our website.</p>
       <p>An application pack, including an application form, is available to download from the school’s website at  http://www.cleaswellhill.northumberland.sch.uk/site</p>
@@ -80,7 +80,7 @@ vacancies:
     -
       slug: 'teacher-of-chemistry-bede-academy'
       job_title: 'Teacher of Chemistry'
-      job_description: "<p>We require from January 2019 a motivated and passionate graduate qualified to teach Chemistry at all levels, including ‘A’ level. The ability to demonstrate excellent subject knowledge and to consistently teach inspirational lessons is essential.</p>
+      job_summary: "<p>We require from January 2019 a motivated and passionate graduate qualified to teach Chemistry at all levels, including ‘A’ level. The ability to demonstrate excellent subject knowledge and to consistently teach inspirational lessons is essential.</p>
       <p>If you believe you have the vision and commitment to work in an Academy which seeks to raise achievement as well as set and maintain high standards and expectations, please contact Bede Academy.</p>
       <p>For an application pack and further information, please visit www.bedeacademy.org.uk Alternatively, please call Mrs Hogg on 01670 545111, option 2 or email recruitment@bedeacademy.org.uk</p>
       <p>Interviews w/c: 26 November 2018</p>
@@ -88,7 +88,7 @@ vacancies:
     -
       slug: 'cover-supervisor-st-michael-s-catholic-academy'
       job_title: 'Cover Supervisor'
-      job_description: "<p>St Michael’s Catholic Academy is a warmly welcoming and inclusive community with a determination to achieve the highest standards. We have strong expectations and an unswerving dedication to ensure that every student achieves their very best. Our Academy is a vibrant, forward thinking and Christ-centred place to work and we are looking to appoint a passionate and committed individual to join the Academy in the role of Cover Supervisor.</p>
+      job_summary: "<p>St Michael’s Catholic Academy is a warmly welcoming and inclusive community with a determination to achieve the highest standards. We have strong expectations and an unswerving dedication to ensure that every student achieves their very best. Our Academy is a vibrant, forward thinking and Christ-centred place to work and we are looking to appoint a passionate and committed individual to join the Academy in the role of Cover Supervisor.</p>
       <p>Duties will include:</p>
       <ul><li>Supervising classes during the short term absence of teachers</li>
       <li>Supervising students using the Learning Resource Centre for the first half hour of lunchtime and also after school for study/homework purposes</li>
@@ -107,7 +107,7 @@ vacancies:
     -
       slug: 'teacher-of-music-maternity-cover-0-6'
       job_title: 'Teacher of Music / maternity cover 0.6'
-      job_description: "<p>Required to start in January 2019 an enthusiastic, well-qualified Music specialist with the ability to teach Music up to GCSE and ‘A’ level. The Music Department is very successful and has a strong tradition of extra-curricular provision.</p>
+      job_summary: "<p>Required to start in January 2019 an enthusiastic, well-qualified Music specialist with the ability to teach Music up to GCSE and ‘A’ level. The Music Department is very successful and has a strong tradition of extra-curricular provision.</p>
       <p>The post would suit either an experienced teacher wishing to extend their experience in our successful environment or a newly qualified teacher.</p>
       <p>The Directors and Local Governing Body are committed to safeguarding and promoting the welfare of children and young people and vulnerable adults. The successful candidate will be subject to an enhanced disclosure through the Disclosure and Barring Service and additional recruitment checks.</p>
       <p>For further details and application form please visit our school website www.emshartlepool.org</p>

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     expires_on { Faker::Time.forward(days: 14) }
     expiry_time { expires_on&.change(sec: 0) }
     hired_status { nil }
-    job_description { Faker::Lorem.paragraph(sentence_count: 4) }
+    job_summary { Faker::Lorem.paragraph(sentence_count: 4) }
     job_roles { ['Teacher'] }
     job_title { Faker::Lorem.sentence[1...30].strip }
     listed_elsewhere { nil }
@@ -33,7 +33,7 @@ FactoryBot.define do
     trait :fail_minimum_validation do
       education { Faker::Lorem.paragraph[0..8] }
       experience { Faker::Lorem.paragraph[0..7] }
-      job_description { Faker::Lorem.paragraph[0..5] }
+      job_summary { Faker::Lorem.paragraph[0..5] }
       job_title { Faker::Job.title[0..2] }
       qualifications { Faker::Lorem.paragraph[0...8] }
     end
@@ -41,7 +41,7 @@ FactoryBot.define do
     trait :fail_maximum_validation do
       education { Faker::Lorem.characters(number: 1005) }
       experience { Faker::Lorem.characters(number: 1010) }
-      job_description { Faker::Lorem.characters(number: 50001) }
+      job_summary { Faker::Lorem.characters(number: 50001) }
       job_title { Faker::Lorem.characters(number: 150) }
       salary { Faker::Lorem.characters(number: 257) }
       qualifications { Faker::Lorem.characters(number: 1002) }

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
       create_list :document, 3, vacancy: vacancy
     end
 
+    about_school { Faker::Lorem.paragraph(sentence_count: 4) }
     application_link { Faker::Internet.url }
     benefits { Faker::Lorem.paragraph(sentence_count: 4) }
     contact_email { Faker::Internet.email }

--- a/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
     scenario 'incomplete pay package step' do
       visit edit_school_job_path(id: draft_vacancy.id)
 
-      expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 5))
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 6))
       expect(page).to have_content(I18n.t('jobs.pay_package'))
     end
 
@@ -33,7 +33,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       fill_in_pay_package_form_fields(draft_vacancy)
       click_on I18n.t('buttons.save_and_continue')
 
-      expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 5))
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
       expect(page).to have_content(I18n.t('jobs.supporting_documents'))
     end
 
@@ -49,7 +49,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       find('label[for="supporting-documents-form-supporting-documents-field-error"]').click
       click_on I18n.t('buttons.save_and_continue')
 
-      expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 5))
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
       expect(page).to have_content(I18n.t('jobs.supporting_documents'))
     end
 
@@ -65,7 +65,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       select_no_for_supporting_documents
       click_on I18n.t('buttons.save_and_continue')
 
-      expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
       expect(page).to have_content(I18n.t('jobs.application_details'))
     end
 
@@ -83,8 +83,35 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
 
       click_on I18n.t('buttons.save_and_continue')
 
-      expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
       expect(page).to have_content(I18n.t('jobs.application_details'))
+    end
+
+    scenario 'incomplete job summary step' do
+      visit edit_school_job_path(id: draft_vacancy.id)
+
+      draft_vacancy.salary = 'Pay scale 1 to Pay scale 2'
+      draft_vacancy.benefits = 'Gym, health insurance'
+
+      fill_in_pay_package_form_fields(draft_vacancy)
+      click_on I18n.t('buttons.save_and_continue')
+
+      find('label[for="supporting-documents-form-supporting-documents-field-error"]').click
+      click_on I18n.t('buttons.save_and_continue')
+
+      click_on I18n.t('buttons.save_and_continue')
+
+      draft_vacancy.contact_email = 'test@email.com'
+      draft_vacancy.application_link = 'https://example.com'
+      draft_vacancy.expires_on = DateTime.now + 1.year
+      draft_vacancy.expiry_time = Time.zone.now
+      draft_vacancy.publish_on = DateTime.now + 1.day
+
+      fill_in_application_details_form_fields(draft_vacancy)
+      click_on I18n.t('buttons.save_and_continue')
+
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 6))
+      expect(page).to have_content(I18n.t('jobs.job_summary'))
     end
   end
 
@@ -107,7 +134,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
 
     scenario 'then editing the draft redirects to incomplete step' do
       visit school_job_path(id: draft_vacancy.id)
-      expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
     end
 
     def edit_a_published_vacancy

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -127,7 +127,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         visit edit_school_job_path(vacancy.id)
         click_header_link(I18n.t('jobs.job_details'))
 
-        fill_in 'job_specification_form[job_description]', with: 'Sample description'
+        fill_in 'job_specification_form[job_summary]', with: 'Sample description'
         click_on I18n.t('buttons.update_job')
       end
     end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Creating a vacancy' do
 
         click_on I18n.t('buttons.save_and_continue')
 
-        mandatory_fields = %w[job_title job_roles job_description working_patterns]
+        mandatory_fields = %w[job_title job_roles job_summary working_patterns]
 
         within('.govuk-error-summary') do
           expect(page).to have_content(I18n.t('errors.title', count: mandatory_fields.size))

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -359,10 +359,8 @@ RSpec.feature 'Creating a vacancy' do
 
         click_on I18n.t('buttons.save_and_continue')
 
-        mandatory_fields = %w[job_summary about_school]
-
         within('.govuk-error-summary') do
-          expect(page).to have_content(I18n.t('errors.title', count: mandatory_fields.size))
+          expect(page).to have_content(I18n.t('errors.title', count: 1))
         end
 
         within_row_for(text: I18n.t('jobs.job_summary')) do
@@ -370,7 +368,7 @@ RSpec.feature 'Creating a vacancy' do
         end
 
         within_row_for(text: I18n.t('jobs.about_school', school: school.name)) do
-          expect(page).to have_content((I18n.t('activerecord.errors.models.vacancy.attributes.about_school.blank')))
+          expect(page).to have_content(school.description)
         end
       end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Creating a vacancy' do
 
         click_on I18n.t('buttons.save_and_continue')
 
-        mandatory_fields = %w[job_title job_roles job_summary working_patterns]
+        mandatory_fields = %w[job_title job_roles working_patterns]
 
         within('.govuk-error-summary') do
           expect(page).to have_content(I18n.t('errors.title', count: mandatory_fields.size))

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Creating a vacancy' do
 
     click_link 'Create a job listing'
 
-    expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 5))
+    expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 6))
   end
 
   context 'creating a new vacancy' do
@@ -44,7 +44,7 @@ RSpec.feature 'Creating a vacancy' do
 
       expect(page.current_path).to eq(job_specification_school_job_path)
       expect(page).to have_content(I18n.t('jobs.create_a_job', school: school.name))
-      expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 5))
+      expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 6))
     end
 
     context '#job_specification' do
@@ -72,7 +72,7 @@ RSpec.feature 'Creating a vacancy' do
         fill_in_job_specification_form_fields(vacancy)
         click_on I18n.t('buttons.save_and_continue')
 
-        expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 5))
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 6))
         expect(page).to have_content(I18n.t('jobs.pay_package'))
       end
 
@@ -107,19 +107,17 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      context 'with feature upload documents enabled' do
-        scenario 'redirects to step 3, supporting documents, when submitted successfuly' do
-          visit new_school_job_path
+      scenario 'redirects to step 3, supporting documents, when submitted successfuly' do
+        visit new_school_job_path
 
-          fill_in_job_specification_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+        fill_in_job_specification_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
 
-          fill_in_pay_package_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+        fill_in_pay_package_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
 
-          expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 5))
-          expect(page.current_path).to eq(supporting_documents_school_job_path)
-        end
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
+        expect(page.current_path).to eq(supporting_documents_school_job_path)
       end
     end
 
@@ -151,7 +149,7 @@ RSpec.feature 'Creating a vacancy' do
         select_no_for_supporting_documents
         click_on I18n.t('buttons.save_and_continue')
 
-        expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
         expect(page.current_path).to eq(application_details_school_job_path)
       end
 
@@ -323,25 +321,80 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      context 'when the upload feature flag is OFF' do
-        scenario 'redirects to the vacancy review page when submitted successfully' do
-          visit new_school_job_path
+      scenario 'redirects to the job summary page when submitted successfully' do
+        visit new_school_job_path
 
-          fill_in_job_specification_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+        fill_in_job_specification_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
 
-          fill_in_pay_package_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+        fill_in_pay_package_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
 
-          select_no_for_supporting_documents
-          click_on I18n.t('buttons.save_and_continue')
+        select_no_for_supporting_documents
+        click_on I18n.t('buttons.save_and_continue')
 
-          fill_in_application_details_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+        fill_in_application_details_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
 
-          expect(page).to have_content(I18n.t('jobs.review'))
-          verify_all_vacancy_details(vacancy)
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 6))
+        expect(page).to have_content(I18n.t('jobs.job_summary'))
+      end
+    end
+
+    context '#job_summary' do
+      scenario 'is invalid unless all mandatory fields are submitted' do
+        visit new_school_job_path
+
+        fill_in_job_specification_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_pay_package_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        select_no_for_supporting_documents
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_application_details_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        click_on I18n.t('buttons.save_and_continue')
+
+        mandatory_fields = %w[job_summary about_school]
+
+        within('.govuk-error-summary') do
+          expect(page).to have_content(I18n.t('errors.title', count: mandatory_fields.size))
         end
+
+        within_row_for(text: I18n.t('jobs.job_summary')) do
+          expect(page).to have_content((I18n.t('activerecord.errors.models.vacancy.attributes.job_summary.blank')))
+        end
+
+        within_row_for(text: I18n.t('jobs.about_school', school: school.name)) do
+          expect(page).to have_content((I18n.t('activerecord.errors.models.vacancy.attributes.about_school.blank')))
+        end
+      end
+
+      scenario 'redirects to the vacancy review page when submitted successfully' do
+        visit new_school_job_path
+
+        fill_in_job_specification_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_pay_package_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        select_no_for_supporting_documents
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_application_details_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_job_summary_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 6, total: 6))
+        expect(page).to have_content(I18n.t('jobs.review'))
+        verify_all_vacancy_details(vacancy)
       end
     end
 
@@ -356,7 +409,7 @@ RSpec.feature 'Creating a vacancy' do
           v = Vacancy.find_by(job_title: vacancy.job_title)
           visit school_job_path(id: v.id)
 
-          expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 5))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 6))
         end
 
         scenario 'redirects to step 4, application details, when that step has not been completed' do
@@ -374,7 +427,28 @@ RSpec.feature 'Creating a vacancy' do
           v = Vacancy.find_by(job_title: vacancy.job_title)
           visit school_job_path(id: v.id)
 
-          expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
+        end
+
+        scenario 'redirects to step 5, job summary, when that step has not been completed' do
+          visit new_school_job_path
+
+          fill_in_job_specification_form_fields(vacancy)
+          click_on I18n.t('buttons.save_and_continue')
+
+          fill_in_pay_package_form_fields(vacancy)
+          click_on I18n.t('buttons.save_and_continue')
+
+          select_no_for_supporting_documents
+          click_on I18n.t('buttons.save_and_continue')
+
+          fill_in_application_details_form_fields(vacancy)
+          click_on I18n.t('buttons.save_and_continue')
+
+          v = Vacancy.find_by(job_title: vacancy.job_title)
+          visit school_job_path(id: v.id)
+
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 6))
         end
 
         scenario 'redirects to appropriate step when clicked on change on review page' do
@@ -392,13 +466,16 @@ RSpec.feature 'Creating a vacancy' do
           fill_in_application_details_form_fields(vacancy)
           click_on I18n.t('buttons.save_and_continue')
 
+          fill_in_job_summary_form_fields(vacancy)
+          click_on I18n.t('buttons.save_and_continue')
+
           click_header_link(I18n.t('jobs.application_details'))
-          expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
 
           click_on I18n.t('buttons.save_and_continue')
 
           click_header_link(I18n.t('jobs.job_details'))
-          expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 5))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 6))
         end
       end
 
@@ -491,7 +568,7 @@ RSpec.feature 'Creating a vacancy' do
           visit school_job_review_path(vacancy.id)
           click_header_link(I18n.t('jobs.job_details'))
 
-          expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 5))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 6))
 
           fill_in 'job_specification_form[job_title]', with: 'An edited job title'
           click_on I18n.t('buttons.save_and_continue')
@@ -507,7 +584,7 @@ RSpec.feature 'Creating a vacancy' do
           visit school_job_review_path(vacancy.id)
           click_header_link(I18n.t('jobs.job_details'))
 
-          expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 5))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 6))
 
           fill_in 'job_specification_form[job_title]', with: 'High school teacher'
           click_on I18n.t('buttons.save_and_continue')
@@ -552,11 +629,14 @@ RSpec.feature 'Creating a vacancy' do
           fill_in_application_details_form_fields(vacancy)
           click_on I18n.t('buttons.save_and_continue')
 
+          fill_in_job_summary_form_fields(vacancy)
+          click_on I18n.t('buttons.save_and_continue')
+
           expect(page).to have_content(I18n.t('jobs.review_heading'))
 
           click_header_link(I18n.t('jobs.supporting_documents'))
 
-          expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 5))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
           expect(page).to have_content(I18n.t('jobs.upload_file'))
 
           click_on I18n.t('buttons.save_and_continue')
@@ -571,7 +651,7 @@ RSpec.feature 'Creating a vacancy' do
           visit school_job_review_path(vacancy.id)
           click_header_link(I18n.t('jobs.application_details'))
 
-          expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
 
           fill_in 'application_details_form[contact_email]', with: 'not a valid email'
           click_on I18n.t('buttons.save_and_continue')
@@ -590,7 +670,7 @@ RSpec.feature 'Creating a vacancy' do
           visit school_job_review_path(vacancy.id)
           click_header_link(I18n.t('jobs.application_details'))
 
-          expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
 
           fill_in 'application_details_form[application_link]', with: 'www invalid.domain.com'
           click_on I18n.t('buttons.save_and_continue')
@@ -609,7 +689,7 @@ RSpec.feature 'Creating a vacancy' do
           visit school_job_review_path(vacancy.id)
           click_header_link(I18n.t('jobs.application_details'))
 
-          expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 5))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
 
           fill_in 'application_details_form[contact_email]', with: 'an@email.com'
           click_on I18n.t('buttons.save_and_continue')
@@ -782,6 +862,8 @@ RSpec.feature 'Creating a vacancy' do
         select_no_for_supporting_documents
         click_on I18n.t('buttons.save_and_continue')
         fill_in_application_details_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+        fill_in_job_summary_form_fields(vacancy)
         click_on I18n.t('buttons.save_and_continue')
         click_link('vacancy-review-submit')
         expect(page).to have_content(I18n.t('jobs.confirmation_page.view_posted_job'))

--- a/spec/features/hiring_staff_can_see_their_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_see_their_vacancies_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Hiring staff can see their vacancies' do
     click_on(vacancy.job_title)
 
     expect(page).to have_content(vacancy.job_title)
-    expect(page).to have_content(vacancy.job_description)
+    expect(page).to have_content(vacancy.job_summary)
   end
 
   context 'with no jobs' do

--- a/spec/features/job_seekers_can_search_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_search_vacancies_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature 'Searching vacancies by subject' do
 
   describe 'does not match' do
     scenario '#description', elasticsearch: true do
-      vacancy = create(:vacancy, job_description: 'Opening has for an outstanding teacher.')
+      vacancy = create(:vacancy, job_summary: 'Opening has for an outstanding teacher.')
 
       Vacancy.__elasticsearch__.client.indices.flush
 

--- a/spec/features/job_seekers_can_view_a_vacancy_on_mobile_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_on_mobile_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Viewing a single vacancy on mobile' do
       visit job_path(vacancy)
 
       expect(page.find('meta[name="description"]', visible: false)['content'])
-        .to eq(strip_tags(vacancy.job_description))
+        .to eq(strip_tags(vacancy.job_summary))
     end
 
     scenario 'the vacancy\'s open graph meta data are rendered correctly' do
@@ -27,7 +27,7 @@ RSpec.feature 'Viewing a single vacancy on mobile' do
       visit job_path(vacancy)
 
       expect(page.find('meta[property="og:description"]', visible: false)['content'])
-        .to eq(strip_tags(vacancy.job_description))
+        .to eq(strip_tags(vacancy.job_summary))
     end
   end
 end

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -162,7 +162,7 @@ RSpec.feature 'Viewing a single published vacancy' do
       visit job_path(vacancy)
 
       expect(page.find('meta[name="description"]', visible: false)['content'])
-        .to eq(strip_tags(vacancy.job_description))
+        .to eq(strip_tags(vacancy.job_summary))
     end
 
     scenario 'the vacancy\'s open graph meta data are rendered correctly' do
@@ -170,7 +170,7 @@ RSpec.feature 'Viewing a single published vacancy' do
       visit job_path(vacancy)
 
       expect(page.find('meta[property="og:description"]', visible: false)['content'])
-        .to eq(strip_tags(vacancy.job_description))
+        .to eq(strip_tags(vacancy.job_summary))
     end
   end
 end

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -120,7 +120,6 @@ RSpec.describe JobSpecificationForm, type: :model do
 
     it 'a JobSpecificationForm can be converted to a vacancy' do
       job_specification_form = JobSpecificationForm.new(job_title: 'English Teacher',
-                                                        job_summary: 'description',
                                                         job_roles: [I18n.t('jobs.job_role_options.teacher')],
                                                         working_patterns: ['full_time'],
                                                         subject_id: main_subject.id,

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe JobSpecificationForm, type: :model do
             .to eq(I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.too_long', count: 100))
         end
       end
+
+      context 'when title contains HTML tags' do
+        let(:job_title) { 'Title with <p>tags</p>' }
+
+        it 'validates presence of HTML tags' do
+          expect(job_specification.valid?).to be false
+          expect(job_specification.errors.messages[:job_title]).to include(
+            I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.invalid_characters')
+          )
+        end
+      end
     end
   end
 

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -48,40 +48,40 @@ RSpec.describe JobSpecificationForm, type: :model do
       end
     end
 
-    describe '#job_description' do
-      let(:job_specification) { JobSpecificationForm.new(job_description: job_description) }
+    describe '#job_summary' do
+      let(:job_specification) { JobSpecificationForm.new(job_summary: job_summary) }
 
       context 'when description is blank' do
-        let(:job_description) { nil }
+        let(:job_summary) { nil }
 
         it 'requests an entry in the field' do
           expect(job_specification.valid?).to be false
-          expect(job_specification.errors.messages[:job_description][0])
+          expect(job_specification.errors.messages[:job_summary][0])
             .to eq('Enter a job description')
         end
       end
 
       context 'when description is too short' do
-        let(:job_description) { 'short' }
+        let(:job_summary) { 'short' }
 
         it 'validates minimum length' do
           expect(job_specification.valid?).to be false
-          expect(job_specification.errors.messages[:job_description][0])
+          expect(job_specification.errors.messages[:job_summary][0])
             .to eq(
-              I18n.t('activemodel.errors.models.job_specification_form.attributes.job_description.too_short',
+              I18n.t('activemodel.errors.models.job_specification_form.attributes.job_summary.too_short',
                 count: 10)
               )
         end
       end
 
       context 'when description is too long' do
-        let(:job_description) { 'Long text' * 10000 }
+        let(:job_summary) { 'Long text' * 10000 }
 
         it 'validates max length' do
           expect(job_specification.valid?).to be false
-          expect(job_specification.errors.messages[:job_description][0])
+          expect(job_specification.errors.messages[:job_summary][0])
             .to eq(
-              I18n.t('activemodel.errors.models.job_specification_form.attributes.job_description.too_long',
+              I18n.t('activemodel.errors.models.job_specification_form.attributes.job_summary.too_long',
                 count: 50000)
               )
         end
@@ -160,7 +160,7 @@ RSpec.describe JobSpecificationForm, type: :model do
 
     it 'a JobSpecificationForm can be converted to a vacancy' do
       job_specification_form = JobSpecificationForm.new(job_title: 'English Teacher',
-                                                        job_description: 'description',
+                                                        job_summary: 'description',
                                                         job_roles: [I18n.t('jobs.job_role_options.teacher')],
                                                         working_patterns: ['full_time'],
                                                         subject_id: main_subject.id,
@@ -169,7 +169,7 @@ RSpec.describe JobSpecificationForm, type: :model do
       expect(job_specification_form.valid?).to be true
       expect(job_specification_form.vacancy.job_title).to eq('English Teacher')
       expect(job_specification_form.vacancy.job_roles).to include(I18n.t('jobs.job_role_options.teacher'))
-      expect(job_specification_form.vacancy.job_description).to eq('description')
+      expect(job_specification_form.vacancy.job_summary).to eq('description')
       expect(job_specification_form.vacancy.working_patterns).to eq(['full_time'])
       expect(job_specification_form.vacancy.subject.name).to eq(main_subject.name)
       expect(job_specification_form.vacancy.newly_qualified_teacher).to eq(true)

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe JobSpecificationForm, type: :model do
         it 'requests an entry in the field' do
           expect(job_specification.valid?).to be false
           expect(job_specification.errors.messages[:job_summary][0])
-            .to eq('Enter a job description')
+            .to eq('Enter a job summary')
         end
       end
 

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -47,46 +47,6 @@ RSpec.describe JobSpecificationForm, type: :model do
         end
       end
     end
-
-    describe '#job_summary' do
-      let(:job_specification) { JobSpecificationForm.new(job_summary: job_summary) }
-
-      context 'when description is blank' do
-        let(:job_summary) { nil }
-
-        it 'requests an entry in the field' do
-          expect(job_specification.valid?).to be false
-          expect(job_specification.errors.messages[:job_summary][0])
-            .to eq('Enter a job summary')
-        end
-      end
-
-      context 'when description is too short' do
-        let(:job_summary) { 'short' }
-
-        it 'validates minimum length' do
-          expect(job_specification.valid?).to be false
-          expect(job_specification.errors.messages[:job_summary][0])
-            .to eq(
-              I18n.t('activemodel.errors.models.job_specification_form.attributes.job_summary.too_short',
-                count: 10)
-              )
-        end
-      end
-
-      context 'when description is too long' do
-        let(:job_summary) { 'Long text' * 10000 }
-
-        it 'validates max length' do
-          expect(job_specification.valid?).to be false
-          expect(job_specification.errors.messages[:job_summary][0])
-            .to eq(
-              I18n.t('activemodel.errors.models.job_specification_form.attributes.job_summary.too_long',
-                count: 50000)
-              )
-        end
-      end
-    end
   end
 
   describe '#starts_on' do
@@ -169,7 +129,6 @@ RSpec.describe JobSpecificationForm, type: :model do
       expect(job_specification_form.valid?).to be true
       expect(job_specification_form.vacancy.job_title).to eq('English Teacher')
       expect(job_specification_form.vacancy.job_roles).to include(I18n.t('jobs.job_role_options.teacher'))
-      expect(job_specification_form.vacancy.job_summary).to eq('description')
       expect(job_specification_form.vacancy.working_patterns).to eq(['full_time'])
       expect(job_specification_form.vacancy.subject.name).to eq(main_subject.name)
       expect(job_specification_form.vacancy.newly_qualified_teacher).to eq(true)

--- a/spec/form_models/job_summary_form_spec.rb
+++ b/spec/form_models/job_summary_form_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe JobSummaryForm, type: :model do
+  context 'validations' do
+    describe '#job_summary' do
+      job_summary_form = JobSummaryForm.new(job_summary: nil)
+
+      context 'when job summary is blank' do
+        let(:job_summary) { nil }
+
+        it 'requests an entry in the field' do
+          expect(job_summary_form.valid?).to be false
+          expect(job_summary_form.errors.messages[:job_summary])
+            .to include(
+              I18n.t('activemodel.errors.models.job_summary_form.attributes.job_summary.blank')
+            )
+        end
+      end
+    end
+
+    describe '#about_school' do
+      job_summary_form = JobSummaryForm.new(about_school: nil)
+
+      context 'when about school is blank' do
+        let(:about_school) { nil }
+
+        it 'requests an entry in the field' do
+          expect(job_summary_form.valid?).to be false
+          expect(job_summary_form.errors.messages[:about_school])
+            .to include(
+              I18n.t('activemodel.errors.models.job_summary_form.attributes.about_school.blank')
+            )
+        end
+      end
+    end
+  end
+
+  context 'when all attributes are valid' do
+    job_summary_form = JobSummaryForm.new(job_summary: 'Summary about the job',
+                                          about_school: 'Description of the school')
+
+    it 'a JobSummaryForm can be converted to a vacancy' do
+      expect(job_summary_form.valid?).to be true
+      expect(job_summary_form.vacancy.job_summary).to eq('Summary about the job')
+      expect(job_summary_form.vacancy.about_school).to eq('Description of the school')
+    end
+  end
+end

--- a/spec/form_models/pay_package_form_spec.rb
+++ b/spec/form_models/pay_package_form_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe PayPackageForm, type: :model do
+  context 'validations' do
+    describe '#salary' do
+      let(:pay_package) { PayPackageForm.new(salary: salary) }
+
+      context 'when salary is blank' do
+        let(:salary) { nil }
+
+        it 'requests an entry in the field' do
+          expect(pay_package.valid?).to be false
+          expect(pay_package.errors.messages[:salary]).to include(
+            I18n.t('activemodel.errors.models.pay_package_form.attributes.salary.blank')
+          )
+        end
+      end
+
+      context 'when salary is too long' do
+        let(:salary) { 'Salary' * 100 }
+
+        it 'validates max length' do
+          expect(pay_package.valid?).to be false
+          expect(pay_package.errors.messages[:salary]).to include(
+            I18n.t('activemodel.errors.models.pay_package_form.attributes.salary.too_long', count: 256)
+          )
+        end
+      end
+
+      context 'when salary contains HTML tags' do
+        let(:salary) { 'Salary with <p>tags</p' }
+
+        it 'validates presence of HTML tags' do
+          expect(pay_package.valid?).to be false
+          expect(pay_package.errors.messages[:salary]).to include(
+            I18n.t('activemodel.errors.models.pay_package_form.attributes.salary.invalid_characters')
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,13 +8,6 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       expect(helper.sanitize(html)).to eq(sanitized_html)
     end
-
-    it 'it converts &amp; to &' do
-      html = '<p>English  &amp; Drama teacher</p>'
-      sanitized_html = '<p>English  & Drama teacher</p>'
-
-      expect(helper.sanitize(html)).to eq(sanitized_html)
-    end
   end
 
   describe '#body_class' do

--- a/spec/lib/job_posting_spec.rb
+++ b/spec/lib/job_posting_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe JobPosting do
         'identifier' => '136352'
       },
       'validThrough' => valid_through,
-      'workHours' => '37.5'
+      'workHours' => '37.5',
+      'aboutSchool' => 'Some information about the school'
     }
   end
   let(:school_by_urn) { build(:school, urn: '136352') }

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -56,11 +56,6 @@ RSpec.describe Vacancy, type: :model do
         expect(subject.errors.messages[:job_title].first)
           .to eq(I18n.t('activerecord.errors.models.vacancy.attributes.job_title.too_short', count: 4))
       end
-
-      it '#job_summary' do
-        expect(subject.errors.messages[:job_summary].first)
-          .to eq(I18n.t('activerecord.errors.models.vacancy.attributes.job_summary.too_short', count: 10))
-      end
     end
 
     context 'restrict maximum length of string fields' do
@@ -77,19 +72,6 @@ RSpec.describe Vacancy, type: :model do
       it '#salary' do
         expect(subject.errors.messages[:salary].first)
           .to eq(I18n.t('activemodel.errors.models.pay_package_form.attributes.salary.too_long', count: 256))
-      end
-    end
-
-    context 'restrict maximum length of text fields' do
-      subject { build(:vacancy, :fail_maximum_validation) }
-      before(:each) do
-        subject.valid?
-      end
-
-      it '#job_summary' do
-        expect(subject.errors.messages[:job_summary].first)
-          .to eq(I18n.t('activemodel.errors.models.job_specification_form.attributes.job_summary.too_long',
-            count: 50000))
       end
     end
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -584,7 +584,7 @@ RSpec.describe Vacancy, type: :model do
       end
     end
 
-    it 'does not update the stats when you are updating the job description' do
+    it 'does not update the stats when you are updating the job summary' do
       Timecop.freeze(2019, 1, 1, 10, 4, 3) do
         expired_job.update(job_summary: 'I am description')
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Vacancy, type: :model do
     context 'a new record' do
       it { should validate_presence_of(:job_title) }
       it { should validate_presence_of(:job_roles) }
-      it { should validate_presence_of(:job_description) }
+      it { should validate_presence_of(:job_summary) }
       it { should validate_presence_of(:working_patterns) }
       it { should validate_presence_of(:salary) }
     end
@@ -57,9 +57,9 @@ RSpec.describe Vacancy, type: :model do
           .to eq(I18n.t('activerecord.errors.models.vacancy.attributes.job_title.too_short', count: 4))
       end
 
-      it '#job_description' do
-        expect(subject.errors.messages[:job_description].first)
-          .to eq(I18n.t('activerecord.errors.models.vacancy.attributes.job_description.too_short', count: 10))
+      it '#job_summary' do
+        expect(subject.errors.messages[:job_summary].first)
+          .to eq(I18n.t('activerecord.errors.models.vacancy.attributes.job_summary.too_short', count: 10))
       end
     end
 
@@ -86,9 +86,9 @@ RSpec.describe Vacancy, type: :model do
         subject.valid?
       end
 
-      it '#job_description' do
-        expect(subject.errors.messages[:job_description].first)
-          .to eq(I18n.t('activemodel.errors.models.job_specification_form.attributes.job_description.too_long',
+      it '#job_summary' do
+        expect(subject.errors.messages[:job_summary].first)
+          .to eq(I18n.t('activemodel.errors.models.job_specification_form.attributes.job_summary.too_long',
             count: 50000))
       end
     end
@@ -383,12 +383,12 @@ RSpec.describe Vacancy, type: :model do
   end
 
   context 'content sanitization' do
-    it '#job_description' do
+    it '#job_summary' do
       html = '<p> a paragraph <a href=\'link\'>with a link</a></p><br>'
-      vacancy = build(:vacancy, job_description: html)
+      vacancy = build(:vacancy, job_summary: html)
 
       sanitized_html = '<p> a paragraph with a link</p><br>'
-      expect(vacancy.job_description).to eq(sanitized_html)
+      expect(vacancy.job_summary).to eq(sanitized_html)
     end
 
     it '#job_title' do
@@ -586,7 +586,7 @@ RSpec.describe Vacancy, type: :model do
 
     it 'does not update the stats when you are updating the job description' do
       Timecop.freeze(2019, 1, 1, 10, 4, 3) do
-        expired_job.update(job_description: 'I am description')
+        expired_job.update(job_summary: 'I am description')
 
         expect(stats_updated_at).to be_nil
       end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -364,42 +364,6 @@ RSpec.describe Vacancy, type: :model do
     end
   end
 
-  context 'content sanitization' do
-    it '#job_summary' do
-      html = '<p> a paragraph <a href=\'link\'>with a link</a></p><br>'
-      vacancy = build(:vacancy, job_summary: html)
-
-      sanitized_html = '<p> a paragraph with a link</p><br>'
-      expect(vacancy.job_summary).to eq(sanitized_html)
-    end
-
-    it '#job_title' do
-      title = '<strong>School teacher </strong>'
-      vacancy = build(:vacancy, job_title: title)
-
-      sanitized_title = 'School teacher '
-      expect(vacancy.job_title).to eq(sanitized_title)
-    end
-
-    context '#salary' do
-      it 'strips the tags' do
-        salary = '<strong>£25,000</strong>'
-        vacancy = build(:vacancy, salary: salary)
-
-        sanitized_salary = '£25,000'
-        expect(vacancy.salary).to eq(sanitized_salary)
-      end
-    end
-
-    it '#benefits' do
-      benefits = '<ul><li><a href="">Gym membership</a></li></ul>'
-      vacancy = build(:vacancy, benefits: benefits)
-
-      sanitized_benefits = '<ul><li>Gym membership</li></ul>'
-      expect(vacancy.benefits).to eq(sanitized_benefits)
-    end
-  end
-
   context '#flexible_working?' do
     context 'when no flexible working options are available' do
       let(:flexible_working) { nil }

--- a/spec/presenters/vacancies_presenter_spec.rb
+++ b/spec/presenters/vacancies_presenter_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe VacanciesPresenter do
                                         hiringOrganization.identifier])
 
       expect(vacancies_csv[1]).to eq([vacancy.job_title,
-                                      vacancy.job_description,
+                                      vacancy.job_summary,
                                       vacancy.salary,
                                       vacancy.benefits,
                                       vacancy.publish_on.to_time.iso8601,

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe VacancyPresenter do
     end
   end
 
-  describe '#job_description' do
-    it 'sanitizes and transforms the job_description into HTML' do
-      vacancy = build(:vacancy, job_description: '<script> call();</script>Sanitized content')
+  describe '#job_summary' do
+    it 'sanitizes and transforms the job_summary into HTML' do
+      vacancy = build(:vacancy, job_summary: '<script> call();</script>Sanitized content')
       presenter = VacancyPresenter.new(vacancy)
 
-      expect(presenter.job_description).to eq('<p> call();Sanitized content</p>')
+      expect(presenter.job_summary).to eq('<p> call();Sanitized content</p>')
     end
   end
 

--- a/spec/services/auditor_spec.rb
+++ b/spec/services/auditor_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Auditor::Audit' do
 
   describe '#log' do
     it 'audits setting values to a model' do
-      vacancy.job_description = 'A new description'
+      vacancy.job_summary = 'A new description'
       audit = Auditor::Audit.new(vacancy, 'vacancy.test_create', 'test_session_id')
       audit.log { vacancy.save }
 
@@ -17,8 +17,8 @@ RSpec.describe 'Auditor::Audit' do
 
     it 'audits any changes to a model' do
       vacancy.save
-      job_description = vacancy.job_description
-      vacancy.job_description = 'A new description'
+      job_summary = vacancy.job_summary
+      vacancy.job_summary = 'A new description'
       audit = Auditor::Audit.new(vacancy, 'vacancy.test', 'test_session_id')
       audit.log { vacancy.save }
 
@@ -26,7 +26,7 @@ RSpec.describe 'Auditor::Audit' do
       expect(audit_log.key).to eq('vacancy.test')
       expect(audit_log.session_id).to eq('test_session_id')
       expect(audit_log.parameters.symbolize_keys)
-        .to eq(job_description: [job_description, 'A new description'])
+        .to eq(job_summary: [job_summary, 'A new description'])
     end
   end
 

--- a/spec/services/vacancy_sort_spec.rb
+++ b/spec/services/vacancy_sort_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe VacancySort do
     end
 
     it 'sets default column if an invalid one is provided' do
-      expect(vacancy_sort.update(column: 'job_description', order: anything).column).to eq 'expires_on'
+      expect(vacancy_sort.update(column: 'job_summary', order: anything).column).to eq 'expires_on'
     end
 
     it 'sets default order if an invalid one is provided' do

--- a/spec/smoke_test/job_seekers_can_view_homepage_spec.rb
+++ b/spec/smoke_test/job_seekers_can_view_homepage_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Page availability', js: true, smoke_test: true do
       vacancy_page = page.first('.view-vacancy-link')
       unless vacancy_page.nil?
         vacancy_page.click
-        expect(page).to have_content(I18n.t('jobs.job_description'))
+        expect(page).to have_content(I18n.t('jobs.job_summary'))
         expect(page.current_url).to include('https://teaching-vacancies.service.gov.uk/jobs/')
       end
     end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -1,7 +1,6 @@
 module VacancyHelpers
   def fill_in_job_specification_form_fields(vacancy)
     fill_in 'job_specification_form[job_title]', with: vacancy.job_title
-    fill_in 'job_specification_form[job_summary]', with: vacancy.job_summary
     select vacancy.subject.name, from: 'job_specification_form[subject_id]' if vacancy.subject
     select vacancy.first_supporting_subject,
       from: 'job_specification_form[first_supporting_subject_id]' if vacancy.first_supporting_subject
@@ -64,6 +63,11 @@ module VacancyHelpers
     fill_in 'application_details_form[publish_on_yyyy]', with: vacancy.publish_on.year
   end
 
+  def fill_in_job_summary_form_fields(vacancy)
+    fill_in 'job_summary_form[job_summary]', with: vacancy.job_summary
+    fill_in 'job_summary_form[about_school]', with: vacancy.about_school
+  end
+
   def fill_in_copy_vacancy_form_fields(vacancy)
     fill_in 'copy_vacancy_form[job_title]', with: vacancy.job_title
 
@@ -91,7 +95,6 @@ module VacancyHelpers
   def verify_all_vacancy_details(vacancy)
     expect(page).to have_content(vacancy.job_title)
     expect(page).to have_content(vacancy.show_job_roles)
-    expect(page.html).to include(vacancy.job_summary)
     expect(page).to have_content(vacancy.subject.name)
     expect(page).to have_content(vacancy.other_subjects)
     expect(page).to have_content(vacancy.working_patterns)
@@ -107,6 +110,9 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.application_link)
     expect(page).to have_content(vacancy.expires_on.to_s.strip)
     expect(page).to have_content(vacancy.publish_on.to_s.strip)
+
+    expect(page.html).to include(vacancy.job_summary)
+    expect(page.html).to include(vacancy.about_school)
   end
 
   def verify_vacancy_show_page_details(vacancy)

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -1,7 +1,7 @@
 module VacancyHelpers
   def fill_in_job_specification_form_fields(vacancy)
     fill_in 'job_specification_form[job_title]', with: vacancy.job_title
-    fill_in 'job_specification_form[job_description]', with: vacancy.job_description
+    fill_in 'job_specification_form[job_summary]', with: vacancy.job_summary
     select vacancy.subject.name, from: 'job_specification_form[subject_id]' if vacancy.subject
     select vacancy.first_supporting_subject,
       from: 'job_specification_form[first_supporting_subject_id]' if vacancy.first_supporting_subject
@@ -91,7 +91,7 @@ module VacancyHelpers
   def verify_all_vacancy_details(vacancy)
     expect(page).to have_content(vacancy.job_title)
     expect(page).to have_content(vacancy.show_job_roles)
-    expect(page.html).to include(vacancy.job_description)
+    expect(page.html).to include(vacancy.job_summary)
     expect(page).to have_content(vacancy.subject.name)
     expect(page).to have_content(vacancy.other_subjects)
     expect(page).to have_content(vacancy.working_patterns)
@@ -112,7 +112,7 @@ module VacancyHelpers
   def verify_vacancy_show_page_details(vacancy)
     expect(page).to have_content(vacancy.job_title)
     expect(page).to have_content(vacancy.show_job_roles)
-    expect(page.html).to include(vacancy.job_description)
+    expect(page.html).to include(vacancy.job_summary)
     expect(page).to have_content(vacancy.subject.name)
     expect(page).to have_content(vacancy.other_subjects)
     expect(page).to have_content(vacancy.working_patterns)
@@ -153,7 +153,7 @@ module VacancyHelpers
       'salary': vacancy.salary,
       'jobBenefits': vacancy.benefits,
       'datePosted': vacancy.publish_on.to_time.iso8601,
-      'description': vacancy.job_description,
+      'description': vacancy.job_summary,
       'educationRequirements': vacancy.education,
       'qualifications': vacancy.qualifications,
       'experienceRequirements': vacancy.experience,


### PR DESCRIPTION
This PR adds a new step (Job summary) to the hiring staff 'Create a job' journey

**TODO**
- [x] Pre-populate about_school field in job summary form with About School data
- [x] Refactor .yml files to wrap after 120 characters
- [x] Refactor user input sanitization
- [x] Product/UX review
- [x] Code review

## Jira ticket URL
[TEVA-542](https://dfedigital.atlassian.net/browse/TEVA-542)
[Figma for design](https://www.figma.com/file/n2wLtKVQ2imMbjdPSHBRKW/Sprint-50?node-id=0%3A1)
## Changes in this PR
- Rename job_description column to job_summary on the vacancies table and allow it to be NULL
- Add about_school column to the vacancies table
- Add Job Summary step to the 'Create a job' journey
## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/25187547/78573985-4845a880-7821-11ea-8805-7d5f2faea008.png)
## Next steps
- Show about_school field on the vacancy in the school overview section that jobseekers see
