### PR TITLE
Point cloudfront to paas

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -249,11 +249,16 @@ module "cloudfront" {
 
   environment                   = "${terraform.workspace}"
   project_name                  = "${var.project_name}"
-  cloudfront_origin_domain_name = "${module.core.alb_dns_name}"
+  cloudfront_origin_domain_name = "${
+    var.cloudfront_origin_domain_name != "" ?
+    var.cloudfront_origin_domain_name : module.core.alb_dns_name
+  }"
   cloudfront_aliases            = "${var.cloudfront_aliases}"
   cloudfront_certificate_arn    = "${var.cloudfront_certificate_arn}"
   offline_bucket_domain_name    = "${var.offline_bucket_domain_name}"
   offline_bucket_origin_path    = "${var.offline_bucket_origin_path}"
+  domain                        = "${var.domain}"
+  forward_host_header           = "${var.cloudfront_origin_domain_name == ""}"
 }
 
 module "elasticache_redis" {

--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -9,6 +9,11 @@ resource "aws_cloudfront_distribution" "default" {
       https_port             = "443"
       origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
     }
+
+    custom_header = {
+      name = "X-Forwarded-Host"
+      value = "${var.domain}"
+    }
   }
 
   origin {
@@ -40,19 +45,7 @@ resource "aws_cloudfront_distribution" "default" {
 
     forwarded_values {
       query_string = true
-      headers      = [
-        "Host",
-        "Authorization",
-        "Origin",
-        "Referer",
-        "Accept",
-        "Accept-Charset",
-        "Accept-DateTime",
-        "Accept-Encoding",
-        "Accept-Language",
-        "CloudFront-Forwarded-Proto",
-        "User-Agent",
-      ]
+      headers      = "${local.header_list}"
 
       cookies {
         forward = "all"

--- a/terraform/modules/cloudfront/input.tf
+++ b/terraform/modules/cloudfront/input.tf
@@ -9,3 +9,28 @@ variable "cloudfront_aliases" {
 variable "cloudfront_certificate_arn" {}
 variable "offline_bucket_domain_name" {}
 variable "offline_bucket_origin_path" {}
+variable "domain" {}
+variable "default_header_list" {
+  default = [
+        "Authorization",
+        "Origin",
+        "Referer",
+        "Accept",
+        "Accept-Charset",
+        "Accept-DateTime",
+        "Accept-Encoding",
+        "Accept-Language",
+        "CloudFront-Forwarded-Proto",
+        "User-Agent",
+      ]
+}
+variable "forward_host_header" {
+  default = false
+}
+locals {
+  host_header = "${
+    var.forward_host_header ?
+    "Host" : ""
+  }"
+  header_list = "${concat(var.default_header_list, compact(list(local.host_header)))}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -430,3 +430,6 @@ variable "feature_sign_in_alert" {
 variable "algolia_app_id" {}
 variable "algolia_write_api_key" {}
 variable "algolia_search_api_key" {}
+variable "cloudfront_origin_domain_name" {
+  default = ""
+}


### PR DESCRIPTION
## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-308

## Changes in this PR:
Terraform changes to allow cloudfront to point to paas while not breaking the existing connection to AWS. 

## Next steps:
Add cloudfront_origin_domain_name variable to environment.tfvars and deploy to make this environment point to paas.

- [ ] Terraform deployment required?
