### PR TITLE
Give hiring staff the ability to save a draft and return later

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -50,8 +50,11 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
   end
 
   def redirect_to_school_draft_jobs(vacancy)
-    redirect_to jobs_with_type_school_path('draft'),
-        success: I18n.t('messages.jobs.draft_saved', job_title: vacancy.job_title)
+    redirect_to jobs_with_type_school_path(
+      'draft',
+      sort_column: 'updated_at',
+      sort_order: 'desc'
+    ), success: I18n.t('messages.jobs.draft_saved', job_title: vacancy.job_title)
   end
 
   def reset_session_vacancy!

--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -49,6 +49,11 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
     redirect_to next_path
   end
 
+  def redirect_to_school_draft_jobs(vacancy)
+    redirect_to jobs_with_type_school_path('draft'),
+        success: I18n.t('messages.jobs.draft_saved', job_title: vacancy.job_title)
+  end
+
   def reset_session_vacancy!
     session[:vacancy_attributes] = nil
     session[:current_step] = nil

--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -12,8 +12,8 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
 
     if @application_details_form.valid?
       session[:completed_step] = current_step
-      vacancy = update_vacancy(@application_details_form.params_to_save)
-      return redirect_after_validation_and_update
+      update_vacancy(@application_details_form.params_to_save)
+      redirect_after_validation_and_update
     else
       session[:current_step] = :step_4 unless session[:current_step].eql?(:review)
       redirect_to application_details_school_job_path(anchor: 'errors')

--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -13,7 +13,7 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
     if @application_details_form.valid?
       session[:completed_step] = current_step
       vacancy = update_vacancy(@application_details_form.params_to_save)
-      redirect_to_next_step(vacancy)
+      return redirect_after_validation_and_update
     else
       session[:current_step] = :step_4 unless session[:current_step].eql?(:review)
       redirect_to application_details_school_job_path(anchor: 'errors')
@@ -58,5 +58,13 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
 
   def next_step
     school_job_job_summary_path(@vacancy.id)
+  end
+
+  def redirect_after_validation_and_update
+    if params[:commit] == I18n.t('buttons.save_and_return')
+      redirect_to_school_draft_jobs(@vacancy)
+    elsif params[:commit] == I18n.t('buttons.save_and_continue')
+      redirect_to_next_step(@vacancy)
+    end
   end
 end

--- a/app/controllers/hiring_staff/vacancies/documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/documents_controller.rb
@@ -64,6 +64,7 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
 
   def redirect_to_next_step_if_save_and_continue
     if params[:commit] == I18n.t('buttons.save_and_continue')
+      session[:clicked_continue_at_school_job_documents_path] = true
       redirect_to_next_step(@vacancy)
     elsif params[:commit] == I18n.t('buttons.update_job')
       redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')

--- a/app/controllers/hiring_staff/vacancies/documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/documents_controller.rb
@@ -67,6 +67,8 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
       redirect_to_next_step(@vacancy)
     elsif params[:commit] == I18n.t('buttons.update_job')
       redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')
+    elsif params[:commit] == I18n.t('buttons.save_and_return')
+      redirect_to_school_draft_jobs(@vacancy)
     end
   end
 

