### PR TITLE
Fix bug that would raise error on text inputs including an ampersand

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,10 @@ module ApplicationHelper
   include ActionView::Helpers::NumberHelper
   include ActionView::Helpers::SanitizeHelper
 
+  def sanitize(text, options = {})
+    super(text, options)&.gsub('&amp;', '&')
+  end
+
   def body_class
     auth_class = authenticated? ? 'hiring-staff' : ''
     action_class = controller_name + '_' + action_name

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -57,6 +57,18 @@ RSpec.describe JobSpecificationForm, type: :model do
           )
         end
       end
+
+      context 'when title does not contain HTML tags' do
+        context 'job title contains &' do
+          let(:job_title) { 'Job & another job' }
+
+          it 'does not validate presence of HTML tags' do
+            expect(job_specification.errors.messages[:job_title]).to_not include(
+              I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.invalid_characters')
+            )
+          end
+        end
+      end
     end
   end
 

--- a/spec/form_models/pay_package_form_spec.rb
+++ b/spec/form_models/pay_package_form_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe PayPackageForm, type: :model do
           )
         end
       end
+
+      context 'when salary does not contain HTML tags' do
+        context 'salary contains &' do
+          let(:salary) { 'Pay scale & another pay scale' }
+
+          it 'does not validate presence of HTML tags' do
+            expect(pay_package.errors.messages[:salary]).to_not include(
+              I18n.t('activemodel.errors.models.pay_package_form.attributes.salary.invalid_characters')
+            )
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Currently if hiring staff enter an ampersand '&' in the job_title or salary text input fields, an incorrect error is returned stating that the field contains html inputs. 

![image](https://user-images.githubusercontent.com/25187547/79217842-69bd1a80-7e47-11ea-8f65-39c6bce4ea2f.png)


**In this PR**
- Fix the bug in the field validation causing this
- Add a test to ensure hiring staff can use '&'
