### PR TITLE
Implement Keyword search

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -8,6 +8,7 @@ class VacanciesController < ApplicationController
   DEFAULT_RADIUS = 20
 
   helper_method :location,
+                :keyword,
                 :subject,
                 :job_title,
                 :working_patterns,
@@ -92,6 +93,10 @@ class VacanciesController < ApplicationController
     return params[:location_category] if params[:location_category]
 
     params[:location]
+  end
+
+  def keyword
+    params[:keyword]
   end
 
   def subject

--- a/app/services/subscription_reference_generator.rb
+++ b/app/services/subscription_reference_generator.rb
@@ -23,14 +23,19 @@ class SubscriptionReferenceGenerator
 
     parts = []
 
-    parts.push(search_criteria['subject'].strip.split(/\s+/).join(' ')) if search_criteria.key?('subject')
-    parts.push(search_criteria['job_title'].strip.split(/\s+/).join(' ')) if search_criteria.key?('job_title')
+    parts.push(strip_split_join(search_criteria['keyword'])) if search_criteria.key?('keyword')
+    parts.push(strip_split_join(search_criteria['subject'])) if search_criteria.key?('subject')
+    parts.push(strip_split_join(search_criteria['job_title'])) if search_criteria.key?('job_title')
 
     parts.join(' ')
   end
 
+  def strip_split_join(field)
+    field.strip.split(/\s+/).join(' ')
+  end
+
   def job_type?
-    ['subject', 'job_title'].any? { |key| search_criteria.key?(key) }
+    ['keyword', 'subject', 'job_title'].any? { |key| search_criteria.key?(key) }
   end
 
   def location_part

--- a/app/services/vacancy_alert_filters.rb
+++ b/app/services/vacancy_alert_filters.rb
@@ -1,17 +1,15 @@
 class VacancyAlertFilters < VacancyFilters
-  AVAILABLE_FILTERS = %i[keyword].concat(superclass::AVAILABLE_FILTERS).freeze
+  AVAILABLE_FILTERS = superclass::AVAILABLE_FILTERS
 
   attr_reader(*AVAILABLE_FILTERS)
 
   def initialize(args)
     args = ActiveSupport::HashWithIndifferentAccess.new(args)
 
-    @keyword = args[:keyword]
-
     super(args)
   end
 
   def to_hash
-    super().merge(keyword: keyword)
+    super()
   end
 end

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -1,7 +1,7 @@
 class VacancyFilters
   include ActiveModel::Model
 
