### PR TITLE
Enable Algolia indexing on production

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -33,7 +33,7 @@ class Vacancy < ApplicationRecord
 
   include AlgoliaSearch
 
-  algoliasearch per_environment: true, disable_indexing: true do
+  algoliasearch disable_indexing: !Rails.env.production? do
     attributes :first_supporting_subject, :job_roles, :job_title, :salary, :second_supporting_subject, :working_patterns
 
     attribute :expiry_date do


### PR DESCRIPTION
This re-enables the integration of the external service with our app, now that we have moved to an environment which reliably contains the correct environment variables.

We may not need to index on development environments. If we later decide to, we can use:

```ruby
algoliasearch per_environment: true, disable_indexing: Rails.env.test? do
```

## Jira ticket URL:

https://dfedigital.atlassian.net/browse/TEVA-659?atlOrigin=eyJpIjoiMjgxMmExY2Q5NDIyNGFhZjk2ZDYxMzFiNTJmY2ExYzUiLCJwIjoiaiJ9

## Next steps:

- [ ] Reindex the Vacancy model with `Vacancy.reindex`. The gem algoliasearch-rails handles this job without requiring downtime, by using a temporary index.
- [ ] If this PR does not cause anything to break we should clean up the `config/initializers/algoliasearch.rb` file so that we no longer fall back to default environment variables such as 'fake_algolia_app_id'.