--- a/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
@@ -11,7 +11,7 @@ class HiringStaff::Vacancies::JobSummaryController < HiringStaff::Vacancies::App
     if @job_summary_form.valid?
       update_vacancy(job_summary_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue
+      return redirect_after_validation_and_update
     end
 
     render :show
@@ -24,11 +24,13 @@ class HiringStaff::Vacancies::JobSummaryController < HiringStaff::Vacancies::App
                                          .merge(completed_step: current_step)
   end
 
-  def redirect_to_next_step_if_save_and_continue
+  def redirect_after_validation_and_update
     if params[:commit] == I18n.t('buttons.save_and_continue')
       redirect_to school_job_review_path(@vacancy.id)
     elsif params[:commit] == I18n.t('buttons.update_job')
       redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')
+    elsif params[:commit] == I18n.t('buttons.save_and_return')
+      redirect_to_school_draft_jobs(@vacancy)
     end
   end
 end

--- a/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
@@ -11,7 +11,7 @@ class HiringStaff::Vacancies::PayPackageController < HiringStaff::Vacancies::App
     if @pay_package_form.valid?
       update_vacancy(pay_package_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue
+      return redirect_after_validation_and_update
     end
 
     render :show
@@ -27,11 +27,13 @@ class HiringStaff::Vacancies::PayPackageController < HiringStaff::Vacancies::App
     supporting_documents_school_job_path
   end
 
-  def redirect_to_next_step_if_save_and_continue
+  def redirect_after_validation_and_update
     if params[:commit] == I18n.t('buttons.save_and_continue')
       redirect_to_next_step(@vacancy)
     elsif params[:commit] == I18n.t('buttons.update_job')
       redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')
+    elsif params[:commit] == I18n.t('buttons.save_and_return')
+      redirect_to_school_draft_jobs(@vacancy)
     end
   end
 end

--- a/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
@@ -12,7 +12,7 @@ class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacan
 
     if @supporting_documents_form.valid?
       update_vacancy(supporting_documents_form_params, @vacancy)
-      return redirect_to next_step
+      return redirect_after_validation_and_update
     end
 
     session[:current_step] = :step_3_intro unless session[:current_step].eql?(:review)
@@ -20,6 +20,14 @@ class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacan
   end
 
   private
+
+  def redirect_after_validation_and_update
+    if params[:commit] == I18n.t('buttons.save_and_return')
+      redirect_to_school_draft_jobs(@vacancy)
+    elsif params[:commit] == I18n.t('buttons.save_and_continue')
+      redirect_to next_step
+    end
+  end
 
   def supporting_documents_form_params
     (params[:supporting_documents_form] || params).permit(:supporting_documents).merge(completed_step: current_step)

--- a/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
@@ -13,6 +13,8 @@ class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacan
     if @supporting_documents_form.valid?
       update_vacancy(supporting_documents_form_params, @vacancy)
       return redirect_after_validation_and_update
+    elsif params[:commit] == I18n.t('buttons.save_and_return')
+      return redirect_to_school_draft_jobs(@vacancy)
     end
 
     session[:current_step] = :step_3_intro unless session[:current_step].eql?(:review)

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -82,8 +82,18 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
   def redirect_to_incomplete_step
     return redirect_to school_job_pay_package_path(@vacancy.id) unless step_valid?(PayPackageForm)
     return redirect_to supporting_documents_school_job_path unless step_valid?(SupportingDocumentsForm)
+    return redirect_to school_job_documents_path(@vacancy.id) if redirect_to_documents_path_condition
     return redirect_to application_details_school_job_path unless step_valid?(ApplicationDetailsForm)
     return redirect_to school_job_job_summary_path(@vacancy.id) unless step_valid?(JobSummaryForm)
+  end
+
+  def redirect_to_documents_path_condition
+    # Give returning users who had said 'yes' to adding a document
+    # (but who did not add a document) one opportunity to do so per session.
+    @vacancy.supporting_documents == 'yes' \
+    && @vacancy.documents.none? \
+    && !step_valid?(ApplicationDetailsForm) \
+    && !session[:clicked_continue_at_school_job_documents_path]
   end
 
   def already_published_message

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -50,6 +50,7 @@ $govuk-image-url-function: frontend-image-url;
 @import 'components/vacancies-count';
 @import 'components/vacancies-show';
 @import 'components/vacancy';
+@import 'components/vacancy_form';
 @import 'ie';
 
 input[type='search'] {

--- a/app/frontend/styles/components/vacancy_form.scss
+++ b/app/frontend/styles/components/vacancy_form.scss
@@ -5,6 +5,12 @@
     }
   }
 
+  div.continue {
+    .govuk-button {
+      width: 190px;
+    }
+  }
+
   div.button-as-link {
     .govuk-button {
       // Remove styling of govuk-button

--- a/app/frontend/styles/components/vacancy_form.scss
+++ b/app/frontend/styles/components/vacancy_form.scss
@@ -1,6 +1,8 @@
 @media (min-width: 40.0625em) {
-  .govuk-button {
-    margin-bottom: 0;
+  div.no-margin-bottom {
+    .govuk-button {
+      margin-bottom: 0;
+    }
   }
 
   div.button-as-link {
@@ -8,8 +10,6 @@
       // Remove styling of govuk-button
       font-family: inherit;
       -webkit-font-smoothing: inherit;
-      margin-bottom: inherit;
-      font-size: inherit;
       width: inherit;
       line-height: inherit;
       font-weight: inherit;
@@ -17,10 +17,8 @@
       display: inherit;
       position: inherit;
       margin-top: inherit;
-      padding: inherit;
       border: inherit;
       border-radius: inherit;
-      color: inherit;
       background-color: inherit;
       box-shadow: inherit;
       text-align: inherit;

--- a/app/frontend/styles/components/vacancy_form.scss
+++ b/app/frontend/styles/components/vacancy_form.scss
@@ -1,0 +1,54 @@
+@media (min-width: 40.0625em) {
+  .govuk-button {
+    margin-bottom: 0;
+  }
+
+  div.button-as-link {
+    .govuk-button {
+      // Remove styling of govuk-button
+      font-family: inherit;
+      -webkit-font-smoothing: inherit;
+      margin-bottom: inherit;
+      font-size: inherit;
+      width: inherit;
+      line-height: inherit;
+      font-weight: inherit;
+      box-sizing: inherit;
+      display: inherit;
+      position: inherit;
+      margin-top: inherit;
+      padding: inherit;
+      border: inherit;
+      border-radius: inherit;
+      color: inherit;
+      background-color: inherit;
+      box-shadow: inherit;
+      text-align: inherit;
+      vertical-align: inherit;
+      cursor: inherit;
+      -webkit-appearance: inherit;
+
+      // Remove pseudo-element from govuk-button
+      content: none;
+
+      // Include govuk-link mixin which is "used in cases where it is not helpful
+      // to distinguish between visited and non-visited links".
+
+      @include govuk-link-common;
+      @include govuk-link-style-no-visited-state;
+
+      // Copy remaining styling of govuk-link
+      font-family: "GDS Transport", Arial, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale; 
+      
+      color: $govuk-link-colour;
+      padding: 0;
+      cursor: pointer;
+      text-decoration: underline;
+      text-decoration-line: underline;
+      text-decoration-style: initial;
+      text-decoration-color: initial;
+    }
+  }
+}

--- a/app/views/hiring_staff/vacancies/application_details/new.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/new.html.haml
@@ -33,7 +33,7 @@
 
       = render 'hiring_staff/vacancies/expiry_time_field', f: f, form: @application_details_form
 
-      = f.button :submit, t('buttons.save_and_continue')
+      = render 'hiring_staff/vacancies/vacancy_form_partials/submit', f: f
 
     .govuk-grid-column-one-third
       = render 'hiring_staff/vacancies/sidebar'

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -67,7 +67,7 @@
       %div.govuk-form-group#ends_on
         = f.gov_uk_date_field :ends_on,
                               legend_options: { page_heading: false, class: "govuk-label" }
-
-      = f.button :submit, t('buttons.save_and_continue')
+      %div.continue
+        = f.button :submit, t('buttons.save_and_continue')
     .govuk-grid-column-one-third
       = render 'hiring_staff/vacancies/sidebar'

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -29,7 +29,7 @@
     = link_to t('jobs.submit_listing.button'), school_job_publish_path(@vacancy.id), method: :post, class: 'govuk-button govuk-button--secondary', id: 'vacancy-review-submit'
 
     %br
-    = link_to t('buttons.save_and_return'), school_path, class: 'govuk-link'
+    = link_to t('buttons.save_and_return'), jobs_with_type_school_path('draft'), class: 'govuk-link'
 
   .govuk-grid-column-one-third
     = render 'hiring_staff/vacancies/sidebar'

--- a/app/views/hiring_staff/vacancies/supporting_documents/new.html.haml
+++ b/app/views/hiring_staff/vacancies/supporting_documents/new.html.haml
@@ -15,6 +15,6 @@
         :capitalize,
         legend: { text: t('helpers.fieldset.supporting_documents_form.supporting_documents_html'), size: 's' },
         hint_text: t('helpers.hint.supporting_documents_form.supporting_documents')
-      = f.govuk_submit t('buttons.save_and_continue')
+      = render 'hiring_staff/vacancies/vacancy_form_partials/submit', f: f
   .govuk-grid-column-one-third
     = render 'hiring_staff/vacancies/sidebar'

--- a/app/views/hiring_staff/vacancies/vacancy_form_partials/_submit.html.haml
+++ b/app/views/hiring_staff/vacancies/vacancy_form_partials/_submit.html.haml
@@ -1,6 +1,14 @@
 - if @vacancy.published?
   = f.govuk_submit t('buttons.update_job')
 - else
-  = f.govuk_submit t('buttons.save_and_continue') do
-    %br
-    = link_to t('buttons.save_and_return'), jobs_with_type_school_path('draft'), class: 'govuk-link'    
+  - if f.class == GOVUKDesignSystemFormBuilder::FormBuilder
+    %div.continue.no-margin-bottom
+      = f.govuk_submit t('buttons.save_and_continue')
+    %div.button-as-link.no-margin-bottom
+      = f.govuk_submit t('buttons.save_and_return')
+  - elsif f.class == SimpleForm::FormBuilder
+    %div.continue.govuk-form-group.no-margin-bottom
+      = f.button :submit, t('buttons.save_and_continue')
+    %div.button-as-link.no-margin-bottom
+      %div.govuk-form-group
+        = f.button :submit, t('buttons.save_and_return')

--- a/app/views/hiring_staff/vacancies/vacancy_form_partials/_submit.html.haml
+++ b/app/views/hiring_staff/vacancies/vacancy_form_partials/_submit.html.haml
@@ -1,4 +1,6 @@
 - if @vacancy.published?
   = f.govuk_submit t('buttons.update_job')
 - else
-  = f.govuk_submit t('buttons.save_and_continue')
+  = f.govuk_submit t('buttons.save_and_continue') do
+    %br
+    = link_to t('buttons.save_and_return'), jobs_with_type_school_path('draft'), class: 'govuk-link'    

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -598,7 +598,7 @@ en:
     delete: 'Delete'
     dismiss: 'Dismiss'
     find: 'Find'
-    save_and_continue: 'Save and continue'
+    save_and_continue: 'Continue'
     save_and_return: 'Save and return later'
     submit: 'Submit'
     update_job: 'Update job'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -609,6 +609,7 @@ en:
         heading: 'New section'
         message: 'Improve your job listing using the new sections and features below'
       delete: The job has been deleted
+      draft_saved: 'Draft saved for %{job_title}'
       updated: 'The job has been updated'
       view:
         only_published: You can only view published jobs

--- a/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       fill_in_pay_package_form_fields(draft_vacancy)
       click_on I18n.t('buttons.save_and_continue')
 
-      find('label[for="supporting-documents-form-supporting-documents-field-error"]').click
+      fill_in_supporting_documents_form_fields
       click_on I18n.t('buttons.save_and_continue')
 
       expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
@@ -78,7 +78,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       fill_in_pay_package_form_fields(draft_vacancy)
       click_on I18n.t('buttons.save_and_continue')
 
-      find('label[for="supporting-documents-form-supporting-documents-field-error"]').click
+      fill_in_supporting_documents_form_fields
       click_on I18n.t('buttons.save_and_continue')
 
       click_on I18n.t('buttons.save_and_continue')
@@ -96,7 +96,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       fill_in_pay_package_form_fields(draft_vacancy)
       click_on I18n.t('buttons.save_and_continue')
 
-      find('label[for="supporting-documents-form-supporting-documents-field-error"]').click
+      fill_in_supporting_documents_form_fields
       click_on I18n.t('buttons.save_and_continue')
 
       click_on I18n.t('buttons.save_and_continue')

--- a/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Hiring staff can preview a vacancy' do
 
     scenario 'users can save and return later' do
       click_on I18n.t('buttons.save_and_return')
-      expect(page).to have_current_path(school_path)
+      expect(page).to have_current_path(jobs_with_type_school_path('draft'))
       expect(page).to have_content(I18n.t('schools.jobs.index', school: school.name))
       expect(page).to have_content(I18n.t('buttons.create_job'))
     end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -119,6 +119,24 @@ RSpec.feature 'Creating a vacancy' do
         expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
         expect(page.current_path).to eq(supporting_documents_school_job_path)
       end
+
+      scenario 'saves draft and redirects to school page when submitted as a draft' do
+        # Testing the version using GOVUKDesignSystemFormBuilder::FormBuilder
+        visit new_school_job_path
+
+        fill_in_job_specification_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_pay_package_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_return')
+
+        expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
+        click_on vacancy.job_title
+
+        # Check that fields were saved
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
+        expect(page.current_path).to eq(supporting_documents_school_job_path)
+      end
     end
 
     context '#supporting_documents' do
@@ -336,6 +354,30 @@ RSpec.feature 'Creating a vacancy' do
         fill_in_application_details_form_fields(vacancy)
         click_on I18n.t('buttons.save_and_continue')
 
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 6))
+        expect(page).to have_content(I18n.t('jobs.job_summary'))
+      end
+
+      scenario 'saves draft and redirects to school page when submitted as a draft' do
+        # Testing the version using SimpleForm::FormBuilder
+        visit new_school_job_path
+
+        fill_in_job_specification_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_pay_package_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        select_no_for_supporting_documents
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_application_details_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_return')
+
+        expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
+        click_on vacancy.job_title
+
+        # Check that fields were saved
         expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 6))
         expect(page).to have_content(I18n.t('jobs.job_summary'))
       end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -121,7 +121,6 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       scenario 'saves draft and redirects to school page when submitted as a draft' do
-        # Testing the version using GOVUKDesignSystemFormBuilder::FormBuilder
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
@@ -183,6 +182,26 @@ RSpec.feature 'Creating a vacancy' do
         choose 'Yes'
         click_on I18n.t('buttons.save_and_continue')
 
+        expect(page).to have_content(I18n.t('jobs.upload_file'))
+      end
+
+      scenario 'saves draft and redirects to school page when submitted as a draft' do
+        visit new_school_job_path
+
+        fill_in_job_specification_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_pay_package_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        choose 'Yes'
+        click_on I18n.t('buttons.save_and_return')
+
+        expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
+        click_on vacancy.job_title
+
+        # Check that fields were saved and that it remembers to ask for a document upload
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
         expect(page).to have_content(I18n.t('jobs.upload_file'))
       end
     end
@@ -298,6 +317,28 @@ RSpec.feature 'Creating a vacancy' do
           end
         end
       end
+
+      scenario 'saves draft and redirects to school page when submitted as a draft' do
+        visit new_school_job_path
+
+        fill_in_job_specification_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_pay_package_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        choose 'Yes'
+        click_on I18n.t('buttons.save_and_continue')
+
+        click_on I18n.t('buttons.save_and_return')
+
+        expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
+        click_on vacancy.job_title
+
+        # Check that fields were saved
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
+        expect(page).to have_content(I18n.t('jobs.upload_file'))
+      end
     end
 
     context '#application_details' do
@@ -359,7 +400,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       scenario 'saves draft and redirects to school page when submitted as a draft' do
-        # Testing the version using SimpleForm::FormBuilder
+        # Tests the version using SimpleForm::FormBuilder
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
@@ -435,6 +476,33 @@ RSpec.feature 'Creating a vacancy' do
         expect(page).to have_content(I18n.t('jobs.current_step', step: 6, total: 6))
         expect(page).to have_content(I18n.t('jobs.review'))
         verify_all_vacancy_details(vacancy)
+      end
+
+      scenario 'saves draft and redirects to school page when submitted as a draft' do
+        # Tests the version using SimpleForm::FormBuilder
+        visit new_school_job_path
+
+        fill_in_job_specification_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_pay_package_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        select_no_for_supporting_documents
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_application_details_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_job_summary_form_fields(vacancy)
+        click_on I18n.t('buttons.save_and_return')
+
+        expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
+        click_on vacancy.job_title
+
+        # Check that fields were saved
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 6, total: 6))
+        expect(page).to have_content(I18n.t('jobs.review'))
       end
     end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -336,11 +336,18 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_return')
 
         expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