-  AVAILABLE_FILTERS = %i[location radius subject job_title working_patterns
+  AVAILABLE_FILTERS = %i[location radius keyword subject job_title working_patterns
                          phases newly_qualified_teacher].freeze
 
   attr_reader(*AVAILABLE_FILTERS)
@@ -11,6 +11,7 @@ class VacancyFilters
 
     @location = args[:location]
     @radius = args[:radius].to_s if args[:radius].present? && !location_category_search?
+    @keyword = args[:keyword]
     @subject = args[:subject]
     @job_title = args[:job_title]
     @newly_qualified_teacher = args[:newly_qualified_teacher]
@@ -22,6 +23,7 @@ class VacancyFilters
     {
       location: location,
       radius: radius,
+      keyword: keyword,
       subject: subject,
       job_title: job_title,
       working_patterns: working_patterns,
@@ -34,7 +36,7 @@ class VacancyFilters
     {
       location: location,
       radius: radius,
-      keyword: nil,
+      keyword: keyword,
       working_patterns: working_patterns,
       phases: phases,
       newly_qualified_teacher: newly_qualified_teacher,

--- a/app/views/pages/home/_search.html.haml
+++ b/app/views/pages/home/_search.html.haml
@@ -3,31 +3,8 @@
 = form_for VacancyFilters.new({}), as: '', url: jobs_path(anchor: 'vacancy-results'), method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
   = f.hidden_field :radius, value: '20'
 
+  = f.govuk_text_field(:keyword, label: { text: t('jobs.filters.keyword') }, placeholder: t('jobs.filters.keyword_hint'))
+
   = render 'shared/location_search_tag', location: nil, extra_label_class: 'govuk-label--s'
-
-  #accordion-default.govuk-accordion{ data: { module: 'govuk-accordion' } }
-    .govuk-accordion__section
-      .govuk-accordion__section-header
-        %h2.govuk-accordion__section-heading.govuk-body
-          %span#accordion-default-heading-1.govuk-accordion__section-button.govuk-label--s
-            = t('jobs.filters.subject')
-      #accordion-default-content-1.govuk-accordion__section-content{ aria: { labelledby: 'accordion-default-heading-1' } }
-        .govuk-body= f.govuk_text_field(:subject, label: { hidden: true, text: t('jobs.filters.subject') }, placeholder: t('jobs.filters.subject_hint'))
-
-    .govuk-accordion__section
-      .govuk-accordion__section-header
-        %h2.govuk-accordion__section-heading
-          %span#accordion-default-heading-2.govuk-accordion__section-button.govuk-label--s
-            = t('jobs.job_title')
-      #accordion-default-content-2.govuk-accordion__section-content{ aria: { labelledby: 'accordion-default-heading-2' } }
-        .govuk-body= f.govuk_text_field(:job_title, label: { hidden: true, text: t('jobs.filters.job_title') }, placeholder: t('jobs.filters.job_title_hint'))
-
-    .govuk-accordion__section
-      .govuk-accordion__section-header
-        %h2.govuk-accordion__section-heading
-          %span#accordion-default-heading-3.govuk-accordion__section-button.govuk-label--s
-            = t('jobs.filters.education_phase')
-      #accordion-default-content-3.govuk-accordion__section-content{ aria: { labelledby: 'accordion-default-heading-3' } }
-        .govuk-body= f.govuk_collection_check_boxes(:phases, school_phase_options, :second, :first, small: true)
 
   = f.govuk_submit t('buttons.apply_filters')

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -1,58 +1,17 @@
-- content_for :advanced_filters do
-  .govuk-form-group
-    = label_tag 'radius', t('jobs.filters.radius'), class: 'govuk-label'
-    = select_tag 'radius', options_for_select(radius_filter_options, radius), disabled: @filters.location_category_search?, class: 'govuk-select govuk-!-width-full'
-  .govuk-form-group
-    = label_tag 'subject', t('jobs.filters.subject'), class: 'govuk-label'
-    = search_field_tag :subject, subject, class: 'govuk-input', placeholder: t('jobs.filters.subject_hint')
-  .govuk-form-group
-    = label_tag 'job_title', t('jobs.filters.job_title'), class: 'govuk-label'
-    = search_field_tag :job_title, job_title, class: 'govuk-input', placeholder: t('jobs.filters.job_title_hint')
-  .govuk-form-group
-    %fieldset.govuk-fieldset
-      = label_tag 'working_pattern', t('jobs.filters.working_pattern'), class: 'govuk-label'
-      .govuk-checkboxes.checkbox-group.govuk-checkboxes--small
-        - working_pattern_options.each_with_index do |working_pattern, i|
-          .govuk-checkboxes__item
-            = check_box_tag 'working_patterns[]', working_pattern[1], working_pattern_checked?(working_pattern[1]), id: 'working_patterns_' + working_pattern[1], class: 'govuk-checkboxes__input'
-            = label_tag 'working_patterns[]', working_pattern[0], for: 'working_patterns_' + working_pattern[1], class: 'govuk-label govuk-checkboxes__label'
-  .govuk-form-group
-    %fieldset.govuk-fieldset
-      = label_tag 'phases', t('jobs.filters.education_phase'), class: 'govuk-label'
-      .govuk-checkboxes.checkbox-group.govuk-checkboxes--small{ class: ('checkbox-group--scrollable' unless specific_phases?) }
-        .govuk-checkboxes__item
-          = check_box_tag 'phases[]', '', !specific_phases?, id: 'phases_any', class: 'govuk-checkboxes__input'
-          = label_tag 'phases[]', 'Any', for: 'phases_any', class: 'govuk-label govuk-checkboxes__label'
-        .checkbox-group__divider
-          = t('jobs.filters.education_phase_divider')
-        - school_phase_options.each_with_index do |phase, i|
-          .govuk-checkboxes__item
-            = check_box_tag 'phases[]', phase[1], phase_checked?(phase[1]), id: 'phases_' + phase[1], class: 'govuk-checkboxes__input'
-            = label_tag 'phases[]', phase[0], for: 'phases_' + phase[1], class: 'govuk-label govuk-checkboxes__label'
-  .govuk-form-group
-    %fieldset.govuk-fieldset
-      .govuk-checkboxes
-        .govuk-checkboxes__item
-          = check_box_tag 'newly_qualified_teacher', 'true', nqt_suitable_checked?(newly_qualified_teacher), class: 'govuk-checkboxes__input'
-          = label_tag 'newly_qualified_teacher', t('jobs.filters.nqt_suitable'), class: 'govuk-label govuk-checkboxes__label'
-
-
 %aside.filter-vacancies
   %h2.govuk-heading-m
     =t('jobs.filters.title')
 
   = form_tag jobs_path(anchor: 'vacancy-results'), class: 'filters-form', method: :get do
+    .govuk-form-group
+      = label_tag 'keyword', t('jobs.filters.keyword'), class: 'govuk-label'
+      = search_field_tag :keyword, keyword, class: 'govuk-input', placeholder: t('jobs.filters.keyword_hint')
+
     = render 'shared/location_search_tag', extra_label_class: nil
 
-    - if local_assigns.fetch :collapsible?, false
-      %details.govuk-details{"data-module": "govuk-details", "data-summary-expanded": t('jobs.filters.summary_expanded'), "data-summary-collapsed": t('jobs.filters.summary_collapsed')}
-        %summary.govuk-details__summary
-          %span.govuk-details__summary-text
-            = t('jobs.filters.summary_nojs')
-        %div
-          = yield :advanced_filters
-    - else
-      = yield :advanced_filters
+    .govuk-form-group
+      = label_tag 'radius', t('jobs.filters.radius'), class: 'govuk-label'
+      = select_tag 'radius', options_for_select(radius_filter_options, radius), disabled: @filters.location_category_search?, class: 'govuk-select govuk-!-width-full'
 
     = hidden_field_tag :sort_column, sort_column
     = hidden_field_tag :sort_order, sort_order

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,6 +412,8 @@ en:
         candidates will be asked to email you for details.
     filters:
       title: 'Search job listings'
+      keyword: 'Keyword'
+      keyword_hint: 'Job title or subject, for example'
       location: 'Location'
       location_hint: 'Enter a city, town or postcode'
       use_current_location: 'use your current location'

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SubscriptionsController, type: :controller do
         {
           subscription: {
             email: 'foo@email.com',
-            search_criteria: { subject: 'english' }.to_json
+            search_criteria: { keyword: 'english' }.to_json
           }
         }
       end

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature 'Filtering vacancies' do
       visit jobs_path
 
       within '.filters-form' do
-        fill_in 'subject', with: 'English'
+        fill_in 'keyword', with: 'English'
         page.find('.govuk-button[type=submit]').click
       end
 
@@ -109,7 +109,7 @@ RSpec.feature 'Filtering vacancies' do
       visit jobs_path
 
       within '.filters-form' do
-        fill_in 'job_title', with: 'Tutor'
+        fill_in 'keyword', with: 'Tutor'
         page.find('.govuk-button[type=submit]').click
       end
 
@@ -118,128 +118,6 @@ RSpec.feature 'Filtering vacancies' do
       expect(page).not_to have_content(english_title_vacancy.job_title)
       expect(page).to have_content(arts_vacancy.job_title)
       expect(page).to have_content(english_subject_vacancy.job_title)
-    end
-  end
-
-  context 'when filtering by working patterns', elasticsearch: true do
-    let!(:part_time_vacancy) { create(:vacancy, :published, working_patterns: ['part_time']) }
-    let!(:full_time_vacancy) { create(:vacancy, :published, working_patterns: ['full_time']) }
-    let!(:job_share_vacancy) { create(:vacancy, :published, working_patterns: ['job_share']) }
-    let!(:full_and_part_time_vacancy) { create(:vacancy, :published, working_patterns: ['full_time', 'part_time']) }
-
-    before(:each) do
-      Vacancy.__elasticsearch__.client.indices.flush
-      visit jobs_path
-    end
-
-    scenario 'is filterable by single working pattern selection', elasticsearch: true do
-      within '.filters-form' do
-        check 'Part-time', name: 'working_patterns[]'
-        page.find('.govuk-button[type=submit]').click
-      end
-
-      expect(page).to have_content(part_time_vacancy.job_title)
-      expect(page).to have_content(full_and_part_time_vacancy.job_title)
-      expect(page).not_to have_content(full_time_vacancy.job_title)
-      expect(page).not_to have_content(job_share_vacancy.job_title)
-    end
-
-    scenario 'is filterable by multiple working pattern selections', elasticsearch: true do
-      within '.filters-form' do
-        check 'Part-time', name: 'working_patterns[]'
-        check 'Full-time', name: 'working_patterns[]'
-        page.find('.govuk-button[type=submit]').click
-      end
-
-      expect(page).to have_content(part_time_vacancy.job_title)
-      expect(page).to have_content(full_and_part_time_vacancy.job_title)
-      expect(page).to have_content(full_time_vacancy.job_title)
-      expect(page).not_to have_content(job_share_vacancy.job_title)
-    end
-  end
-
-  context 'with jobs with education phases', elasticsearch: true do
-    let!(:nursery_vacancy) { create(:vacancy, :published, school: build(:school, :nursery)) }
-    let!(:primary_vacancy) { create(:vacancy, :published, school: build(:school, :primary)) }
-    let!(:secondary_vacancy) { create(:vacancy, :published, school: build(:school, :secondary)) }
-
-    before(:each) { Vacancy.__elasticsearch__.client.indices.flush }
-
-    scenario 'is filterable by single education phase selection' do
-      visit jobs_path
-
-      within '.filters-form' do
-        check 'Primary', name: 'phases[]'
-        page.find('.govuk-button[type=submit]').click
-      end
-
-      expect(page).not_to have_content(nursery_vacancy.job_title)
-      expect(page).to have_content(primary_vacancy.job_title)
-      expect(page).not_to have_content(secondary_vacancy.job_title)
-    end
-
-    scenario 'is filterable by multiple education phase selections' do
-      visit jobs_path
-
-      within '.filters-form' do
-        check 'Primary', name: 'phases[]'
-        check 'Secondary', name: 'phases[]'
-        page.find('.govuk-button[type=submit]').click
-      end
-
-      expect(page).not_to have_content(nursery_vacancy.job_title)
-      expect(page).to have_content(primary_vacancy.job_title)
-      expect(page).to have_content(secondary_vacancy.job_title)
-    end
-
-    scenario 'displays all available jobs when "Any" education phase selected' do
-      visit jobs_path
-
-      within '.filters-form' do
-        check 'Any', name: 'phases[]'
-        page.find('.govuk-button[type=submit]').click
-      end
-
-      expect(page).to have_content(nursery_vacancy.job_title)
-      expect(page).to have_content(primary_vacancy.job_title)
-      expect(page).to have_content(secondary_vacancy.job_title)
-    end
-  end
-
-  context 'when filtering by newly qualified teacher', elasticsearch: true do
-    scenario 'search results can be filtered by NQT suitability' do
-      nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: true)
-      not_nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: false)
-
-      Vacancy.__elasticsearch__.client.indices.flush
-      visit jobs_path
-
-      within '.filters-form' do
-        check 'newly_qualified_teacher'
-        page.find('.govuk-button[type=submit]').click
-      end
-
-      expect(page).to have_content(nqt_suitable_vacancy.job_title)
-      expect(page).not_to have_content(not_nqt_suitable_vacancy.job_title)
-      expect(page).to have_field('newly_qualified_teacher', checked: true)
-    end
-
-    scenario 'displays all available jobs when NQT suitable is unchecked', elasticsearch: true do
-      nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: true)
-      not_nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: false)
-
-      Vacancy.__elasticsearch__.client.indices.flush
-      visit jobs_path
-
-      within '.filters-form' do
-        check 'newly_qualified_teacher'
-        uncheck 'newly_qualified_teacher'
-        page.find('.govuk-button[type=submit]').click
-      end
-
-      expect(page).to have_content(not_nqt_suitable_vacancy.job_title)
-      expect(page).to have_content(nqt_suitable_vacancy.job_title)
-      expect(page).to have_field('newly_qualified_teacher', checked: false)
     end
   end
 
