### PR TITLE
Add more school info to Algolia indexing

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -78,10 +78,13 @@ class Vacancy < ApplicationRecord
       { name: self.school.name,
         address: self.school.address,
         county: self.school.county,
+        detailed_school_type: self.school.detailed_school_type&.label,
         local_authority: self.school.local_authority,
         phase: self.school.phase,
         postcode: self.school.postcode,
-        region: self.school.region.name,
+        religious_character: self.school.gias_data['ReligiousCharacter (name)'],
+        region: self.school.region&.name,
+        school_type: self.school.school_type&.label&.singularize,
         town: self.school.town }
     end
 


### PR DESCRIPTION
## Slack thread

https://ukgovernmentdfe.slack.com/archives/C0104ERDRB8/p1589444144009900?thread_ts=1589442955.003300&cid=C0104ERDRB8

## Changes in this PR:

We need to index school types too, and they should be searchable. Sanity-checked by indexing 29 seed vacancies to Vacancy_development.
