### PR TITLE
Redirect to DfE Sign-in when signing out

### DIFF
--- a/app/controllers/hiring_staff/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sessions_controller.rb
@@ -5,11 +5,16 @@ class HiringStaff::SessionsController < HiringStaff::BaseController
   skip_before_action :check_terms_and_conditions, only: %i[destroy]
 
   def destroy
-    session.destroy
-    redirect_to root_path, notice: I18n.t('messages.access.signed_out')
+    redirect_to dsi_logout_url
   end
 
   private
+
+  def dsi_logout_url
+    url = URI.parse("#{ENV['DFE_SIGN_IN_ISSUER']}/session/end")
+    url.query = { post_logout_redirect_uri: auth_dfe_signout_url, id_token_hint: session[:id_token] }.to_query
+    url.to_s
+  end
 
   def redirect_to_dfe_sign_in
     # This is defined by the class name of our Omniauth strategy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
            path: '/dfe/sessions',
            controller: 'hiring_staff/sign_in/dfe/sessions'
   get '/auth/dfe/callback', to: 'hiring_staff/sign_in/dfe/sessions#create'
+  get '/auth/dfe/signout', to: 'hiring_staff/sign_in/dfe/sessions#destroy'
   get '/auth/failure', to: 'hiring_staff/sign_in/dfe/sessions#new'
 
   resource :terms_and_conditions, only: %i[show update], controller: 'hiring_staff/terms_and_conditions'

--- a/spec/features/hiring_staff_can_sign_out_spec.rb
+++ b/spec/features/hiring_staff_can_sign_out_spec.rb
@@ -8,6 +8,9 @@ RSpec.feature 'Hiring staff can sign out' do
     visit root_path
 
     click_on(I18n.t('nav.sign_out'))
+    # A request to logout is sent to DfE Sign-in system. On success DSI comes back at auth_dfe_signout_path
+    visit auth_dfe_signout_path
+
     within('.govuk-header__navigation') { expect(page).to have_content(I18n.t('nav.sign_in')) }
     expect(page).to have_content(I18n.t('messages.access.signed_out'))
   end

--- a/spec/features/hiring_staff_have_to_accept_terms_spec.rb
+++ b/spec/features/hiring_staff_have_to_accept_terms_spec.rb
@@ -59,6 +59,8 @@ RSpec.feature 'Hiring staff accepts terms and conditions' do
     scenario 'can sign out' do
       visit terms_and_conditions_path
       click_on(I18n.t('nav.sign_out'))
+      # A request to logout is sent to DfE Sign-in system. On success DSI comes back at auth_dfe_signout_path
+      visit auth_dfe_signout_path
 
       expect(page).to have_content(I18n.t('messages.access.signed_out'))
     end


### PR DESCRIPTION
With this fix we redirect to DfE Sign-in for signing out, effectively destroying the session and logging out the user.
