### PR TITLE
Server side inactive signout

### DIFF
--- a/app/controllers/hiring_staff/base_controller.rb
+++ b/app/controllers/hiring_staff/base_controller.rb
@@ -1,7 +1,11 @@
 class HiringStaff::BaseController < ApplicationController
-  before_action :redirect_to_root_if_read_only
-  before_action :check_session
-  before_action :check_terms_and_conditions
+  TIMEOUT_PERIOD = 60.minutes
+
+  before_action :check_user_last_activity_at,
+    :update_user_last_activity_at,
+    :redirect_to_root_if_read_only,
+    :check_session,
+    :check_terms_and_conditions
 
   helper_method :current_school
 
@@ -27,5 +31,34 @@ class HiringStaff::BaseController < ApplicationController
     return if current_session_id.blank?
 
     @current_user ||= User.find_or_create_by(oid: current_session_id)
+  end
+
+  def check_user_last_activity_at
+    # config/session_store.rb expires sessions after 8 hours of inactivity,
+    # resulting in current_user == nil.
+
+    # TODO: remove config/session_store.rb when it has become redundant.
+
+    # The session_store.rb behaviour does not meet security requirements
+    # as it does not call the dsi_logout_url. Rather it only deletes our session,
+    # so the user may still be logged in on DSI, so signing in
+    # will skip the requirement to enter a password.
+    if current_user&.last_activity_at.blank?
+      redirect_to dsi_logout_url
+    elsif Time.zone.now > (current_user.last_activity_at + TIMEOUT_PERIOD)
+      session[:signing_out_for_inactivity] = true
+      redirect_to dsi_logout_url
+    end
+  end
+
+  def update_user_last_activity_at
+    return if current_user.blank?
+    current_user.update(last_activity_at: Time.zone.now)
+  end
+
+  def dsi_logout_url
+    url = URI.parse("#{ENV['DFE_SIGN_IN_ISSUER']}/session/end")
+    url.query = { post_logout_redirect_uri: auth_dfe_signout_url, id_token_hint: session[:id_token] }.to_query
+    url.to_s
   end
 end

--- a/app/controllers/hiring_staff/identifications_controller.rb
+++ b/app/controllers/hiring_staff/identifications_controller.rb
@@ -1,6 +1,7 @@
 class HiringStaff::IdentificationsController < HiringStaff::BaseController
   include ActionView::Helpers::OutputSafetyHelper
 
+  skip_before_action :check_user_last_activity_at
   skip_before_action :check_session, only: %i[new create]
   skip_before_action :check_terms_and_conditions, only: %i[new create]
   skip_before_action :verify_authenticity_token, only: [:create]

--- a/app/controllers/hiring_staff/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sessions_controller.rb
@@ -1,6 +1,8 @@
 class HiringStaff::SessionsController < HiringStaff::BaseController
   protect_from_forgery with: :null_session, only: %i[destroy]
 
+  skip_before_action :check_user_last_activity_at, only: %i[destroy]
+  skip_before_action :update_user_last_activity_at, only: %i[destroy]
   skip_before_action :check_session, only: %i[destroy]
   skip_before_action :check_terms_and_conditions, only: %i[destroy]
 
@@ -9,12 +11,6 @@ class HiringStaff::SessionsController < HiringStaff::BaseController
   end
 
   private
-
-  def dsi_logout_url
-    url = URI.parse("#{ENV['DFE_SIGN_IN_ISSUER']}/session/end")
-    url.query = { post_logout_redirect_uri: auth_dfe_signout_url, id_token_hint: session[:id_token] }.to_query
-    url.to_s
-  end
 
   def redirect_to_dfe_sign_in
     # This is defined by the class name of our Omniauth strategy

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -1,6 +1,7 @@
 class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
   include SignInAuditConcerns
 
+  skip_before_action :check_user_last_activity_at
   skip_before_action :check_session, only: %i[create new]
   skip_before_action :check_terms_and_conditions, only: %i[create new destroy]
   skip_before_action :verify_authenticity_token, only: %i[create new destroy]
@@ -18,8 +19,13 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
   end
 
   def destroy
+    if session[:signing_out_for_inactivity]
+      flash_message = { notice: I18n.t('messages.access.signed_out_for_inactivity') }
+    else
+      flash_message = { success: I18n.t('messages.access.signed_out') }
+    end
     session.destroy
-    redirect_to root_path, notice: I18n.t('messages.access.signed_out')
+    redirect_to new_identifications_path, flash_message
   end
 
   private
