### PR TITLE
Update GovUK PaaS docs

### DIFF
--- a/documentation/govuk-paas.md
+++ b/documentation/govuk-paas.md
@@ -162,23 +162,18 @@ Get log destination from Papertrail
 cf7 create-user-provided-service teaching-vacancies-papertrail-dev -l syslog-tls://logsX.papertrailapp.com:XXXXX
 ```
 
-### Set environment variables
+### Set environment variables for the app
 For all the environment variables defined in `.env.example` set them up with:
 ```bash
 cf7 set-env teaching-vacancies-dev ENV_VAR_NAME env_var_value
 ```
 
-You will be asked to stage the changes. Do so with:
-```bash
-cf7 stage teaching-vacancies-dev
-```
-
-Verify the changes:
+Verify that you see the desired changes:
 ```bash
 cf7 env teaching-vacancies-dev
 ```
 
-When you are done setting up environment variables, remember to restart the app, using `--strategy rolling` if you wish to avoid downtime:
+When you are done setting up environment variables, remember to restart the app, using `--strategy rolling` if you wish to avoid downtime. In the case of changing environment variables used only by the app, `restart` is sufficient and `restage` is unnecessary:
 ```bash
 cf7 restart teaching-vacancies-dev --strategy rolling
 ```

--- a/documentation/govuk-paas.md
+++ b/documentation/govuk-paas.md
@@ -168,9 +168,19 @@ For all the environment variables defined in `.env.example` set them up with:
 cf7 set-env teaching-vacancies-dev ENV_VAR_NAME env_var_value
 ```
 
-When you are done setting up environment variables remember to restart the app:
+You will be asked to stage the changes. Do so with:
 ```bash
-cf7 restart teaching-vacancies-dev
+cf7 stage teaching-vacancies-dev
+```
+
+Verify the changes:
+```bash
+cf7 env teaching-vacancies-dev
+```
+
+When you are done setting up environment variables, remember to restart the app, using `--strategy rolling` if you wish to avoid downtime:
+```bash
+cf7 restart teaching-vacancies-dev --strategy rolling
 ```
 
 ## Backup/Restore GOV.UK PaaS Postgres service database


### PR DESCRIPTION
This adds a mention of how to avoid downtime when changing environment variables, as this is necessary on the production environment. We need to document how to do this rather than relying on interpolating between Google results and our non-prod docs.

Since I've done this twice recently on production, it means we know that the instructions can work on production without breaking things, at least sometimes. But I don't really know what I'm doing, so would appreciate a careful review from Colin/Cesi to make sure this isn't missing something specific to the production environment.