### PR TITLE
Add missing cronjobs

### DIFF
--- a/app/jobs/reset_sessions_job.rb
+++ b/app/jobs/reset_sessions_job.rb
@@ -1,0 +1,8 @@
+class ResetSessionsJob < ApplicationJob
+  queue_as :reset_sessions
+
+  def perform
+    Rails.application.load_tasks
+    Rake::Task['db:sessions:trim'].invoke
+  end
+end

--- a/app/jobs/submit_performance_platform_job.rb
+++ b/app/jobs/submit_performance_platform_job.rb
@@ -1,0 +1,8 @@
+class SubmitPerformancePlatformJob < ApplicationJob
+  queue_as :submit_performance_platform
+
+  def perform
+    Rails.application.load_tasks
+    Rake::Task['performance_platform:submit_transactions'].invoke
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -17,3 +17,13 @@ export_tables:
   cron: '0 03 * * *'
   class: 'ExportTablesToBigQueryJob'
   queue: export_tables
+
+reset_sessions:
+  cron: '0 02 * * *'
+  class: 'ResetSessionsJob'
+  queue: reset_sessions
+
+submit_performance_platform:
+  cron: '0 04 * * *'
+  class: 'SubmitPerformancePlatformJob'
+  queue: submit_performance_platform

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -16,6 +16,8 @@
   - [seed_vacancies_from_api, 1]
   - [export_users, 1]
   - [export_tables, 1]
+  - [reset_sessions, 1]
+  - [submit_performance_platform, 1]
 audit_published_vacancy:
   :concurrency: 1
 audit_vacancies:
@@ -37,4 +39,8 @@ seed_vacancies_from_api:
 export_users:
   :concurrency: 1
 export_tables:
+  :concurrency: 1
+reset_sessions:
+  :concurrency: 1
+submit_performance_platform:
   :concurrency: 1

--- a/spec/jobs/reset_sessions_job_spec.rb
+++ b/spec/jobs/reset_sessions_job_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe ResetSessionsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the reset_sessions queue' do
+    expect(job.queue_name).to eq('reset_sessions')
+  end
+end

--- a/spec/jobs/submit_performance_platform_job_spec.rb
+++ b/spec/jobs/submit_performance_platform_job_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe SubmitPerformancePlatformJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the submit_performance_platform queue' do
+    expect(job.queue_name).to eq('submit_performance_platform')
+  end
+end


### PR DESCRIPTION
## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-777

We have 2 missing cronjobs from the migration to PaaS, they both call a rake task and both are executed daily:

rake performance_platform:submit_transactions

rake db:sessions:trim

we need to add them back, this time in schedule.yml file