### PR TITLE
Create a job tweaks

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -44,18 +44,25 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
     vacancy
   end
 
-  def redirect_to_next_step(vacancy)
-    next_path = session[:current_step].eql?(:review) ? review_path(vacancy) : next_step
+  def redirect_to_next_step_if_save_and_continue(vacancy_id)
+    if params[:commit] == I18n.t('buttons.save_and_continue')
+      redirect_to_next_step(vacancy_id)
+    elsif params[:commit] == I18n.t('buttons.update_job')
+      redirect_to edit_school_job_path(vacancy_id), success: I18n.t('messages.jobs.updated')
+    end
+  end
+
+  def redirect_to_next_step(vacancy_id)
+    next_path = session[:current_step].eql?(:review) ? school_job_review_path(
+      school_id: current_school.id,
+      job_id: vacancy_id
+    ) : next_step
     redirect_to next_path
   end
 
   def reset_session_vacancy!
     session[:vacancy_attributes] = nil
     session[:current_step] = nil
-  end
-
-  def review_path(vacancy)
-    school_job_review_path(school_id: current_school.id, job_id: vacancy.id)
   end
 
   def review_path_with_errors(vacancy)

--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -13,7 +13,7 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
     if @application_details_form.complete_and_valid?
       update_vacancy(@application_details_form.params_to_save, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue
+      return redirect_to_next_step_if_save_and_continue(@vacancy.id)
     end
 
     render :show
@@ -45,13 +45,5 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
 
   def next_step
     school_job_job_summary_path(@vacancy.id)
-  end
-
-  def redirect_to_next_step_if_save_and_continue
-    if params[:commit] == I18n.t('buttons.save_and_continue')
-      redirect_to_next_step(@vacancy)
-    elsif params[:commit] == I18n.t('buttons.update_job')
-      redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')
-    end
   end
 end

--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -19,7 +19,7 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
     if valid_copy_form?
       new_vacancy = CopyVacancy.new(@proposed_vacancy).call
       Auditor::Audit.new(new_vacancy, 'vacancy.copy', current_session_id).log
-      return redirect_to review_path(new_vacancy)
+      return redirect_to school_job_review_path(new_vacancy.id)
     end
 
     render :new

--- a/app/controllers/hiring_staff/vacancies/documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/documents_controller.rb
@@ -5,7 +5,9 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
 
   before_action :redirect_unless_vacancy
   before_action :redirect_unless_supporting_documents
-  before_action :redirect_to_next_step_if_save_and_continue, only: %i[create]
+  before_action only: %i[create] do
+    redirect_to_next_step_if_save_and_continue(@vacancy.id)
+  end
 
   before_action :set_documents_form, only: %i[show create]
   before_action :set_documents, only: %i[show create destroy]
@@ -60,14 +62,6 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
 
   def next_step
     school_job_application_details_path(@vacancy.id)
-  end
-
-  def redirect_to_next_step_if_save_and_continue
-    if params[:commit] == I18n.t('buttons.save_and_continue')
-      redirect_to_next_step(@vacancy)
-    elsif params[:commit] == I18n.t('buttons.update_job')
-      redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')
-    end
   end
 
   def process_documents

--- a/app/controllers/hiring_staff/vacancies/documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/documents_controller.rb
@@ -55,7 +55,7 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
       @vacancy.save
     end
 
-    redirect_to supporting_documents_school_job_path unless @vacancy.supporting_documents
+    redirect_to school_job_supporting_documents_path(@vacancy.id) unless @vacancy.supporting_documents
   end
 
   def next_step

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -22,7 +22,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
     if @job_specification_form.complete_and_valid?
       session_vacancy_id ? update_vacancy(job_specification_form_params) : save_vacancy_without_validation
       store_vacancy_attributes(@job_specification_form.vacancy.attributes)
-      return redirect_to_next_step_if_save_and_continue
+      return redirect_to_next_step_if_save_and_continue(@vacancy&.id.present? ? @vacancy.id : session_vacancy_id)
     end
 
     render :show
@@ -32,7 +32,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
     if @job_specification_form.complete_and_valid?
       update_vacancy(job_specification_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue
+      return redirect_to_next_step_if_save_and_continue(@vacancy.id)
     end
 
     render :show
@@ -78,13 +78,5 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
 
   def next_step
     school_job_pay_package_path(@vacancy&.id.present? ? @vacancy.id : session_vacancy_id)
-  end
-
-  def redirect_to_next_step_if_save_and_continue
-    if params[:commit] == I18n.t('buttons.save_and_continue')
-      redirect_to_next_step(@vacancy)
-    elsif params[:commit] == I18n.t('buttons.update_job')
-      redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')
-    end
   end
 end

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -3,6 +3,7 @@ require 'persist_nqt_job_role'
 class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancies::ApplicationController
   include PersistNQTJobRole
 
+  before_action :set_up_url
   before_action :set_up_job_specification_form, only: %i[create update]
 
   def show
@@ -29,7 +30,6 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
 
   def update
     if @job_specification_form.complete_and_valid?
-      reset_session_vacancy!
       update_vacancy(job_specification_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
       return redirect_to_next_step_if_save_and_continue
@@ -39,6 +39,12 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   end
 
   private
+
+  def set_up_url
+    @job_specification_url_method = @vacancy&.id.present? ? 'patch' : 'post'
+    @job_specification_url = @vacancy&.id.present? ?
+      school_job_job_specification_path(@vacancy.id) : job_specification_school_job_path(school_id: current_school.id)
+  end
 
   def set_up_job_specification_form
     date_errors = convert_multiparameter_attributes_to_dates(:job_specification_form, [:starts_on, :ends_on])
@@ -71,7 +77,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   end
 
   def next_step
-    school_job_pay_package_path(session_vacancy_id)
+    school_job_pay_package_path(@vacancy&.id.present? ? @vacancy.id : session_vacancy_id)
   end
 
   def redirect_to_next_step_if_save_and_continue

--- a/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
@@ -11,7 +11,7 @@ class HiringStaff::Vacancies::JobSummaryController < HiringStaff::Vacancies::App
     if @job_summary_form.valid?
       update_vacancy(job_summary_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue
+      return redirect_to_next_step_if_save_and_continue(@vacancy.id)
     end
 
     render :show
@@ -20,15 +20,10 @@ class HiringStaff::Vacancies::JobSummaryController < HiringStaff::Vacancies::App
   private
 
   def job_summary_form_params
-    (params[:job_summary_form] || params).permit(:job_summary, :about_school)
-                                         .merge(completed_step: current_step)
+    params.require(:job_summary_form).permit(:job_summary, :about_school).merge(completed_step: current_step)
   end
 
-  def redirect_to_next_step_if_save_and_continue
-    if params[:commit] == I18n.t('buttons.save_and_continue')
-      redirect_to school_job_review_path(@vacancy.id)
-    elsif params[:commit] == I18n.t('buttons.update_job')
-      redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')
-    end
+  def next_step
+    school_job_review_path(@vacancy.id)
   end
 end

--- a/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
@@ -11,7 +11,7 @@ class HiringStaff::Vacancies::PayPackageController < HiringStaff::Vacancies::App
     if @pay_package_form.valid?
       update_vacancy(pay_package_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue
+      return redirect_to_next_step_if_save_and_continue(@vacancy.id)
     end
 
     render :show
@@ -20,18 +20,10 @@ class HiringStaff::Vacancies::PayPackageController < HiringStaff::Vacancies::App
   private
 
   def pay_package_form_params
-    (params[:pay_package_form] || params).permit(:salary, :benefits).merge(completed_step: current_step)
+    params.require(:pay_package_form).permit(:salary, :benefits).merge(completed_step: current_step)
   end
 
   def next_step
-    supporting_documents_school_job_path
-  end
-
-  def redirect_to_next_step_if_save_and_continue
-    if params[:commit] == I18n.t('buttons.save_and_continue')
-      redirect_to_next_step(@vacancy)
-    elsif params[:commit] == I18n.t('buttons.update_job')
-      redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')
-    end
+    school_job_supporting_documents_path(@vacancy.id)
   end
 end

--- a/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
@@ -1,32 +1,43 @@
 class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacancies::ApplicationController
   before_action :redirect_unless_vacancy
 
-  def new
-    @supporting_documents_form = SupportingDocumentsForm.new(session[:vacancy_attributes])
-    @supporting_documents_form.valid? if %i[step_3_intro review].include?(session[:current_step])
+  def show
+    @supporting_documents_form = SupportingDocumentsForm.new(@vacancy.attributes)
   end
 
-  def create
+  def update
     @supporting_documents_form = SupportingDocumentsForm.new(supporting_documents_form_params)
-    store_vacancy_attributes(@supporting_documents_form.vacancy.attributes)
 
     if @supporting_documents_form.valid?
+      store_vacancy_attributes(@supporting_documents_form.vacancy.attributes)
       update_vacancy(supporting_documents_form_params, @vacancy)
-      return redirect_to next_step
+      update_google_index(@vacancy) if @vacancy.listed?
+      return redirect_to_next_step_if_save_and_continue
     end
 
-    session[:current_step] = :step_3_intro unless session[:current_step].eql?(:review)
-    redirect_to supporting_documents_school_job_path(anchor: 'errors')
+    render :show
   end
 
   private
 
   def supporting_documents_form_params
-    (params[:supporting_documents_form] || params).permit(:supporting_documents).merge(completed_step: current_step)
+    (params[:supporting_documents_form] || params)
+      .permit(:supporting_documents)
+      .merge(completed_step: current_step)
   end
 
   def next_step
     @supporting_documents_form.supporting_documents == 'yes' ?
       school_job_documents_path(@vacancy.id) : school_job_application_details_path(@vacancy.id)
+  end
+
+  def redirect_to_next_step_if_save_and_continue
+    if session[:current_step].eql?(:review) && @supporting_documents_form.supporting_documents == 'yes'
+      redirect_to school_job_documents_path(@vacancy.id)
+    elsif params[:commit] == I18n.t('buttons.save_and_continue')
+      redirect_to_next_step(@vacancy)
+    elsif params[:commit] == I18n.t('buttons.update_job')
+      redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')
+    end
   end
 end

--- a/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
@@ -12,7 +12,7 @@ class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacan
       store_vacancy_attributes(@supporting_documents_form.vacancy.attributes)
       update_vacancy(supporting_documents_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue
+      return redirect_to_documents_or_next_step
     end
 
     render :show
@@ -31,13 +31,11 @@ class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacan
       school_job_documents_path(@vacancy.id) : school_job_application_details_path(@vacancy.id)
   end
 
-  def redirect_to_next_step_if_save_and_continue
+  def redirect_to_documents_or_next_step
     if session[:current_step].eql?(:review) && @supporting_documents_form.supporting_documents == 'yes'
       redirect_to school_job_documents_path(@vacancy.id)
-    elsif params[:commit] == I18n.t('buttons.save_and_continue')
-      redirect_to_next_step(@vacancy)
-    elsif params[:commit] == I18n.t('buttons.update_job')
-      redirect_to edit_school_job_path(@vacancy.id), success: I18n.t('messages.jobs.updated')
+    else
+      redirect_to_next_step_if_save_and_continue(@vacancy.id)
     end
   end
 end

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -81,7 +81,7 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
 
   def redirect_to_incomplete_step
     return redirect_to school_job_pay_package_path(@vacancy.id) unless step_valid?(PayPackageForm)
-    return redirect_to supporting_documents_school_job_path unless step_valid?(SupportingDocumentsForm)
+    return redirect_to school_job_supporting_documents_path(@vacancy.id) unless step_valid?(SupportingDocumentsForm)
     return redirect_to school_job_application_details_path(@vacancy.id) unless step_valid?(ApplicationDetailsForm)
     return redirect_to school_job_job_summary_path(@vacancy.id) unless step_valid?(JobSummaryForm)
   end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -113,4 +113,14 @@ module VacanciesHelper
     sections << 'supporting_documents' unless vacancy.supporting_documents
     sections
   end
+
+  def page_title_prefix(vacancy, form_object, page_heading)
+    if vacancy.published?
+      "#{form_object.errors.present? ?
+        'Error: ' : ''}Edit the #{page_heading}"
+    else
+      "#{form_object.errors.present? ?
+        'Error: ' : ''}#{page_heading} — #{t('jobs.create_a_job', school: current_school.name)}"
+    end
+  end
 end

--- a/app/views/hiring_staff/vacancies/application_details/show.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/show.html.haml
@@ -1,8 +1,4 @@
-- if @vacancy.published?
-  - content_for :page_title_prefix, "#{@application_details_form.errors.present? ? 'Error: ' : ''}Edit the #{t('jobs.application_details')}"
-- else
-  - content_for :page_title_prefix, "#{@application_details_form.errors.present? ? 'Error: ' : ''}#{t('jobs.application_details')} — #{t('jobs.create_a_job', school: current_school.name)}"
-
+- content_for :page_title_prefix, page_title_prefix(@vacancy, @application_details_form, t('jobs.application_details'))
 = render 'hiring_staff/vacancies/vacancy_form_partials/title'
 
 .govuk-grid-row

--- a/app/views/hiring_staff/vacancies/documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/documents/show.html.haml
@@ -1,8 +1,4 @@
-- if @vacancy.published?
-  - content_for :page_title_prefix, "#{@documents_form.errors.present? ? 'Error: ' : ''}Edit the #{t('jobs.supporting_documents')}"
-- else
-  - content_for :page_title_prefix, "#{@documents_form.errors.present? ? 'Error: ' : ''}#{t('jobs.supporting_documents')} — #{t('jobs.create_a_job', school: current_school.name)}"
-
+- content_for :page_title_prefix, page_title_prefix(@vacancy, @documents_form, t('jobs.supporting_documents'))
 = render 'hiring_staff/vacancies/vacancy_form_partials/title'
 
 .govuk-grid-row

--- a/app/views/hiring_staff/vacancies/job_specification/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/show.html.haml
@@ -7,7 +7,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @job_specification_form, url: @vacancy&.published? ? school_job_job_specification_path(@vacancy.id) : job_specification_school_job_path(school_id: current_school.id), html: { method: @vacancy&.published? ? "patch" : "post" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @job_specification_form, url: @job_specification_url, html: { method: @job_specification_url_method }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
       = f.govuk_error_summary t('jobs.errors_present')
 
       %h2.govuk-heading-l

--- a/app/views/hiring_staff/vacancies/job_specification/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/show.html.haml
@@ -1,5 +1,5 @@
-- if @vacancy&.published?
-  - content_for :page_title_prefix, "#{@job_specification_form.errors.present? ? 'Error: ' : ''}Edit the #{t('jobs.job_details')}"
+- if @vacancy.present?
+  - content_for :page_title_prefix, page_title_prefix(@vacancy, @job_specification_form, t('jobs.job_details'))
 - else
   - content_for :page_title_prefix, "#{@job_specification_form.errors.present? ? 'Error: ' : ''}#{t('jobs.job_details')} — #{t('jobs.create_a_job', school: current_school.name)}"
 

--- a/app/views/hiring_staff/vacancies/job_summary/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_summary/show.html.haml
@@ -1,8 +1,4 @@
-- if @vacancy.published?
-  - content_for :page_title_prefix, "#{@job_summary_form.errors.present? ? 'Error: ' : ''}Edit the #{t('jobs.job_summary')}"
-- else
-  - content_for :page_title_prefix, "#{@job_summary_form.errors.present? ? 'Error: ' : ''}#{t('jobs.job_summary')} — #{t('jobs.create_a_job', school: current_school.name)}"
-
+- content_for :page_title_prefix, page_title_prefix(@vacancy, @job_summary_form, t('jobs.job_summary'))
 = render 'hiring_staff/vacancies/vacancy_form_partials/title'
 
 .govuk-grid-row

--- a/app/views/hiring_staff/vacancies/pay_package/show.html.haml
+++ b/app/views/hiring_staff/vacancies/pay_package/show.html.haml
@@ -1,8 +1,4 @@
-- if @vacancy.published?
-  - content_for :page_title_prefix, "#{@pay_package_form.errors.present? ? 'Error: ' : ''}Edit the #{t('jobs.pay_package')}"
-- else
-  - content_for :page_title_prefix, "#{@pay_package_form.errors.present? ? 'Error: ' : ''}#{t('jobs.pay_package')} — #{t('jobs.create_a_job', school: current_school.name)}"
-
+- content_for :page_title_prefix, page_title_prefix(@vacancy, @pay_package_form, t('jobs.pay_package'))
 = render 'hiring_staff/vacancies/vacancy_form_partials/title'
 
 .govuk-grid-row

--- a/app/views/hiring_staff/vacancies/supporting_documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/supporting_documents/show.html.haml
@@ -1,5 +1,4 @@
-- content_for :page_title_prefix, "#{@supporting_documents_form.errors.present? ? 'Error: ' : ''}#{t('jobs.supporting_documents')} — #{t('jobs.create_a_job', school: current_school.name)}"
-
+- content_for :page_title_prefix, page_title_prefix(@vacancy, @supporting_documents_form, t('jobs.supporting_documents'))
 = render 'hiring_staff/vacancies/vacancy_form_partials/title'
 
 .govuk-grid-row

--- a/app/views/hiring_staff/vacancies/supporting_documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/supporting_documents/show.html.haml
@@ -1,9 +1,10 @@
 - content_for :page_title_prefix, "#{@supporting_documents_form.errors.present? ? 'Error: ' : ''}#{t('jobs.supporting_documents')} — #{t('jobs.create_a_job', school: current_school.name)}"
+
 = render 'hiring_staff/vacancies/vacancy_form_partials/title'
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @supporting_documents_form, action: :post, url: supporting_documents_school_job_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @supporting_documents_form, url: school_job_supporting_documents_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
       = f.govuk_error_summary t('jobs.errors_present')
 
       %h2.govuk-heading-l
@@ -15,6 +16,7 @@
         :capitalize,
         legend: { text: t('helpers.fieldset.supporting_documents_form.supporting_documents_html'), size: 's' },
         hint_text: t('helpers.hint.supporting_documents_form.supporting_documents')
-      = f.govuk_submit t('buttons.save_and_continue')
+
+      = render 'hiring_staff/vacancies/vacancy_form_partials/submit', f: f
   .govuk-grid-column-one-third
     = render 'hiring_staff/vacancies/sidebar'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
         controller: 'hiring_staff/vacancies/pay_package',
         defaults: { create_step: 2, step_title: I18n.t('jobs.pay_package') }
       resource :supporting_documents,
-        only: %i[edit update],
+        only: %i[show update],
         controller: 'hiring_staff/vacancies/supporting_documents',
         defaults: { create_step: 3, step_title: I18n.t('jobs.supporting_documents') }
       resource :documents,
@@ -89,12 +89,6 @@ Rails.application.routes.draw do
     end
 
     resource :job, only: [] do
-      get :supporting_documents,
-        to: 'hiring_staff/vacancies/supporting_documents#new',
-        defaults: { create_step: 3, step_title: I18n.t('jobs.supporting_documents') }
-      post :supporting_documents,
-        to: 'hiring_staff/vacancies/supporting_documents#create',
-        defaults: { create_step: 3, step_title: I18n.t('jobs.supporting_documents') }
       get :job_specification,
         to: 'hiring_staff/vacancies/job_specification#show',
         defaults: { create_step: 1, step_title: I18n.t('jobs.job_details') }

--- a/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
+++ b/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
@@ -1,13 +1,52 @@
 require 'rails_helper'
 
 RSpec.describe HiringStaff::Vacancies::JobSpecificationController, type: :controller do
-  describe '#create' do
+  let(:vacancy) { double('vacancy') }
+  let(:vacancy_id) { double('test_vacancy_id') }
+  let(:school_id) { double('test_school_id') }
+  let(:job_specification_form) { class_double(JobSpecificationForm) }
+
+  before do
+    allow(job_specification_form).to receive(:new)
+
+    allow(controller).to receive(:session).and_return(double('session').as_null_object)
+    allow(controller).to receive_message_chain(:session, :key?).with(:urn).and_return(true)
+    allow(controller).to receive_message_chain(:current_user, :accepted_terms_and_conditions?).and_return(true)
+
+    allow(vacancy).to receive_message_chain(:id).and_return(vacancy_id)
+    controller.instance_variable_set(:@vacancy, vacancy)
+  end
+
+  describe '#set_up_url' do
     before do
-      allow(controller).to receive(:session).and_return(double('session').as_null_object)
-      allow(controller).to receive_message_chain(:session, :key?).with(:urn).and_return(true)
-      allow(controller).to receive_message_chain(:current_user, :accepted_terms_and_conditions?).and_return(true)
+      allow(vacancy).to receive(:attributes).and_return(double('attributes').as_null_object)
     end
 
+    context 'vacancy id is present' do
+      it 'uses the update action' do
+        get :show
+        expect(controller.instance_variable_get(:@job_specification_url_method)).to eql('patch')
+        expect(controller.instance_variable_get(:@job_specification_url))
+          .to eql(school_job_job_specification_path(vacancy_id))
+      end
+    end
+
+    context 'vacancy id is not present' do
+      before do
+        allow(controller).to receive_message_chain(:current_school, :id).and_return(school_id)
+        controller.instance_variable_set(:@vacancy, nil)
+      end
+
+      it 'uses the create action' do
+        get :show
+        expect(controller.instance_variable_get(:@job_specification_url_method)).to eql('post')
+        expect(controller.instance_variable_get(:@job_specification_url))
+          .to eql(job_specification_school_job_path(school_id: school_id))
+      end
+    end
+  end
+
+  describe '#create' do
     context 'job role is suitable for NQT' do
       let(:params) do
         {

--- a/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
@@ -21,7 +21,9 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       visit edit_school_job_path(id: draft_vacancy.id)
 
       expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 6))
-      expect(page).to have_content(I18n.t('jobs.pay_package'))
+      within('h2.govuk-heading-l') do
+        expect(page).to have_content(I18n.t('jobs.pay_package'))
+      end
     end
 
     scenario 'incomplete supporting documents step' do
@@ -34,7 +36,9 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       click_on I18n.t('buttons.save_and_continue')
 
       expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
-      expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+      within('h2.govuk-heading-l') do
+        expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+      end
     end
 
     scenario 'documents step if YES selected for supporting documents' do
@@ -46,11 +50,13 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       fill_in_pay_package_form_fields(draft_vacancy)
       click_on I18n.t('buttons.save_and_continue')
 
-      find('label[for="supporting-documents-form-supporting-documents-field-error"]').click
+      fill_in_supporting_documents_form_fields
       click_on I18n.t('buttons.save_and_continue')
 
       expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
-      expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+      within('h2.govuk-heading-l') do
+        expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+      end
     end
 
     scenario 'application details step if NO selected for supporting documents' do
@@ -66,7 +72,9 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       click_on I18n.t('buttons.save_and_continue')
 
       expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
-      expect(page).to have_content(I18n.t('jobs.application_details'))
+      within('h2.govuk-heading-l') do
+        expect(page).to have_content(I18n.t('jobs.application_details'))
+      end
     end
 
     scenario 'incomplete application details step' do
@@ -78,13 +86,15 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       fill_in_pay_package_form_fields(draft_vacancy)
       click_on I18n.t('buttons.save_and_continue')
 
-      find('label[for="supporting-documents-form-supporting-documents-field-error"]').click
+      fill_in_supporting_documents_form_fields
       click_on I18n.t('buttons.save_and_continue')
 
       click_on I18n.t('buttons.save_and_continue')
 
       expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
-      expect(page).to have_content(I18n.t('jobs.application_details'))
+      within('h2.govuk-heading-l') do
+        expect(page).to have_content(I18n.t('jobs.application_details'))
+      end
     end
 
     scenario 'incomplete job summary step' do
@@ -96,7 +106,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       fill_in_pay_package_form_fields(draft_vacancy)
       click_on I18n.t('buttons.save_and_continue')
 
-      find('label[for="supporting-documents-form-supporting-documents-field-error"]').click
+      fill_in_supporting_documents_form_fields
       click_on I18n.t('buttons.save_and_continue')
 
       click_on I18n.t('buttons.save_and_continue')
@@ -111,7 +121,9 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
       click_on I18n.t('buttons.save_and_continue')
 
       expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 6))
-      expect(page).to have_content(I18n.t('jobs.job_summary'))
+      within('h2.govuk-heading-l') do
+        expect(page).to have_content(I18n.t('jobs.job_summary'))
+      end
     end
   end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -87,7 +87,9 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 6))
