### PR TITLE
Correct gias_data attribute names in school factory

### DIFF
--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -11,18 +11,18 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph(sentence_count: 1) }
     easting { '1' }
     gias_data { {
-      close_date: nil,
-      head_first_name: Faker::Name.first_name,
-      head_last_name: Faker::Name.last_name,
-      head_title: Faker::Name.prefix.gsub('.', ''),
-      last_ofsted_inspection_date: Faker::Date.between(from: 999.days.ago, to: 5.days.ago),
-      number_of_pupils: Faker::Number.number(digits: 3),
-      oftsed_rating: OFSTED_RATINGS.sample,
-      open_date: Faker::Date.between(from: 10000.days.ago, to: 1000.days.ago),
-      religious_character: RELIGIOUS_CHARACTERS.sample,
-      school_capacity: Faker::Number.number(digits: 4),
-      telephone: Faker::Number.number(digits: 11).to_s,
-      trust_name: Faker::Company.name + ' Trust'
+      "CloseDate": nil,
+      "HeadFirstName": Faker::Name.first_name,
+      "HeadLastName": Faker::Name.last_name,
+      "HeadPreferredJobTitle": Faker::Name.prefix.gsub('.', ''),
+      "DateOfLastInspectionVisit": Faker::Date.between(from: 999.days.ago, to: 5.days.ago),
+      "NumberOfPupils": Faker::Number.number(digits: 3),
+      "OfstedRating (name)": OFSTED_RATINGS.sample,
+      "OpenDate": Faker::Date.between(from: 10000.days.ago, to: 1000.days.ago),
+      "ReligiousCharacter (name)": RELIGIOUS_CHARACTERS.sample,
+      "SchoolCapacity": Faker::Number.number(digits: 4),
+      "TelephoneNum": Faker::Number.number(digits: 11).to_s,
+      "Trusts (name)": Faker::Company.name + ' Trust'
       } }
     local_authority { Faker::Address.state_abbr }
     name { Faker::Educator.secondary_school.strip }


### PR DESCRIPTION
These were rubified into snake_case, but that's not how we actually
store the attribute names. We keep them as we find them in the GIAS csv.