### PR TITLE
Bigquery handle incomplete vacancy table

### DIFF
--- a/bigquery/append-latest-vacancy-counts-to-benchmarked-table.sql
+++ b/bigquery/append-latest-vacancy-counts-to-benchmarked-table.sql
@@ -1,28 +1,46 @@
-SELECT
-  *
-FROM (
-  SELECT #pull counts for today for sites we benchmark against from a Google Sheet
+WITH
+  current_vacancy_counts AS (
+  SELECT
+    #pull counts for today for sites we benchmark against from a Google Sheet
     CURRENT_DATE() AS date,
     Site AS site,
     Current_number_of_comparable_vacancies AS number_of_vacancies
   FROM
     `teacher-vacancy-service.production_dataset.current_vacancy_counts_from_comparable_sites_from_google_sheets`
-  WHERE #don't take obviously erroneous values from the Google Sheet
-    Site IS NOT NULL
-    AND Current_number_of_comparable_vacancies > 0
-  UNION ALL #pull count for today for Teaching Vacancies from our own vacancy table
-  SELECT
-    CURRENT_DATE() AS date,
-    "Teaching Vacancies" AS site,
-    COUNT(*) AS number_of_vacancies
-  FROM
-    `teacher-vacancy-service.production_dataset.feb20_vacancy`
   WHERE
-    status NOT IN ("deleted",
-      "trashed",
-      "draft")
-    AND publish_on <= CURRENT_DATE()
-    AND expiry_time > CURRENT_DATETIME() )
+    #don't take obviously erroneous values from the Google Sheet
+    Site IS NOT NULL
+    AND Current_number_of_comparable_vacancies > 0 )
+SELECT
+  *
+FROM (
+  SELECT
+    *
+  FROM
+    current_vacancy_counts
+  UNION ALL (
+    SELECT
+      *
+    FROM (
+        #pull count for today for Teaching Vacancies from our own vacancy table
+      SELECT
+        CURRENT_DATE() AS date,
+        "Teaching Vacancies" AS site,
+        COUNT(*) AS number_of_vacancies
+      FROM
+        `teacher-vacancy-service.production_dataset.feb20_vacancy`
+      WHERE
+        status NOT IN ("deleted",
+          "trashed",
+          "draft")
+        AND publish_on <= CURRENT_DATE()
+        AND expiry_time > CURRENT_DATETIME())
+    WHERE
+      "Teaching Vacancies" NOT IN ( #only take the Teaching Vacancies vacancy count from our database if we haven't been able to web scrape it (to avoid relying on the write job to this large table)
+      SELECT
+        site
+      FROM
+        current_vacancy_counts)))
 WHERE
   site NOT IN (
   SELECT

--- a/bigquery/monitor-tables-for-errors.sql
+++ b/bigquery/monitor-tables-for-errors.sql
@@ -18,6 +18,12 @@ IF
         #sets a minimum threshold for the number of schools that should be in the database - this should not change much unless we change the scope, so going below this threshold most likely means the dataset in BQ is incomplete
         "Table appears incomplete",
         #check whether there are at least this many schools in the schools table
+    IF
+      (table LIKE "%vacancy"
+        AND row_count <29000,
+        #sets a minimum threshold for the number of schools that should be in the database - this should not change much unless we change the scope, so going below this threshold most likely means the dataset in BQ is incomplete
+        "Table appears incomplete",
+        #check whether there are at least this many schools in the schools table
       IF
         (table = "dsi_users"
           AND row_count <25000,
@@ -44,7 +50,7 @@ IF
                 FROM
                   `teacher-vacancy-service.production_dataset.feb20_alertrun` ) < DATE_SUB(CURRENT_DATE(),INTERVAL 3 DAY)),
               "Latest date a row was updated in a frequently updated table from this source was at least 3 days ago",
-              "OK")))))) AS status
+              "OK"))))))) AS status
 FROM (
   SELECT
     table,
@@ -72,6 +78,7 @@ FROM (
     WHERE
       TYPE != 3 #exclude tables which are just Google Sheets - these don't have meaningful time/size data in __TABLES__
       AND table_id NOT LIKE "STATIC%" #don't monitor tables that don't change
+      AND table_id != 'CALCULATED_table_error_status' #don't monitor the table this query outputs to as we haven't written to it yet
       ))
 ORDER BY
   status DESC,

