### PR TITLE
Remove job_summary attribute from Algolia index

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -40,10 +40,6 @@ class Vacancy < ApplicationRecord
       convert_date_to_unix_time(self.expires_on)
     end
 
-    attribute :job_summary do
-      self.job_summary&.truncate(256)
-    end
-
     attribute :last_updated_at do
       # Convert from ActiveSupport::TimeWithZone object to Unix time
       self.updated_at.to_i


### PR DESCRIPTION
Removing this attribute helped to solve an out of memory error during indexing.

This also reduces the size of the records, improving search speed, and makes it
more likely that searches will return useful results, rather than 'red herrings'
hidden within a job_summary.