@@ -77,6 +83,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
     if authorisation_permissions.authorised?
       update_session(authorisation_permissions)
       current_user.update(email: identifier)
+      update_user_last_activity_at
       redirect_to school_path
     else
       not_authorised

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -635,6 +635,7 @@ en:
         only_published: You can only view published jobs
     access:
       signed_out: You've been signed out.
+      signed_out_for_inactivity: You've been signed out due to inactivity.
     feedback:
       submitted: Your feedback has been successfully submitted
     subscriptions:

--- a/db/migrate/20200517172627_add_last_activity_at_to_users.rb
+++ b/db/migrate/20200517172627_add_last_activity_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastActivityAtToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :last_activity_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -181,6 +181,10 @@ ActiveRecord::Schema.define(version: 2020_06_05_112853) do
     t.datetime "accepted_terms_at"
     t.string "email"
     t.jsonb "dsi_data"
+    t.string "magic_link_token"
+    t.datetime "magic_link_token_sent_at"
+    t.datetime "last_activity_at"
+    t.index ["magic_link_token"], name: "index_users_on_magic_link_token", unique: true
     t.index ["oid"], name: "index_users_on_oid", unique: true
   end
 

--- a/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
+++ b/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
@@ -12,8 +12,10 @@ RSpec.describe HiringStaff::Vacancies::JobSpecificationController, type: :contro
     allow(controller).to receive(:session).and_return(double('session').as_null_object)
     allow(controller).to receive_message_chain(:session, :key?).with(:urn).and_return(true)
     allow(controller).to receive_message_chain(:current_user, :accepted_terms_and_conditions?).and_return(true)
+    allow(controller).to receive_message_chain(:current_user, :last_activity_at).and_return(Time.zone.now)
+    allow(controller).to receive_message_chain(:current_user, :update)
 
-    allow(vacancy).to receive_message_chain(:id).and_return(vacancy_id)
+    allow(vacancy).to receive(:id).and_return(vacancy_id)
     allow(vacancy).to receive(:state).and_return('create')
     controller.instance_variable_set(:@vacancy, vacancy)
   end

--- a/spec/features/hiring_staff_session_timeout_spec.rb
+++ b/spec/features/hiring_staff_session_timeout_spec.rb
@@ -12,20 +12,42 @@ RSpec.feature 'Hiring staff session' do
     Timecop.return
   end
 
-  it 'expires after 8 hours and redirects to login page' do
+  def keep_user_active(length_of_time, path: new_school_job_path)
+    time_between_visits = HiringStaff::BaseController::TIMEOUT_PERIOD / 2
+    number_of_times_to_visit = length_of_time / time_between_visits
+
+    number_of_times_to_visit.times do
+      visit path
+      Timecop.travel(time_between_visits)
+    end
+  end
+
+  # TODO: add tests for TIMEOUT_PERIOD sign out
+
+  it 'expires after inactivity and redirects to login page' do
+    dsi_signout_path = '/session/end'
+
     visit new_school_job_path
 
-    Timecop.travel(8.hours)
+    Timecop.travel(HiringStaff::BaseController::TIMEOUT_PERIOD + 1.second)
 
     click_on I18n.t('buttons.save_and_continue')
 
+    expect(page.current_path).to eq dsi_signout_path
+
+    # A request to logout is sent to DfE Sign-in system. On success DSI comes back at auth_dfe_signout_path
+    visit auth_dfe_signout_path
+
     expect(page.current_path).to eq new_identifications_path
+
+    within('.govuk-header__navigation') { expect(page).to have_content(I18n.t('nav.sign_in')) }
+    expect(page).to have_content(I18n.t('messages.access.signed_out_for_inactivity'))
   end
 
-  it 'doesn\'t expire before 8 hours' do
+  it 'doesn\'t expire while user is active' do
     visit new_school_job_path
 
-    Timecop.travel(1.hour)
+    keep_user_active(10.hours)
 
     click_on I18n.t('buttons.save_and_continue')
 

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -18,7 +18,7 @@ module AuthHelpers
   def stub_hiring_staff_auth(urn:, session_id: 'session_id', email: nil)
     page.set_rack_session(urn: urn)
     page.set_rack_session(session_id: session_id)
-    create(:user, oid: session_id, email: email)
+    create(:user, oid: session_id, email: email, last_activity_at: Time.zone.now)
   end
 
   def stub_authentication_step(organisation_id: '939eac36-0777-48c2-9c2c-b87c948a9ee0',


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-698

## Changes in this PR:

This is the server-side implementation, missing the front-end (modal dialogue box) and it was based on the original obsolete acceptance criteria.

Requires migrating the database.
