### PR TITLE
Teva 730 site down at weekend

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,9 +28,11 @@ en:
           and email address to %{mail_to}. Or email your details directly to that address, copying in your headteacher
           or senior leader.
         some_of_our_users: >-
-          Some of our users are having having trouble signing in. We're working on the problem now. If you can't sign
-          in, try again soon.
-        you_might_have_problems_signing_in: You might have problems signing in
+          We’re completing planned maintenance.
+          You can search and view vacancies, but you can’t manage them.
+          You’ll be able to use the full service from 9:00am on Monday morning.
+          Contact our support team if you need help.
+        you_might_have_problems_signing_in: Sorry, the service is unavailable
   nav:
     sign_in: 'List a teaching job'
     sign_out: 'Sign out'

--- a/spec/views/hiring_staff/identifications/new.html.haml_spec.rb
+++ b/spec/views/hiring_staff/identifications/new.html.haml_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'hiring_staff/identifications/new.html.haml' do
     end
 
     it 'does not show the sign in warning' do
-      expect(render).not_to match(/you might have problems signing in/i)
+      expect(render).not_to match(/#{I18n.t('hiring_staff.identifications.new.you_might_have_problems_signing_in')}/)
     end
   end
 
@@ -19,7 +19,7 @@ RSpec.describe 'hiring_staff/identifications/new.html.haml' do
     end
 
     it 'does not show the sign in warning' do
-      expect(render).not_to match(/you might have problems signing in/i)
+      expect(render).not_to match(/#{I18n.t('hiring_staff.identifications.new.you_might_have_problems_signing_in')}/)
     end
   end
 
@@ -30,7 +30,7 @@ RSpec.describe 'hiring_staff/identifications/new.html.haml' do
     end
 
     it 'shows the sign in warning' do
-      expect(render).to match('You might have problems signing in')
+      expect(render).to match(/#{I18n.t('hiring_staff.identifications.new.you_might_have_problems_signing_in')}/)
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe 'hiring_staff/identifications/new.html.haml' do
     end
 
     it 'shows the sign in warning' do
-      expect(render).to match('You might have problems signing in')
+      expect(render).to match(/#{I18n.t('hiring_staff.identifications.new.you_might_have_problems_signing_in')}/)
     end
   end
 end

--- a/variables.tf
+++ b/variables.tf
@@ -424,7 +424,7 @@ variable "cloud_storage_bucket" {
 }
 
 variable "feature_sign_in_alert" {
-  default = "false"
+  default = "true"
 }
 
 variable "algolia_app_id" {}


### PR DESCRIPTION
Quick commit to change system maintenance message ahead of DSI downtime tomorrow.  Will exceptionally push and activate without approval today provided tests pass. 