### PR TITLE
Sign user out after (30) minutes of inactivity

### DIFF
--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -16,6 +16,7 @@ import 'src/googleOptimise';
 import 'src/googleTagManagerUrlSnippet';
 import 'src/removeCommaFromNumber';
 import 'src/shareUrl';
+import 'src/signOutAfterInactivity.js';
 import 'src/sortJobList';
 import 'src/submitFeedback';
 import 'src/uploadDocuments';

--- a/app/frontend/src/signOutAfterInactivity.js
+++ b/app/frontend/src/signOutAfterInactivity.js
@@ -1,0 +1,28 @@
+var timeoutInMinutes = 30
+
+var timeoutId; 
+
+function resetTimer() { 
+    window.clearTimeout(timeoutId)
+    startTimer();
+}
+
+function clickSignOut() {
+    document.getElementById('sign_out').click();
+}
+
+function startTimer() { 
+    var timeoutInMilliseconds = timeoutInMinutes * 60000;
+    timeoutId = window.setTimeout(clickSignOut, timeoutInMilliseconds)
+}
+ 
+function setupTimers () {
+    document.addEventListener("mousemove", resetTimer, false);
+    document.addEventListener("mousedown", resetTimer, false);
+    document.addEventListener("keypress", resetTimer, false);
+    document.addEventListener("touchmove", resetTimer, false);
+     
+    startTimer();
+}
+
+setupTimers();

--- a/app/views/shared/_navigation.haml
+++ b/app/views/shared/_navigation.haml
@@ -3,7 +3,7 @@
     - if authenticated? && !ReadOnlyFeature.enabled?
       %li{ class: active_link_class(school_path) }= link_to t('nav.school_page_link'), school_path, class: 'govuk-header__link'
       %li{ class: active_link_class(root_path) }= link_to t('nav.jobseekers_index_link'), root_path, class: 'govuk-header__link'
-      %li{ class: active_link_class(sessions_path) }= link_to t('nav.sign_out'), sessions_path, method: :delete, class: 'govuk-header__link'
+      %li{ class: active_link_class(sessions_path) }= link_to t('nav.sign_out'), sessions_path, method: :delete, class: 'govuk-header__link', id: 'sign_out'
     - else
       %label.govuk-label.navigation_heading
         = t('footer.for_job_seekers')


### PR DESCRIPTION
# Draft

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-698

## Changes in this PR:

Clicks 'sign out' link after 30 minutes of no mouse movement, key presses, or clicks.

This JS is adapted from something I found online, and I am not a JS person (YET (GROWTH MINDSET)), so let me know what is bad JS style.

We don't have any JS tests at the moment, so is it OK for this code to be untested, or should we reintroduce JS tests, or should this be totally reimplemented in Ruby?

I tested this by reducing the inactivity timeout to 6 seconds. When there is no sign_out link visible, there is an error message in the console of not finding the link; but the user is already not signed in, if that is the case.