@@ -255,12 +133,12 @@ RSpec.feature 'Filtering vacancies' do
         total_count: 3,
         location: '',
         radius: '20',
-        keyword: nil,
+        keyword: 'Physics',
         working_patterns: nil,
         phases: nil,
-        newly_qualified_teacher: 'true',
-        subject: 'Physics',
-        job_title: ''
+        newly_qualified_teacher: nil,
+        subject: nil,
+        job_title: nil
       }
 
       expect(AuditSearchEventJob).to receive(:perform_later)
@@ -270,8 +148,7 @@ RSpec.feature 'Filtering vacancies' do
 
       Timecop.freeze(timestamp) do
         within '.filters-form' do
-          check 'newly_qualified_teacher'
-          fill_in 'subject', with: 'Physics'
+          fill_in 'keyword', with: 'Physics'
           page.find('.govuk-button[type=submit]').click
         end
       end
@@ -287,12 +164,12 @@ RSpec.feature 'Filtering vacancies' do
         total_count: 12,
         location: '',
         radius: '20',
-        keyword: nil,
+        keyword: 'Math',
         working_patterns: nil,
         phases: nil,
-        newly_qualified_teacher: 'true',
-        subject: 'Math',
-        job_title: ''
+        newly_qualified_teacher: nil,
+        subject: nil,
+        job_title: nil
       }
 
       expect(AuditSearchEventJob).to receive(:perform_later)
