### PR TITLE
Add logging to record school_urn for debugging purposes

### DIFF
--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -39,6 +39,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
       multiple_schools: authorisation_permissions.many_schools?,
       id_token: id_token
     )
+    Rails.logger.info("Updated session with URN #{session[:urn]}")
     audit_successful_authorisation
   end
 


### PR DESCRIPTION
This is to help diagnose an issue where a user cannot access their /school page.

I did not find any leads to explain why they were seeing `Page not found` and I wasn't (when I was set to the same permissions as them), except for a section in our README that mentions `Page not found` being caused by discrepancies in URNs between the session and the School. So I'd like to get some evidence about that by logging the user's school URN when it's set in the session.