### PR TITLE
Disable Algolia indexing

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -33,7 +33,7 @@ class Vacancy < ApplicationRecord
 
   include AlgoliaSearch
 
-  algoliasearch per_environment: true, disable_indexing: Rails.env.test? do
+  algoliasearch per_environment: true, disable_indexing: true do
     attributes :first_supporting_subject, :job_roles, :job_title, :salary, :second_supporting_subject, :working_patterns
 
     attribute :expiry_date do


### PR DESCRIPTION
This is to reduce error logging noise while we wait for our improved build pipeline (GovUK Paas) to come into existence, at which point I hope/trust that the environment variables for Algolia will be reliably found (they are AWOL often now, with the result that many things cause Algolia gem to throw errors).