@@ -302,8 +179,7 @@ RSpec.feature 'Filtering vacancies' do
 
       Timecop.freeze(timestamp) do
         within '.filters-form' do
-          check 'newly_qualified_teacher'
-          fill_in 'subject', with: 'Math'
+          fill_in 'keyword', with: 'Math'
           page.find('.govuk-button[type=submit]').click
         end
       end
@@ -318,7 +194,7 @@ RSpec.feature 'Filtering vacancies' do
       visit jobs_path
 
       within '.filters-form' do
-        fill_in 'subject', with: 'Physics'
+        fill_in 'keyword', with: 'Physics'
         page.find('.govuk-button[type=submit]').click
       end
 

--- a/spec/features/job_seekers_can_search_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_search_vacancies_spec.rb
@@ -2,43 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Searching vacancies by subject' do
   describe 'searchable fields' do
-    context '#job_title' do
-      scenario 'exact match', elasticsearch: true do
-        vacancy = create(:vacancy, job_title: 'Maths Teacher')
-
-        Vacancy.__elasticsearch__.client.indices.flush
-
-        visit jobs_path
-
-        expect(page.find('.vacancy:eq(1)')).to have_content(vacancy.job_title)
-
-        within '.filters-form' do
-          fill_in 'subject', with: vacancy.job_title
-          page.find('.govuk-button[type=submit]').click
-        end
-
-        expect(page.find('.vacancy:eq(1)')).to have_content(vacancy.job_title)
-      end
-
-      scenario 'partial match', elasticsearch: true do
-        vacancy = create(:vacancy, job_title: 'Maths Teacher')
-
-        Vacancy.__elasticsearch__.client.indices.flush
-
-        visit jobs_path
-
-        expect(page.find('.vacancy:eq(1)')).to have_content(vacancy.job_title)
-
-        within '.filters-form' do
-          fill_in 'subject', with: 'Math'
-          page.find('.govuk-button[type=submit]').click
-        end
-
-        expect(page.find('.vacancy:eq(1)')).to have_content(vacancy.job_title)
-      end
-    end
-
-    scenario '#subject', elasticsearch: true do
+    scenario '#keyword', elasticsearch: true do
       arts_vacancy = create(:vacancy, job_title: 'Arts Teacher', subject: create(:subject, name: 'Arts'),
                                       first_supporting_subject: create(:subject, name: 'English'))
       maths_vacancy = create(:vacancy, job_title: 'Teacher Bar', subject: create(:subject, name: 'Maths'))
