### PR TITLE
Allow indexing of vacancy with expires_on of nil

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -355,6 +355,7 @@ class Vacancy < ApplicationRecord
   private
 
   def expires_at
+    return nil if self.expires_on.blank? && self.expiry_time.blank?
     # rubocop:disable Rails/Date
     self.expiry_time.presence || Time.zone.at(self.expires_on.to_time).to_datetime.end_of_day
     # rubocop:enable Rails/Date


### PR DESCRIPTION
## Changes in this PR:

Draft jobs may have no `expires_on` attribute.

```
Traceback (most recent call last):
        4: from (irb):2
        3: from (irb):2:in `rescue in irb_binding'
        2: from app/models/vacancy.rb:41:in `block (2 levels) in <class:Vacancy>'
        1: from app/models/vacancy.rb:359:in `expires_at'
NoMethodError (undefined method `to_time' for nil:NilClass)
```