### PR TITLE
Change which fields are required when exporting DSI users to BigQuery

### DIFF
--- a/lib/export_dsi_users_to_big_query.rb
+++ b/lib/export_dsi_users_to_big_query.rb
@@ -31,13 +31,13 @@ class ExportDsiUsersToBigQuery < BaseDsiExporter
   def insert_table_data(batch)
     dataset.insert TABLE_NAME, present_for_big_query(batch), autocreate: true do |schema|
       schema.string 'user_id', mode: :required
-      schema.string 'role', mode: :required
+      schema.string 'role', mode: :nullable
       schema.timestamp 'approval_datetime', mode: :nullable
       schema.timestamp 'update_datetime', mode: :nullable
-      schema.string 'given_name', mode: :required
-      schema.string 'family_name', mode: :required
+      schema.string 'given_name', mode: :nullable
+      schema.string 'family_name', mode: :nullable
       schema.string 'email', mode: :required
-      schema.integer 'school_urn', mode: :nullable
+      schema.integer 'school_urn', mode: :required
     end
   end
 


### PR DESCRIPTION
This PR should address an unknown issue which led to users disappearing from the BigQuery table overnight. It changes which fields we require when exporting DSI users from the DSI API into BigQuery. 

As discussed with @stevenleggdfe, a user must have
- User ID
- Email
- School URN

All other fields should be nullable.