-        expect(page).to have_content(I18n.t('jobs.pay_package'))
+        within('h2.govuk-heading-l') do
+          expect(page).to have_content(I18n.t('jobs.pay_package'))
+        end
       end
 
       scenario 'tracks the vacancy creation' do
@@ -131,7 +133,9 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
-        expect(page.current_path).to eq(supporting_documents_school_job_path)
+        within('h2.govuk-heading-l') do
+          expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+        end
       end
     end
 
@@ -164,7 +168,9 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
-        expect(page).to have_content(I18n.t('jobs.application_details'))
+        within('h2.govuk-heading-l') do
+          expect(page).to have_content(I18n.t('jobs.application_details'))
+        end
       end
 
       scenario 'redirects to step 3, upload_documents, when choosing yes' do
@@ -179,6 +185,10 @@ RSpec.feature 'Creating a vacancy' do
         choose 'Yes'
         click_on I18n.t('buttons.save_and_continue')
 
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
+        within('h2.govuk-heading-l') do
+          expect(page).to have_content(I18n.t('jobs.supporting_documents'))
+        end
         expect(page).to have_content(I18n.t('jobs.upload_file'))
       end
     end
@@ -351,7 +361,9 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 6))
-        expect(page).to have_content(I18n.t('jobs.job_summary'))
+        within('h2.govuk-heading-l') do
+          expect(page).to have_content(I18n.t('jobs.job_summary'))
+        end
       end
     end
 