@@ -53,7 +17,7 @@ RSpec.feature 'Searching vacancies by subject' do
       expect(page).to have_content(english_vacancy.job_title)
 
       within '.filters-form' do
-        fill_in 'subject', with: 'English'
+        fill_in 'keyword', with: 'English'
         page.find('.govuk-button[type=submit]').click
       end
 
@@ -74,7 +38,7 @@ RSpec.feature 'Searching vacancies by subject' do
       expect(page.find('.vacancy:eq(1)')).to have_content(vacancy.job_title)
 
       within '.filters-form' do
-        fill_in 'subject', with: 'standing'
+        fill_in 'keyword', with: 'standing'
         page.find('.govuk-button[type=submit]').click
       end
 
@@ -82,7 +46,7 @@ RSpec.feature 'Searching vacancies by subject' do
     end
   end
 
-  context 'fuzzy search on subject' do
+  context 'fuzzy search on keyword' do
     scenario 'finds on any searchable word with a single typo', elasticsearch: true do
       vacancy = create(:vacancy, job_title: 'Maths Teacher')
 
@@ -93,7 +57,7 @@ RSpec.feature 'Searching vacancies by subject' do
       expect(page.find('.vacancy:eq(1)')).to have_content(vacancy.job_title)
 
       within '.filters-form' do
-        fill_in 'subject', with: 'Mahts'
+        fill_in 'keyword', with: 'Mahts'
         page.find('.govuk-button[type=submit]').click
       end
 
@@ -131,7 +95,7 @@ RSpec.feature 'Searching vacancies by subject' do
       expect(page.all('.vacancy', count: 5)).to_not be_empty
 
       within '.filters-form' do
