### PR TITLE
Refactor Vacancy to add expires_at

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -37,8 +37,12 @@ class Vacancy < ApplicationRecord
   algoliasearch disable_indexing: !Rails.env.production? do
     attributes :job_roles, :job_title, :salary, :working_patterns
 
-    attribute :expiry_date do
-      convert_date_to_unix_time(self.expires_on)
+    attribute :expires_at do
+      expires_at.to_s
+    end
+
+    attribute :expires_at_timestamp do
+      expires_at.to_i
     end
 
     attribute :first_supporting_subject do
@@ -63,7 +67,11 @@ class Vacancy < ApplicationRecord
     end
 
     attribute :publication_date do
-      convert_date_to_unix_time(self.publish_on)
+      self.publish_on&.to_s
+    end
+
+    attribute :publication_date_timestamp do
+      self.publish_on&.to_datetime&.to_i
     end
 
     attribute :school do
@@ -82,7 +90,11 @@ class Vacancy < ApplicationRecord
     end
 
     attribute :start_date do
-      convert_date_to_unix_time(self.starts_on)
+      self.starts_on&.to_s
+    end
+
+    attribute :start_date_timestamp do
+      self.starts_on&.to_datetime&.to_i
     end
 
     attribute :subject do
@@ -324,11 +336,8 @@ class Vacancy < ApplicationRecord
 
   private
 
-  def convert_date_to_unix_time(date)
-    # nil.to_i returns 0 in unix time (1970-01-01), so if date is nil we should return nil.
-    return nil if date == nil
-    # Convert to unix time via DateTime object in order to use correct time zone
-    Time.zone.at(date.to_time).to_datetime.midday.to_i
+  def expires_at
+    self.expiry_time.presence || Time.zone.at(self.expires_on.to_time).to_datetime.end_of_day
   end
 
   def slug_candidates

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -337,7 +337,9 @@ class Vacancy < ApplicationRecord
   private
 
   def expires_at
+    # rubocop:disable Rails/Date
     self.expiry_time.presence || Time.zone.at(self.expires_on.to_time).to_datetime.end_of_day
+    # rubocop:enable Rails/Date
   end
 
   def slug_candidates


### PR DESCRIPTION
## Jira ticket URL:

https://dfedigital.atlassian.net/browse/TEVA-764

## Changes in this PR:

This consolidates the expiry date and time into a single object expires_at, which is indexed as a string (for performant rendering of results) and as an integer (for Algolia to sort by).

Publication date and start date are also indexed as string and integer.

Code was tested by reindexing the 29 seed vacancies and checking the result.

Here is an example of a resultant vacancy record:

```javascript
{
      "job_roles": [
        "Teacher"
      ],
      "job_title": "Teacher of Drama",
      "salary": "£28,000",
      "working_patterns": [
        "full_time"
      ],
      "expires_at": "11 May 2022 00:00",
      "expires_at_timestamp": 1652223600,
      "first_supporting_subject": null,
      "last_updated_at": 1589185519,
      "listing_status": "published",
      "newly_qualified_teacher_status": true,
      "permalink": "teacher-of-drama",
      "publication_date": "11 May 2021",
      "publication_date_timestamp": 1620691200,
      "school": {
        "name": "Macmillan Academy",
        "address": "Stockton Road",
        "county": "KY",
        "local_authority": "ME",
        "phase": "secondary",
        "postcode": "TS5 4AG",
        "region": "London",
        "town": "Middlesbrough"
      },
      "second_supporting_subject": null,
      "start_date": null,
      "start_date_timestamp": null,
      "subject": "Drama",
      "_geoloc": {
        "lat": 54.56577,
        "lng": -1.264489
      },
      "objectID": "f7678258-95b6-4c25-86b8-adf498d1cc16"
}
```