### PR TITLE
Bigquery fix flexibleworking proportion

### DIFF
--- a/bigquery/working-patterns-monthly-by-GOR.sql
+++ b/bigquery/working-patterns-monthly-by-GOR.sql
@@ -21,7 +21,10 @@ FROM (
     COUNT(vacancy.id) AS number_of_vacancies,
     COUNTIF("full_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
       AND ARRAY_LENGTH(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \"")) = 1) AS number_of_full_time_only_vacancies,
-    COUNTIF("full_time" NOT IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_flexible_working,
+    COUNTIF("part_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
+      OR "job_share" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
+      OR "compressed_hours" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
+      OR "staggered_hours" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \"")) ) AS number_of_vacancies_offering_flexible_working,
     COUNTIF("full_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_full_time,
     COUNTIF("part_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_part_time,
     COUNTIF("job_share" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_job_share,

--- a/bigquery/working-patterns-monthly-by-la.sql
+++ b/bigquery/working-patterns-monthly-by-la.sql
@@ -21,7 +21,10 @@ FROM (
     COUNT(vacancy.id) AS number_of_vacancies,
     COUNTIF("full_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
       AND ARRAY_LENGTH(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \"")) = 1) AS number_of_full_time_only_vacancies,
-    COUNTIF("full_time" NOT IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_flexible_working,
+    COUNTIF("part_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
+      OR "job_share" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
+      OR "compressed_hours" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
+      OR "staggered_hours" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \"")) ) AS number_of_vacancies_offering_flexible_working,
     COUNTIF("full_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_full_time,
     COUNTIF("part_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_part_time,
     COUNTIF("job_share" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_job_share,

--- a/bigquery/working-patterns-monthly.sql
+++ b/bigquery/working-patterns-monthly.sql
@@ -20,7 +20,10 @@ FROM (
     COUNT(vacancy.id) AS number_of_vacancies,
     COUNTIF("full_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
       AND ARRAY_LENGTH(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))=1) AS number_of_full_time_only_vacancies,
-    COUNTIF("full_time" NOT IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_flexible_working,
+    COUNTIF("part_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
+      OR "job_share" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
+      OR "compressed_hours" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))
+      OR "staggered_hours" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \"")) ) AS number_of_vacancies_offering_flexible_working,
     COUNTIF("full_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_full_time,
     COUNTIF("part_time" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_part_time,
     COUNTIF("job_share" IN UNNEST(SPLIT(TRIM(vacancy.working_patterns,"[]\""),"\", \""))) AS number_of_vacancies_offering_job_share,


### PR DESCRIPTION
## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-669

## Changes in this PR:
Several tables in BigQuery include a metric that calculates the proportion of vacancies in a month that offered flexible working. We were incorrectly calculating this as the proportion that were *not* offering full time working. This incorrectly missed out vacancies that offered flexible working, but which also offered full time working. This PR fixes this by replacing the calculation with OR statements that check whether the vacancy offered each of the available types of flexible working (part time, job share, compressed hours and staggered hours).