### PR TITLE
Add listing status to default settings

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -106,7 +106,7 @@ class Vacancy < ApplicationRecord
 
     geoloc :lat, :lng
 
-    attributesForFaceting [:job_roles, :working_patterns, :school]
+    attributesForFaceting [:job_roles, :working_patterns, :school, :listing_status]
 
     add_replica 'Vacancy_publish_on_desc', inherit: true do
       ranking ['desc(publication_date_timestamp)']


### PR DESCRIPTION
## Changes in this PR:
- Add `listing_status` as a faceted attribute in the `Vacancy` model, to hopefully avoid the setting being overridden when vacancies are indexed in algolia
