### PR TITLE
Algolia indexing - reopened PR

### DIFF
--- a/app/controllers/hiring_staff/identifications_controller.rb
+++ b/app/controllers/hiring_staff/identifications_controller.rb
@@ -14,6 +14,7 @@ class HiringStaff::IdentificationsController < HiringStaff::BaseController
   end
 
   def redirect_signed_in_users
+    binding.pry
     return redirect_to school_path if session.key?(:urn)
   end
 end

--- a/app/controllers/hiring_staff/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sessions_controller.rb
@@ -5,6 +5,7 @@ class HiringStaff::SessionsController < HiringStaff::BaseController
   skip_before_action :check_terms_and_conditions, only: %i[destroy]
 
   def destroy
+    binding.pry
     session.destroy
     redirect_to root_path, notice: I18n.t('messages.access.signed_out')
   end

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -11,6 +11,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
   end
 
   def create
+    binding.pry # hi, you are creating the session! NOT expecting this from post logout redirect.
     Rails.logger.warn("Hiring staff signed in: #{user_id}")
     audit_successful_authentication
 

--- a/config/initializers/algoliasearch.rb
+++ b/config/initializers/algoliasearch.rb
@@ -1,0 +1,5 @@
+AlgoliaSearch.configuration = {
+    application_id: ENV.fetch('ALGOLIA_APP_ID'),
+    api_key: ENV.fetch('ALGOLIA_WRITE_API_KEY')
+}
+

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -8,6 +8,7 @@ module OmniAuth
       # rubocop:disable Style/GuardClause
       # Please refer to this commit to read why this has been copied from: https://github.com/m0n9oose/omniauth_openid_connect/blob/master/lib/omniauth/strategies/openid_connect.rb
       def callback_phase
+        binding.pry # We're in the monkey patch area.
         Rollbar.log(:info, 'A sign-in callback was started',
                     stored_state: session['omniauth.state'],
                     accept_header: request.has_header?('Accept') ? request.get_header('Accept') : request.get_header('HTTP_ACCEPT'),

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -224,9 +224,9 @@ ActiveRecord::Schema.define(version: 2020_04_06_102653) do
     t.uuid "publisher_user_id"
     t.datetime "expiry_time"
     t.string "supporting_documents"
+    t.string "job_roles", array: true
     t.string "salary"
     t.integer "completed_step"
-    t.string "job_roles", array: true
     t.text "about_school"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["expiry_time"], name: "index_vacancies_on_expiry_time"


### PR DESCRIPTION
I have already merged a very similar PR #1489 onto master (accidentally), and then rolled back the merge in #1491. This reopens the changes in #1489 as a new PR on a new branch, so that the errors can be fixed.

NB this PR isn't ready as it contains the wrong commits.

Original PR description:

This PR emerged from the draft PR for the search spike. https://github.com/DFE-Digital/teacher-vacancy-service/pull/1471

This PR implements step 1 in the below Jira ticket.

##  Jira ticket URL:

https://dfedigital.atlassian.net/browse/TEVA-659

## Changes in this PR:

This PR includes the necessary code for indexing Vacancy (sending our data to Algolia).

To see the Vacancy index, including examples of records: https://www.algolia.com/apps/QM2YE0HRBW/explorer/browse/Vacancy

You will need to be invited to Todd's Algolia team. One record copied below.

```ruby
{
      "first_supporting_subject": null,
      "job_roles": null,
      "job_title": "Business Studies Teacher",
      "second_supporting_subject": null,
      "working_patterns": [
        "full_time"
      ],
      "expiry_date": 1585267200,
      "last_updated_at": 1585274468,
      "listing_status": "published",
      "newly_qualified_teacher_status": false,
      "permalink": "business-studies-teacher-whitley-academy",
      "publication_date": 1583884800,
      "school": {
        "name": "Whitley Academy",
        "address": "Abbey Road",
        "county": "West Midlands",
        "local_authority": "Coventry",
        "phase": "secondary",
        "postcode": "CV3 4BD",
        "region": "West Midlands",
        "town": "Coventry"
      },
      "start_date": 1598918400,
      "subject": "Business Studies",
      "_geoloc": {
        "lat": 52.38614499118846,
        "lng": -1.486365476684278
      },
      "objectID": "fff5bc2f-7b7e-48f1-b7bf-c80f85a1d399",
}
```

To index Vacancy attributes for consumption by Algolia (you'll need to get the necessary API keys from secrets repo):

    To index Vacancy for the first time, run this in the console:
    Vacancy.reindex

    To reindex Vacancy (without deleting removed objects):
    Vacancy.reindex!

## Next steps:

- [ ] Ensure that we are configured to use automatic indexing, which comes by default with the algoliasearch-rails but can be disabled if we are overwriting method hooks. So that updating, creating, and deleting a record result in appropriate changes to the Algolia vacancy index.
- [ ] Add tests which make sure Algolia is notified when a new record is added.
- [ ] Ensure (either in automatic tests or manually) that changes in development database only affect Vacancy_development and prod only affects prod etc.