@@ -405,7 +417,9 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.save_and_continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 6, total: 6))
-        expect(page).to have_content(I18n.t('jobs.review'))
+        within('h2.govuk-heading-l') do
+          expect(page).to have_content(I18n.t('jobs.review_heading'))
+        end
         verify_all_vacancy_details(vacancy)
       end
     end
@@ -422,6 +436,9 @@ RSpec.feature 'Creating a vacancy' do
           visit school_job_path(id: v.id)
 
           expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 6))
+          within('h2.govuk-heading-l') do
+            expect(page).to have_content(I18n.t('jobs.pay_package'))
+          end
         end
 
         scenario 'redirects to step 4, application details, when that step has not been completed' do
@@ -440,6 +457,9 @@ RSpec.feature 'Creating a vacancy' do
           visit school_job_path(id: v.id)
 
           expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
+          within('h2.govuk-heading-l') do
+            expect(page).to have_content(I18n.t('jobs.application_details'))
+          end
         end
 
         scenario 'redirects to step 5, job summary, when that step has not been completed' do
@@ -461,6 +481,9 @@ RSpec.feature 'Creating a vacancy' do
           visit school_job_path(id: v.id)
 
           expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 6))
+          within('h2.govuk-heading-l') do
+            expect(page).to have_content(I18n.t('jobs.job_summary'))
+          end
         end
 
         scenario 'redirects to appropriate step when clicked on change on review page' do
