### PR TITLE
Convert job_roles array to string before exporting to BigQuery

### DIFF
--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -91,6 +91,8 @@ class ExportTablesToBigQuery
       # Another bloody enum gem edge case. Only in vacancies and causes that whole table to fail despite the column
       # being nullable.
       data = '' if c.name == 'hired_status' && data.nil?
+      # This prevents an error whereby BigQuery rejects arrays of exactly one element.
+      data = data.to_s if c.name == 'job_roles'
       data = data.to_s if c.name == 'working_patterns'
       data = data.to_s(:db) if !data.nil? && (c.type == :datetime || c.type == :date)
       @bigquery_data[c.name] = data


### PR DESCRIPTION
This is to prevent an error whereby BigQuery rejects arrays of exactly one element.

This had been causing data feed failures for 5 days.

The error message I got when I ran the task for only the Vacancy table in ssh was: 'Array specified for non-repeated field.'
