### PR TITLE
Stop forwarding Host header for /api

### DIFF
--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -112,7 +112,7 @@ resource "aws_cloudfront_distribution" "default" {
 
     forwarded_values = {
       query_string = true
-      headers      = ["Host", "Authorization"]
+      headers      = ["Authorization"]
 
       cookies {
         forward = "none"


### PR DESCRIPTION
## Jira ticket URL:
https://dfedigital.atlassian.net/browse/TEVA-784?atlOrigin=eyJpIjoiZDkwMzgxYmUyMGE1NGMyMjhiMzU4ZDZiM2ZhZDZlODciLCJwIjoiaiJ9

## Changes in this PR:
Stop forwarding Host header for /api
This breaks anything under /api as it can't find the app on paas

- [x] Terraform deployment required?

- [ ] New development configuration to be shared?