-        click_on vacancy.job_title
+        expect(page).to have_content(vacancy.job_title)
 
-        # Check that fields were saved
+        # Check that fields were saved on supporting_documents,
+        # and that the user is given one chance to upload docs
+        # after saying 'yes' to supporting_documents
+        visit edit_school_job_path(id: vacancy_model.id)
         expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
         expect(page).to have_content(I18n.t('jobs.upload_file'))
+
+        # Check that user can proceed to next step after being given a chance to upload
+        click_on I18n.t('buttons.save_and_continue')
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
       end
     end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -131,7 +131,8 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_return')
 
         expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
-        expect(page).to have_content(vacancy.job_title)
+        expect(page).to have_content(I18n.t('messages.jobs.draft_saved',
+          job_title: vacancy.job_title))
 
         # Check that fields were saved
         visit edit_school_job_path(id: vacancy_model.id)
@@ -200,7 +201,8 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_return')
 
         expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
-        expect(page).to have_content(vacancy.job_title)
+        expect(page).to have_content(I18n.t('messages.jobs.draft_saved',
+          job_title: vacancy.job_title))
 
         # Check that fields were saved and that it remembers to ask for a document upload
         visit edit_school_job_path(id: vacancy_model.id)
@@ -336,7 +338,8 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_return')
 
         expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