-        fill_in 'subject', with: 'Science'
+        fill_in 'keyword', with: 'Science'
         page.find('.govuk-button[type=submit]').click
       end
 
@@ -140,7 +104,7 @@ RSpec.feature 'Searching vacancies by subject' do
       expect(page).to have_content('2 jobs match your search')
 
       within '.filters-form' do
-        fill_in 'subject', with: 'Sceinc'
+        fill_in 'keyword', with: 'Sceinc'
         page.find('.govuk-button[type=submit]').click
       end
 
@@ -149,47 +113,13 @@ RSpec.feature 'Searching vacancies by subject' do
       expect(page).to have_content('2 jobs match your search')
 
       within '.filters-form' do
-        fill_in 'subject', with: 'Part'
+        fill_in 'keyword', with: 'Part'
         page.find('.govuk-button[type=submit]').click
       end
       expect(page).to have_content('0 jobs match your search')
 
       within '.filters-form' do
-        fill_in 'subject', with: 'time'
-        page.find('.govuk-button[type=submit]').click
-      end
-      expect(page).to have_content('0 jobs match your search')
-    end
-
-    scenario 'does not include results with words removed from the index in their title when searching by job title' do
-      visit jobs_path
-
-      expect(page.all('.vacancy', count: 5)).to_not be_empty
-
-      within '.filters-form' do
-        fill_in 'job_title', with: 'Science'
-        page.find('.govuk-button[type=submit]').click
-      end
-
-      expect(page.find('.vacancy:eq(1)')).to have_content('Science Teacher')
-      expect(page).to have_content('1 job matches your search')
-
-      within '.filters-form' do
-        fill_in 'job_title', with: 'Sceinc'
-        page.find('.govuk-button[type=submit]').click
-      end
-
-      expect(page.find('.vacancy:eq(1)')).to have_content('Science Teacher')
-      expect(page).to have_content('1 job matches your search')
-
-      within '.filters-form' do
-        fill_in 'job_title', with: 'Part'
-        page.find('.govuk-button[type=submit]').click
-      end
-      expect(page).to have_content('0 jobs match your search')
-
-      within '.filters-form' do
-        fill_in 'job_title', with: 'time'
+        fill_in 'keyword', with: 'time'
         page.find('.govuk-button[type=submit]').click
       end
       expect(page).to have_content('0 jobs match your search')
@@ -205,7 +135,7 @@ RSpec.feature 'Searching vacancies by subject' do
       visit jobs_path
 
       within '.filters-form' do
-        fill_in 'subject', with: 'Maths'
+        fill_in 'keyword', with: 'Maths'
         page.find('.govuk-button[type=submit]').click
       end
 
@@ -213,7 +143,7 @@ RSpec.feature 'Searching vacancies by subject' do
       expect(page).to have_content('Maths Teacher')
 
       page.find('.govuk-back-link').click
-      expect(page.current_url).to include('subject=Maths')
+      expect(page.current_url).to include('keyword=Maths')
     end
   end
 
@@ -226,7 +156,7 @@ RSpec.feature 'Searching vacancies by subject' do
       visit jobs_path
 
       within '.filters-form' do
-        fill_in 'subject', with: 'Biology'
+        fill_in 'keyword', with: 'Biology'
         page.find('.govuk-button[type=submit]').click
       end
 
@@ -234,7 +164,7 @@ RSpec.feature 'Searching vacancies by subject' do
       expect(page).to have_content('Biology Teacher')
 
       page.find('.govuk-back-link').click
-      expect(page.current_url).to include('subject=Biology')
+      expect(page.current_url).to include('keyword=Biology')
     end
   end
 end

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -12,22 +12,14 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
     end
 
     scenario 'can view the search criteria' do
-      visit new_subscription_path(search_criteria: { newly_qualified_teacher: 'true',
-                                                     subject: 'physics',
-                                                     job_title: 'teacher',
-                                                     location: 'EC2 9AN',
-                                                     radius: '10',
-                                                     working_patterns: ['full_time'] })
+      visit new_subscription_path(search_criteria: { keyword: 'physics', location: 'EC2 9AN', radius: '10' })
 
-      expect(page).to have_content('Subject: physics')
-      expect(page).to have_content('Job title: teacher')
-      expect(page).to have_content('Suitable for NQTs')
+      expect(page).to have_content('Keyword: physics')
       expect(page).to have_content('Location: Within 10 miles of EC2 9AN')
