### PR TITLE
Revert "Change 'Save and continue' to 'Continue'"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -598,7 +598,7 @@ en:
     delete: 'Delete'
     dismiss: 'Dismiss'
     find: 'Find'
-    save_and_continue: 'Continue'
+    save_and_continue: 'Save and continue'
     save_and_return: 'Save and return later'
     submit: 'Submit'
     update_job: 'Update job'


### PR DESCRIPTION
Reverts DFE-Digital/teacher-vacancy-service#1495

This is because it has not yet been run past UX, and may be dependent on TEVA-539.