--- a/bigquery/monitor-tables-for-errors.sql
+++ b/bigquery/monitor-tables-for-errors.sql
@@ -17,40 +17,40 @@ IF
         AND row_count <28000,
         #sets a minimum threshold for the number of schools that should be in the database - this should not change much unless we change the scope, so going below this threshold most likely means the dataset in BQ is incomplete
         "Table appears incomplete",
-        #check whether there are at least this many schools in the schools table
-    IF
-      (table LIKE "%vacancy"
-        AND row_count <29000,
-        #sets a minimum threshold for the number of schools that should be in the database - this should not change much unless we change the scope, so going below this threshold most likely means the dataset in BQ is incomplete
-        "Table appears incomplete",
-        #check whether there are at least this many schools in the schools table
+        #check whether there are at least this many schools in the school table
       IF
-        (table = "dsi_users"
-          AND row_count <25000,
-          #sets a minimum threshold for the number of users that should be in the DSI database - this should not decrease, so going below this threshold most likely means the dataset in BQ is incomplete
+        (table LIKE "%vacancy"
+          AND row_count <29000,
+          #sets a minimum threshold for the number of vacancies  that should be in the database - this will always increase so should never dip below this number
           "Table appears incomplete",
-          #check whether there are at least this many users in the dsi_users table
+          #check whether there are at least this many vacancies in the vacancy table
         IF
-          (table = "dsi_approvers"
-            AND row_count <35000,
-            #sets a minimum threshold for the number of approvers that should be in the DSI database - this should not decrease, so going below this threshold most likely means the dataset in BQ is incomplete
+          (table = "dsi_users"
+            AND row_count <25000,
+            #sets a minimum threshold for the number of users that should be in the DSI database - this should not decrease, so going below this threshold most likely means the dataset in BQ is incomplete
             "Table appears incomplete",
-            #check whether there are at least this many approvers in the dsi_approvers table
+            #check whether there are at least this many users in the dsi_users table
           IF
-            ((table ="dsi_users"
-                AND (
-                SELECT
-                  MAX(update_datetime)
-                FROM
-                  `teacher-vacancy-service.production_dataset.dsi_users` ) < TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 3 DAY)) #check the last updated date for any user's data from DSI - produce error if more than three days old (i.e. if longer ago than the last working day)
-              OR (table LIKE "feb20_%"
-                AND (
-                SELECT
-                  MAX(run_on)
-                FROM
-                  `teacher-vacancy-service.production_dataset.feb20_alertrun` ) < DATE_SUB(CURRENT_DATE(),INTERVAL 3 DAY)),
-              "Latest date a row was updated in a frequently updated table from this source was at least 3 days ago",
-              "OK"))))))) AS status
+            (table = "dsi_approvers"
+              AND row_count <35000,
+              #sets a minimum threshold for the number of approvers that should be in the DSI database - this should not decrease, so going below this threshold most likely means the dataset in BQ is incomplete
+              "Table appears incomplete",
+              #check whether there are at least this many approvers in the dsi_approvers table
+            IF
+              ((table ="dsi_users"
+                  AND (
+                  SELECT
+                    MAX(update_datetime)
+                  FROM
+                    `teacher-vacancy-service.production_dataset.dsi_users` ) < TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 3 DAY)) #check the last updated date for any user's data from DSI - produce error if more than three days old (i.e. if longer ago than the last working day)
+                OR (table LIKE "feb20_%"
+                  AND (
+                  SELECT
+                    MAX(run_on)
+                  FROM
+                    `teacher-vacancy-service.production_dataset.feb20_alertrun` ) < DATE_SUB(CURRENT_DATE(),INTERVAL 3 DAY)),
+                "Latest date a row was updated in a frequently updated table from this source was at least 3 days ago",
+                "OK"))))))) AS status
 FROM (
   SELECT
     table,


### PR DESCRIPTION
- Adds size monitoring to vacancy table in BigQuery
- Removes monitoring of the monitoring table
- Takes Teaching Vacancies live vacancies count from web scraping if available and only if that fails obtains this from the db.