### PR TITLE
Fix dsi_users export bug

### DIFF
--- a/lib/export_dsi_users_to_big_query.rb
+++ b/lib/export_dsi_users_to_big_query.rb
@@ -30,14 +30,14 @@ class ExportDsiUsersToBigQuery < BaseDsiExporter
 
   def insert_table_data(batch)
     dataset.insert TABLE_NAME, present_for_big_query(batch), autocreate: true do |schema|
-      schema.string 'user_id', mode: :required
+      schema.string 'user_id', mode: :nullable
       schema.string 'role', mode: :nullable
       schema.timestamp 'approval_datetime', mode: :nullable
       schema.timestamp 'update_datetime', mode: :nullable
       schema.string 'given_name', mode: :nullable
       schema.string 'family_name', mode: :nullable
-      schema.string 'email', mode: :required
-      schema.integer 'school_urn', mode: :required
+      schema.string 'email', mode: :nullable
+      schema.integer 'school_urn', mode: :nullable
     end
   end
 


### PR DESCRIPTION
BigQuery fails to insert data when one of the rows has missing data. This PR addresses the issue.

## Jira ticket URL:
[TEVA-695](https://dfedigital.atlassian.net/browse/TEVA-695)
## Changes in this PR:
- Allow all columns to be nullable when inserting rows
