### PR TITLE
Info log to Rollbar when google drive detects malicious file upload

### DIFF
--- a/app/services/document_upload.rb
+++ b/app/services/document_upload.rb
@@ -50,6 +50,7 @@ class DocumentUpload
     if e.status_code == FILE_VIRUS_STATUS_CODE
       self.safe_download = false
       drive_service.delete_file(uploaded.id)
+      Rollbar.log(:info, 'Google drive detected the upload of a malicious file. This file has been deleted.')
     else
       self.google_error = true
     end


### PR DESCRIPTION
## Jira ticket URL

[TEVA-701](https://dfedigital.atlassian.net/browse/TEVA-701)

## Changes in this PR:
- Log to Rollbar when Google drive detects a malicious file upload