-      expect(page).to have_content('Working patterns: Full-time')
     end
 
     scenario 'subscribing to a search creates a new daily subscription audit' do
-      visit new_subscription_path(search_criteria: { job_title: 'test' })
+      visit new_subscription_path(search_criteria: { keyword: 'test' })
       fill_in 'subscription[email]', with: 'jane.doe@example.com'
       click_on 'Subscribe'
 
@@ -74,22 +66,20 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
         end
 
         scenario 'where they can go back to the filtered search' do
-          visit new_subscription_path(search_criteria: { job_title: 'teacher',
-                                                         newly_qualified_teacher: 'true' })
+          visit new_subscription_path(search_criteria: { keyword: 'teacher' })
           fill_in 'subscription[email]', with: 'jane.doe@example.com'
           click_on 'Subscribe'
 
           click_on 'Return to your search results'
 
-          expect(page.find('#job_title').value).to eq('teacher')
-          expect(page.find('#newly_qualified_teacher').checked?).to eq(true)
+          expect(page.find('#keyword').value).to eq('teacher')
         end
       end
     end
 
     context 'is not able to create a new subscription' do
       scenario 'when the email address is invalid' do
-        visit new_subscription_path(search_criteria: { job_title: 'test' })
+        visit new_subscription_path(search_criteria: { keyword: 'test' })
         fill_in 'subscription[email]', with: 'jane.doe@example'
         click_on 'Subscribe'
 
@@ -120,7 +110,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
       visit jobs_path
 
       within '.filters-form' do
-        fill_in 'subject', with: 'English'
+        fill_in 'keyword', with: 'English'
         page.find('.govuk-button[type=submit]').click
       end
 
@@ -129,7 +119,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
       click_on I18n.t('subscriptions.link.text')
 
       expect(page).to have_content(I18n.t('subscriptions.new.page_description'))
-      expect(page).to have_content('Subject: English')
+      expect(page).to have_content('Keyword: English')
 
       fill_in 'subscription[email]', with: 'john.doe@sample-email.com'
       fill_in 'subscription[reference]', with: 'Daily alerts for: English'

--- a/spec/features/job_seekers_can_view_home_page_spec.rb
+++ b/spec/features/job_seekers_can_view_home_page_spec.rb
@@ -6,10 +6,7 @@ RSpec.feature 'Viewing the home page' do
   scenario 'searching from the blue box lands on the jobs index page', elasticsearch: true do
     within '.search_panel' do
       fill_in 'location', with: 'bristol'
-      fill_in 'subject', with: 'math'
-      fill_in 'job_title', with: 'head teacher'
-      check 'Primary', name: 'phases[]'
-      check 'Secondary', name: 'phases[]'
+      fill_in 'keyword', with: 'math'
 
       page.find('.govuk-button[type=submit]').click
     end
@@ -17,11 +14,7 @@ RSpec.feature 'Viewing the home page' do
     expect(page.current_path).to eq(jobs_path)
 
     expect(find_field('location').value).to eq 'bristol'
-    expect(find_field('subject').value).to eq 'math'
-    expect(find_field('job_title').value).to eq 'head teacher'
-    expect(page).to have_field('phases_primary', checked: true)
-    expect(page).to have_field('phases_secondary', checked: true)
-    expect(page).to have_field('phases_not_applicable', checked: false)
+    expect(find_field('keyword').value).to eq 'math'
   end
 
   context 'request headers' do

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature 'Viewing vacancies' do
     Vacancy.__elasticsearch__.client.indices.flush
     visit jobs_path
     within '.filters-form' do
-      fill_in 'subject', with: 'English'
+      fill_in 'keyword', with: 'English'
       page.find('.govuk-button[type=submit]').click
     end
     expect(page).to have_content(I18n.t('jobs.job_count', count: vacancies.count))
@@ -85,7 +85,7 @@ RSpec.feature 'Viewing vacancies' do
     Vacancy.__elasticsearch__.client.indices.flush
     visit jobs_path
     within '.filters-form' do
-      fill_in 'subject', with: 'English'
+      fill_in 'keyword', with: 'English'
       page.find('.govuk-button[type=submit]').click
     end
     expect(page).to have_content(I18n.t('jobs.job_count_plural', count: vacancies.count))
@@ -110,7 +110,7 @@ RSpec.feature 'Viewing vacancies' do
     visit jobs_path
 
     within '.filters-form' do