-        expect(page).to have_content(vacancy.job_title)
+        expect(page).to have_content(I18n.t('messages.jobs.draft_saved',
+          job_title: vacancy.job_title))
 
         # Check that fields were saved on supporting_documents,
         # and that the user is given one chance to upload docs
@@ -426,7 +429,8 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_return')
 
         expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
-        expect(page).to have_content(vacancy.job_title)
+        expect(page).to have_content(I18n.t('messages.jobs.draft_saved',
+          job_title: vacancy.job_title))
 
         # Check that fields were saved
         visit edit_school_job_path(id: vacancy_model.id)
@@ -509,7 +513,8 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_return')
 
         expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
-        expect(page).to have_content(vacancy.job_title)
+        expect(page).to have_content(I18n.t('messages.jobs.draft_saved',
+          job_title: vacancy.job_title))
 
         # Check that fields were saved
         visit edit_school_job_path(id: vacancy_model.id)

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Creating a vacancy' do
 
   context 'creating a new vacancy' do
     let!(:subjects) { create_list(:subject, 3) }
-    let(:vacancy) do
+    let!(:vacancy) do
       VacancyPresenter.new(build(:vacancy, :complete,
                                  job_roles: [
                                    I18n.t('jobs.job_role_options.teacher'),
@@ -38,6 +38,7 @@ RSpec.feature 'Creating a vacancy' do
                                  working_patterns: ['full_time', 'part_time'],
                                  publish_on: Time.zone.today))
     end
+    let(:vacancy_model) { Vacancy.find_by(job_title: vacancy.job_title) }
 
     scenario 'redirects to step 1, job specification' do
       visit new_school_job_path
@@ -130,9 +131,10 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_return')
 
         expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
-        click_on vacancy.job_title
+        expect(page).to have_content(vacancy.job_title)
 
         # Check that fields were saved
+        visit edit_school_job_path(id: vacancy_model.id)
         expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
         expect(page.current_path).to eq(supporting_documents_school_job_path)
       end
@@ -198,9 +200,10 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_return')
 
         expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
-        click_on vacancy.job_title
+        expect(page).to have_content(vacancy.job_title)
 
         # Check that fields were saved and that it remembers to ask for a document upload
+        visit edit_school_job_path(id: vacancy_model.id)
         expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
         expect(page).to have_content(I18n.t('jobs.upload_file'))
       end
@@ -416,9 +419,10 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_return')
 
         expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
-        click_on vacancy.job_title
+        expect(page).to have_content(vacancy.job_title)
 
         # Check that fields were saved
+        visit edit_school_job_path(id: vacancy_model.id)
         expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 6))
         expect(page).to have_content(I18n.t('jobs.job_summary'))
       end
