### PR TITLE
Remove DB constraint on minimum salary

### DIFF
--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -65,8 +65,6 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   end
 
   def save_vacancy_without_validation
-    # TODO remove after migration to remove minimum salary column
-    @job_specification_form.vacancy.minimum_salary = ''
     @job_specification_form.vacancy.school_id = current_school.id
     @job_specification_form.vacancy.send :set_slug
     @job_specification_form.vacancy.status = :draft

--- a/db/migrate/20200514084513_remove_minimum_salary_db_contraint.rb
+++ b/db/migrate/20200514084513_remove_minimum_salary_db_contraint.rb
@@ -1,0 +1,5 @@
+class RemoveMinimumSalaryDbContraint < ActiveRecord::Migration[5.2]
+  def change
+    change_column :vacancies, :minimum_salary, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_06_102653) do
+ActiveRecord::Schema.define(version: 2020_05_14_084513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -185,7 +185,7 @@ ActiveRecord::Schema.define(version: 2020_04_06_102653) do
     t.string "job_title", null: false
     t.string "slug", null: false
     t.text "job_summary"
-    t.string "minimum_salary", null: false
+    t.string "minimum_salary"
     t.string "maximum_salary"
     t.text "benefits"
     t.date "starts_on"
@@ -217,9 +217,9 @@ ActiveRecord::Schema.define(version: 2020_04_06_102653) do
     t.integer "total_get_more_info_clicks"
     t.datetime "total_get_more_info_clicks_updated_at"
     t.integer "working_patterns", array: true
+    t.boolean "pro_rata_salary"
     t.integer "listed_elsewhere"
     t.integer "hired_status"
-    t.boolean "pro_rata_salary"
     t.datetime "stats_updated_at"
     t.uuid "publisher_user_id"
     t.datetime "expiry_time"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -21,7 +21,6 @@ FactoryBot.define do
     job_roles { ['Teacher'] }
     job_title { Faker::Lorem.sentence[1...30].strip }
     listed_elsewhere { nil }
-    minimum_salary { '' }
     newly_qualified_teacher { true }
     publish_on { Time.zone.today }
     qualifications { Faker::Lorem.paragraph(sentence_count: 4) }


### PR DESCRIPTION
Minimum salary is a field that is not used anymore, but still contains potential useful data as it was required in https://schema.org/JobPosting. For now I just remove the DB constraint as it was preventing the import of vacancies

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-516