### PR TITLE
Restrict documents that can be uploaded

### DIFF
--- a/app/controllers/hiring_staff/vacancies/documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/documents_controller.rb
@@ -4,7 +4,10 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
   CONTENT_TYPES_ALLOWED = %w[ application/pdf
                               image/jpeg image/png
                               video/mp4
-                              application/msword application/vnd.ms-excel application/vnd.ms-powerpoint ]
+                              application/msword application/vnd.ms-excel application/vnd.ms-powerpoint
+                              application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                              application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                              application/vnd.openxmlformats-officedocument.presentationml.presentation ]
   FILE_SIZE_LIMIT = 10.megabytes
 
   before_action :redirect_unless_vacancy

--- a/app/views/hiring_staff/vacancies/documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/documents/show.html.haml
@@ -13,6 +13,7 @@
 
       = f.govuk_file_field :documents,
         label: { text: t('jobs.upload_file'), size: 's' },
+        accept: '.doc, .xls, .ppt, .pdf, image/jpeg, image/png, video/mp4',
         multiple: true,
         enctype: 'multipart/form-data' do
 

--- a/app/views/hiring_staff/vacancies/documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/documents/show.html.haml
@@ -13,7 +13,7 @@
 
       = f.govuk_file_field :documents,
         label: { text: t('jobs.upload_file'), size: 's' },
-        accept: '.doc, .xls, .ppt, .pdf, image/jpeg, image/png, video/mp4',
+        accept: '.doc, .docx, .xls, .xlsx, .ppt, .pptx, .pdf, image/jpeg, image/png, video/mp4',
         multiple: true,
         enctype: 'multipart/form-data' do
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -265,6 +265,7 @@ en:
     file_google_error_message: '%{filename} could not be uploaded - try again'
     file_input_error_message: 'The selected file(s) could not be uploaded'
     file_size_error_message: '%{filename} must be smaller than %{size_limit}'
+    file_type_error_message: '%{filename} must be a valid file type'
     file_virus_error_message: '%{filename} contains a virus'
     upload_documents_table:
       headers:

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -206,6 +206,7 @@ RSpec.feature 'Creating a vacancy' do
 
       context 'when uploading files' do
         let(:document_upload) { double('document_upload') }
+        let(:filename) { 'blank_job_spec.pdf' }
 
         before do
           allow(DocumentUpload).to receive(:new).and_return(document_upload)
@@ -222,10 +223,25 @@ RSpec.feature 'Creating a vacancy' do
           upload_document(
             'new_documents_form',
             'documents-form-documents-field',
-            'spec/fixtures/files/blank_job_spec.pdf'
+            "spec/fixtures/files/#{filename}"
           )
 
-          expect(page).to have_content('blank_job_spec.pdf')
+          expect(page).to have_content(filename)
+        end
+
+        scenario 'displays error message when invalid file type is uploaded' do
+          visit school_job_documents_path(documents_vacancy.id)
+
+          allow_any_instance_of(HiringStaff::Vacancies::DocumentsController)
+            .to receive_message_chain(:valid_content_type?).and_return(false)
+
+          upload_document(
+            'new_documents_form',
+            'documents-form-documents-field',
+            "spec/fixtures/files/#{filename}"
+          )
+
+          expect(page).to have_content(I18n.t('jobs.file_type_error_message', filename: filename))
         end
 
         scenario 'displays error message when large file is uploaded' do
@@ -235,10 +251,12 @@ RSpec.feature 'Creating a vacancy' do
           upload_document(
             'new_documents_form',
             'documents-form-documents-field',
-            'spec/fixtures/files/blank_job_spec.pdf'
+            "spec/fixtures/files/#{filename}"
           )
 
-          expect(page).to have_content('blank_job_spec.pdf must be smaller than')
+          expect(page).to have_content(
+            I18n.t('jobs.file_size_error_message', filename: filename, size_limit: '1 KB')
+          )
         end
 
         scenario 'displays error message when virus file is uploaded' do
@@ -249,10 +267,10 @@ RSpec.feature 'Creating a vacancy' do
           upload_document(
             'new_documents_form',
             'documents-form-documents-field',
-            'spec/fixtures/files/blank_job_spec.pdf'
+            "spec/fixtures/files/#{filename}"
           )
 
-          expect(page).to have_content('blank_job_spec.pdf contains a virus')
+          expect(page).to have_content(I18n.t('jobs.file_virus_error_message', filename: filename))
         end
 
         scenario 'displays error message when file not uploaded' do
@@ -263,10 +281,10 @@ RSpec.feature 'Creating a vacancy' do
           upload_document(
             'new_documents_form',
             'documents-form-documents-field',
-            'spec/fixtures/files/blank_job_spec.pdf'
+            "spec/fixtures/files/#{filename}"
           )
 
-          expect(page).to have_content('blank_job_spec.pdf could not be uploaded - try again')
+          expect(page).to have_content(I18n.t('jobs.file_google_error_message', filename: filename))
         end
       end
 


### PR DESCRIPTION
Restrict content-types accepted by the file input and implement server side check on content-type.

Error message has been signed off by Content.

## Jira ticket URL
[TEVA-697](https://dfedigital.atlassian.net/browse/TEVA-697)

## Changes in this PR:
- Accept only .doc, .xls, .ppt, .pdf, .jpeg and .mp4 file types in the file input so users can't select other file types
- Restrict this server side as well in case an invalid file type was able to be submitted

## Screenshots of UI changes:
![image](https://user-images.githubusercontent.com/25187547/81936582-6d7cc200-95ea-11ea-8667-5dd5671f62e3.png)

