### PR TITLE
Fix copying a vacancy without about_school set

### DIFF
--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -27,7 +27,7 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
 
   def copy_form_params
     persist_nqt_job_role_to_nqt_attribute(:copy_vacancy_form)
-    params.require(:copy_vacancy_form).permit(:job_title,
+    params.require(:copy_vacancy_form).permit(:job_title, :about_school,
                                               :starts_on_dd, :starts_on_mm, :starts_on_yyyy,
                                               :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
                                               :expires_on_dd, :expires_on_mm, :expires_on_yyyy,

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -28,6 +28,16 @@
                   collection: job_role_options,
                   required: true
 
+      - unless @copy_form.vacancy.about_school.present?
+        = f.input :about_school,
+                  wrapper: 'textarea',
+                  as: :text,
+                  label: t('jobs.about_school', school: current_school.name),
+                  hint: t('helpers.hint.job_summary_form.about_school'),
+                  input_html: { rows: 10, value: @vacancy.school.description.presence.to_s, },
+                  wrapper_html: { id: 'about_school' },
+                  required: true
+
       %div.govuk-form-group#starts_on
         = f.gov_uk_date_field :starts_on,
                               legend_options: { page_heading: false, class: "govuk-label" }

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -18,7 +18,8 @@
                 wrapper_html: { id: 'job_title' },
                 input_html: { class: 'govuk-input' },
                 required: true
-      - if @copy_form.vacancy.job_roles&.none?
+
+      - unless @copy_form.vacancy.job_roles.present?
         = f.input :job_roles,
                   as: :check_boxes,
                   wrapper: :checkboxes,

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature 'Copying a vacancy' do
   context '#job_roles' do
     context 'when a copied job has no job role set' do
       scenario 'it shows the job role field' do
-        original_vacancy = build(:vacancy, :past_publish, job_roles: [], school: school)
+        original_vacancy = build(:vacancy, :past_publish, job_roles: nil, school: school)
         original_vacancy.save(validate: false)
 
         visit school_path
@@ -165,6 +165,39 @@ RSpec.feature 'Copying a vacancy' do
 
         expect(page).to have_content(I18n.t('jobs.copy_page_title', job_title: original_vacancy.job_title))
         expect(page).to_not have_content(I18n.t('jobs.job_roles'))
+      end
+    end
+  end
+
+  context '#about_school' do
+    context 'when a copied job has no about_school set' do
+      scenario 'it shows the about_school field' do
+        original_vacancy = build(:vacancy, :past_publish, about_school: nil, school: school)
+        original_vacancy.save(validate: false)
+
+        visit school_path
+
+        within('table.vacancies') do
+          click_on I18n.t('jobs.copy_link')
+        end
+
+        expect(page).to have_content(I18n.t('jobs.copy_page_title', job_title: original_vacancy.job_title))
+        expect(page).to have_content(I18n.t('jobs.about_school', school: school.name))
+      end
+    end
+
+    context 'when a copied job has about_school set' do
+      scenario 'it does not show the about_school field' do
+        original_vacancy = create(:vacancy, school: school)
+
+        visit school_path
+
+        within('table.vacancies') do
+          click_on I18n.t('jobs.copy_link')
+        end
+
+        expect(page).to have_content(I18n.t('jobs.copy_page_title', job_title: original_vacancy.job_title))
+        expect(page).to_not have_content(I18n.t('jobs.about_school', school: school.name))
       end
     end
   end


### PR DESCRIPTION
- Add the about school field to the copy view
- Pre-populate with school description if it exists
- Permit the field in the copy params
