### PR TITLE
Remove Algolia fall-back environment variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,10 @@ jobs:
           - 9200:9200
         options: -e="discovery.type=single-node" --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
 
+    env:
+      ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+      ALGOLIA_WRITE_API_KEY: ${{ secrets.ALGOLIA_WRITE_API_KEY }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/config/initializers/algoliasearch.rb
+++ b/config/initializers/algoliasearch.rb
@@ -1,18 +1,4 @@
-def application_id
-  ENV.fetch('ALGOLIA_APP_ID')
-rescue KeyError => e
-  Rails.logger.error("Could not find environment variable. Defaulting to 'fake_algolia_app_id'. #{e.message}")
-  'fake_algolia_app_id'
-end
-
-def api_key
-  ENV.fetch('ALGOLIA_WRITE_API_KEY')
-rescue KeyError => e
-  Rails.logger.error("Could not find environment variable. Defaulting to 'fake_algolia_write_api_key'. #{e.message}")
-  'fake_algolia_write_api_key'
-end
-
 AlgoliaSearch.configuration = {
-  application_id: application_id,
-  api_key: api_key
+  application_id: ENV.fetch('ALGOLIA_APP_ID'),
+  api_key: ENV.fetch('ALGOLIA_WRITE_API_KEY')
 }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-713

## Changes in this PR:

The fall-back variables were introduced because when we used AWS as our
hosting solution, some instances did not load all the environment variables.

We need all instances to have access to the real environment variables,
so that they can communicate with Algolia.

I am attempting to have the github workflow know about the environment variables so that the test run can pass.