@@ -498,9 +502,10 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_return')
 
         expect(page.current_path).to eq(jobs_with_type_school_path('draft'))
-        click_on vacancy.job_title
+        expect(page).to have_content(vacancy.job_title)
 
         # Check that fields were saved
+        visit edit_school_job_path(id: vacancy_model.id)
         expect(page).to have_content(I18n.t('jobs.current_step', step: 6, total: 6))
         expect(page).to have_content(I18n.t('jobs.review'))
       end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -32,7 +32,7 @@ module VacancyHelpers
   end
 
   def fill_in_supporting_documents_form_fields
-    find('label[for="supporting-documents-form-supporting-documents-yes-field"]').click
+    page.find_all(:xpath, "//*[normalize-space(text())='Yes']").first.click
   end
 
   def select_no_for_supporting_documents


### PR DESCRIPTION
## Jira ticket URLs:

https://dfedigital.atlassian.net/browse/TEVA-539
https://dfedigital.atlassian.net/browse/TEVA-550

## Changes in this PR:

- Add 'Save and return later' link to each page in the hiring staff journey
- This updates the vacancy and redirects to the school's page, focusing on the draft jobs tab
- Update the text of 'Save and continue' to 'Continue'

## Screenshots of UI changes:

### Before
<img width="861" alt="Screenshot 2020-04-16 at 01 23 59" src="https://user-images.githubusercontent.com/60350599/79401489-2797f400-7f81-11ea-9ea4-ad361f2bfe94.png">


### After
<img width="861" alt="Screenshot 2020-04-16 at 01 24 32" src="https://user-images.githubusercontent.com/60350599/79401498-2c5ca800-7f81-11ea-84af-758bf4134d21.png">
<img width="1265" alt="Screenshot 2020-04-16 at 01 24 53" src="https://user-images.githubusercontent.com/60350599/79401509-31b9f280-7f81-11ea-905a-c36b60369c55.png">

## Next steps:

- [ ] Review by UX/product