### PR TITLE
Add tick svg to summary page once a user publishes a listing

### DIFF
--- a/app/frontend/styles/components/hiring-staff.scss
+++ b/app/frontend/styles/components/hiring-staff.scss
@@ -25,3 +25,32 @@ body.hiring-staff {
   margin-bottom: 0;
   margin-top: 1.5rem;
 }
+
+.hod-checkmark {
+  font-size: 35px;
+  display: block;
+  margin: 15px auto;
+  position: relative;
+  background: rgba(255, 255, 255, 0.1);
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+
+  &::before {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  svg {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+  }
+
+  + .govuk-heading-l {
+    margin-top: 0;
+  }
+}

--- a/app/views/hiring_staff/vacancies/summary.html.haml
+++ b/app/views/hiring_staff/vacancies/summary.html.haml
@@ -3,6 +3,10 @@
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds
     .govuk-panel.govuk-panel--confirmation
+      %span.hod-checkmark
+        %svg{ xmlns: "http://www.w3.org/2000/svg", role: "presentation", focusable: "false", viewBox: "0 0 25 25", height: "40", width: "40" }
+          %path{ fill: "currentColor", d: "M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" }
+
       %h1.govuk-panel__title
         = t('jobs.confirmation_page.submitted')
 


### PR DESCRIPTION
## Jira ticket URL:
[TEVA-547](https://dfedigital.atlassian.net/browse/TEVA-547)
[Figma](https://www.figma.com/file/n2wLtKVQ2imMbjdPSHBRKW/Sprint-50?node-id=0%3A1
)
[Prototype](https://dfe-prototype.herokuapp.com/hs_2/8-success
)
## Changes in this PR:
- Add the tick svg

![image](https://user-images.githubusercontent.com/25187547/78681060-29f4b100-78e4-11ea-9a0e-5671aa8397e3.png)