@@ -483,11 +506,17 @@ RSpec.feature 'Creating a vacancy' do
 
           click_header_link(I18n.t('jobs.application_details'))
           expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
+          within('h2.govuk-heading-l') do
+            expect(page).to have_content(I18n.t('jobs.application_details'))
+          end
 
           click_on I18n.t('buttons.save_and_continue')
 
           click_header_link(I18n.t('jobs.job_details'))
           expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 6))
+          within('h2.govuk-heading-l') do
+            expect(page).to have_content(I18n.t('jobs.job_details'))
+          end
         end
       end
 

--- a/spec/views/hiring_staff/vacancies/job_specification/show.html.haml_spec.rb
+++ b/spec/views/hiring_staff/vacancies/job_specification/show.html.haml_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'hiring_staff/vacancies/job_specification/show' do
     # important for *this* test.
     allow(view).to receive(:params).and_return({ create_step: 1 })
     assign(:job_specification_form, JobSpecificationForm.new)
+    assign(:job_specification_url_method, 'post')
+    assign(:job_specification_url, job_specification_school_job_path(school_id: 'school_id'))
     render
   end
 


### PR DESCRIPTION
This PR implements small tweaks in the create a job journey to reduce code complexity and bring all steps of the process more in line with one another 

## Changes in this PR:
- Fixed bug that meant the update action in the job specification was only used for published vacancies
- Refactored the supporting documents controller
- Refactored redirect function to remove code duplication
- Add a page title helper to remove code duplication

