### PR TITLE
Bigquery pull in document downloads data figures from GA

### DIFF
--- a/bigquery/join-documents-to-downloads.sql
+++ b/bigquery/join-documents-to-downloads.sql
@@ -1,0 +1,36 @@
+SELECT
+  document_downloads.slug,
+  document_downloads.file_extension,
+  document_downloads.document_name,
+  SUM(document_downloads.unique_downloads) AS total_downloads,
+  document.id,
+  document.size,
+  document.content_type,
+  document.download_url,
+  document.google_drive_id,
+  CAST(document.created_at AS DATE) AS created_date,
+  CAST(document.updated_at AS DATE) AS updated_date,
+  document.vacancy_id
+FROM
+  `teacher-vacancy-service.production_dataset.CALCULATED_documents_downloaded_each_day` AS document_downloads
+LEFT JOIN
+  `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
+USING
+  (slug)
+RIGHT JOIN
+  `teacher-vacancy-service.production_dataset.feb20_document` AS document
+ON
+  vacancy.id=document.vacancy_id
+  AND CONCAT(document_downloads.document_name,".",document_downloads.file_extension)=document.name
+GROUP BY
+  document_downloads.slug,
+  document_downloads.file_extension,
+  document_downloads.document_name,
+  document.id,
+  document.size,
+  document.content_type,
+  document.download_url,
+  document.google_drive_id,
+  document.created_at,
+  document.updated_at,
+  document.vacancy_id

--- a/bigquery/update_documents_downloaded_each_day_from_GA.sql
+++ b/bigquery/update_documents_downloaded_each_day_from_GA.sql
@@ -3,7 +3,7 @@ SELECT
   slug,
   file_extension,
   document_name,
-  MAX(unique_downloads) #if the latest unique_downloads of a particular document on a particular day in the Google Sheet from GA differs from the version we have in the table already, take the higher of the two values
+  MAX(unique_downloads) AS unique_downloads #if the latest unique_downloads of a particular document on a particular day in the Google Sheet from GA differs from the version we have in the table already, take the higher of the two values
 FROM (
   SELECT
     Date AS date,

--- a/bigquery/update_documents_downloaded_each_day_from_GA.sql
+++ b/bigquery/update_documents_downloaded_each_day_from_GA.sql
@@ -1,0 +1,34 @@
+SELECT
+  date,
+  slug,
+  file_extension,
+  document_name,
+  MAX(unique_downloads) #if the latest unique_downloads of a particular document on a particular day in the Google Sheet from GA differs from the version we have in the table already, take the higher of the two values
+FROM (
+  SELECT
+    Date AS date,
+    SPLIT(TRIM(Page_path_level_2,"/"),"?")[ORDINAL(1)] AS slug,
+    #remove the / from the front of the path and strip out any parameters after a ? to convert the level 2 path into the vacancy slug
+    ARRAY_REVERSE(SPLIT(Event_Label,"."))[ORDINAL(1)] AS file_extension,
+    #select everything after the *last* . as the file extension
+    TRIM(REPLACE(Event_Label,ARRAY_REVERSE(SPLIT(Event_Label,"."))[ORDINAL(1)],""),".") AS document_name,
+    #replace the file extension with a null string to extract the document name (this allows for period characters in the document name)
+    Unique_Events AS unique_downloads
+  FROM
+    `teacher-vacancy-service.production_dataset.GA_documents_downloaded_each_day` AS latest_table
+  WHERE
+    Date IS NOT NULL
+  UNION ALL
+  SELECT
+    date,
+    slug,
+    file_extension,
+    document_name,
+    unique_downloads
+  FROM
+    `teacher-vacancy-service.production_dataset.CALCULATED_documents_downloaded_each_day` AS previous_table )
+GROUP BY
+  date,
+  slug,
+  file_extension,
+  document_name


### PR DESCRIPTION
## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-718

## Changes in this PR:
- Gets GA data on document downloads on each date for the last 7 days in via Google Sheets and puts them in a table to store longer term
- Creates a documents table nightly that includes the total number of downloads so far
- Splits out the file extension from the document name for later analysis