-      fill_in 'subject', with: 'English'
+      fill_in 'keyword', with: 'English'
       click_on I18n.t('buttons.apply_filters')
     end
 
@@ -159,7 +159,7 @@ RSpec.feature 'Viewing vacancies' do
     visit jobs_path
 
     within '.filters-form' do
-      fill_in 'subject', with: 'Maths'
+      fill_in 'keyword', with: 'Maths'
       click_button('Search')
     end
 
@@ -187,7 +187,7 @@ RSpec.feature 'Viewing vacancies' do
     visit jobs_path
 
     within '.filters-form' do
-      fill_in 'subject', with: 'English'
+      fill_in 'keyword', with: 'English'
       expect(find('.govuk-button').value).to eq('Search')
       click_on I18n.t('buttons.apply_filters')
     end
@@ -204,21 +204,6 @@ RSpec.feature 'Viewing vacancies' do
       visit jobs_path(vacancy)
 
       verify_vacancy_list_page_details(VacancyPresenter.new(vacancy))
-    end
-  end
-
-  context 'when the user is not on mobile' do
-    scenario 'they should not see the \'refine your search\' link' do
-      visit jobs_path
-      expect(page).not_to have_content('Refine your search')
-    end
-  end
-
-  context 'when the user is on mobile', js: true do
-    scenario 'they should see the \'Show more filters\' link' do
-      page.driver.add_header('User-Agent', USER_AGENTS['MOBILE_CHROME'])
-      visit jobs_path
-      expect(page).to have_content(I18n.t('jobs.filters.summary_collapsed'))
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Subscription, type: :model do
     context 'when common search criteria is provided' do
       it 'generates a reference on initialization' do
         subscription = Subscription.new(search_criteria: {
-          location: 'Somewhere', radius: 30, subject: 'english maths science'
+          location: 'Somewhere', radius: 30, keyword: 'english maths science'
         }.to_json)
 
         expect(subscription.reference).to eq('English maths science jobs within 30 miles of Somewhere')

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -8,14 +8,15 @@ RSpec.describe Vacancy, type: :model do
   describe '.public_search' do
     context 'when there were no results' do
       it 'records the event in Rollbar' do
-        filters = VacancyFilters.new(subject: 'subject', job_title: 'job title')
+        filters = VacancyFilters.new(keyword: 'keyword')
         expect(Rollbar).to receive(:log)
           .with(:info,
                 'A search returned 0 results',
                 location: nil,
                 radius: nil,
-                subject: 'subject',
-                job_title: 'job title',
+                keyword: 'keyword',
+                subject: nil,
+                job_title: nil,
                 working_patterns: nil,
                 newly_qualified_teacher: nil,
                 phases: nil)

--- a/spec/services/subscription_reference_generator_spec.rb
+++ b/spec/services/subscription_reference_generator_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe SubscriptionReferenceGenerator do
       end
     end
 
-    context 'with subject in search criteria' do
-      let(:params) { { search_criteria: { 'subject' => 'maths and science', 'radius' => 20 } } }
+    context 'with keyword in search criteria' do
+      let(:params) { { search_criteria: { 'keyword' => 'maths and science', 'radius' => 20 } } }
 
       it 'returns a reference containing the subject' do
         service = described_class.new(params)
@@ -45,7 +45,7 @@ RSpec.describe SubscriptionReferenceGenerator do
       let(:params) do
         {
           search_criteria: {
-            'subject' => 'maths and science',
+            'keyword' => 'maths and science',
             'job_title' => 'headteacher',
             'radius' => 20
           }

--- a/spec/services/vacancy_filters_spec.rb
+++ b/spec/services/vacancy_filters_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe VacancyFilters do
     it 'returns a hash of the reader attributes' do
       filters = described_class.new(
         location: 'location',
+        keyword: 'keyword',
         subject: 'subject',
         job_title: 'job_title',
         radius: 20,
@@ -80,6 +81,7 @@ RSpec.describe VacancyFilters do
 
       expect(result).to eql(
         location: 'location',
+        keyword: 'keyword',
         subject: 'subject',
         job_title: 'job_title',
         radius: '20',


### PR DESCRIPTION
<img width="964" alt="Screenshot 2020-04-14 at 16 21 11" src="https://user-images.githubusercontent.com/7215/79242393-2fb23f80-7e6c-11ea-8593-f621c19e5f6a.png">

This sets up the new views on the homepage and on the vacancies index page. It implements keyword search with ElasticSearch and keeps old email subscription working. 

All the feature specs updated to work with keyword search.