### PR TITLE
Remove algolia fall-back environment variables

### DIFF
--- a/config/initializers/algoliasearch.rb
+++ b/config/initializers/algoliasearch.rb
@@ -1,18 +1,4 @@
-def application_id
-  ENV.fetch('ALGOLIA_APP_ID')
-rescue KeyError => e
-  Rails.logger.error("Could not find environment variable. Defaulting to 'fake_algolia_app_id'. #{e.message}")
-  'fake_algolia_app_id'
-end
-
-def api_key
-  ENV.fetch('ALGOLIA_WRITE_API_KEY')
-rescue KeyError => e
-  Rails.logger.error("Could not find environment variable. Defaulting to 'fake_algolia_write_api_key'. #{e.message}")
-  'fake_algolia_write_api_key'
-end
-
 AlgoliaSearch.configuration = {
-  application_id: application_id,
-  api_key: api_key
+  application_id: ENV.fetch('ALGOLIA_APP_ID'),
+  api_key: ENV.fetch('ALGOLIA_WRITE_API_KEY')
 }


### PR DESCRIPTION
The fall-back variables were introduced because when we used AWS as our
hosting solution, some instances did not load all the environment variables.

The problem seems to have gone away since GovUK PaaS migration.

We need all instances to have access to the real environment variables,
so that they can communicate with Algolia.