### PR TITLE
NQT comparision should be against a string for legacy job alerts

### DIFF
--- a/app/services/vacancy_algolia_alert_builder.rb
+++ b/app/services/vacancy_algolia_alert_builder.rb
@@ -46,7 +46,7 @@ class VacancyAlgoliaAlertBuilder < VacancyAlgoliaSearchBuilder
     }&.join(' OR ')
 
     job_roles = "job_roles:'#{I18n.t('jobs.job_role_options.nqt_suitable')}'" if
-      subscription_hash[:newly_qualified_teacher] == true
+      subscription_hash[:newly_qualified_teacher] == 'true'
 
     phases = subscription_hash[:phases]&.map {
       |phase| "school.phase:#{phase}"

--- a/app/services/vacancy_algolia_alert_builder.rb
+++ b/app/services/vacancy_algolia_alert_builder.rb
@@ -31,7 +31,11 @@ class VacancyAlgoliaAlertBuilder < VacancyAlgoliaSearchBuilder
       hitsPerPage: MAXIMUM_SUBSCRIPTION_RESULTS,
       filters: search_filter
     )
-    Rails.logger.info("#{vacancies.count} vacancies found for job alert with criteria: #{subscription_hash}")
+    Rails.logger.info(
+      "#{vacancies.count} vacancies found for job alert with criteria: #{subscription_hash}, "\
+      "search_query: #{search_query}, replica: #{search_replica}, location_filter: #{location_filter} "\
+      "and filters: #{search_filter}"
+    )
     vacancies
   end
 

--- a/spec/jobs/send_daily_alert_email_job_spec.rb
+++ b/spec/jobs/send_daily_alert_email_job_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe SendDailyAlertEmailJob, type: :job do
             job_title: 'Teacher',
             working_patterns: ['full_time'],
             phases: ['primary', 'secondary'],
-            newly_qualified_teacher: true
+            newly_qualified_teacher: 'true'
           }.to_json
         end
 

--- a/spec/services/vacancy_algolia_alert_builder_spec.rb
+++ b/spec/services/vacancy_algolia_alert_builder_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
         subject: search_subject,
         job_title: job_title,
         working_patterns: ['full_time', 'part_time'],
-        newly_qualified_teacher: true,
+        newly_qualified_teacher: 'true',
         phases: ['secondary', 'primary'],
         from_date: date_today,
         to_date: date_today


### PR DESCRIPTION
This addresses a small bug that meant new job alerts would not respect the NQT filter applied in legacy job alerts.

## Jira ticket URL
[TEVA-817](https://dfedigital.atlassian.net/browse/TEVA-817)

## Changes in this PR:
- Fix bug that meant NQT filters were not applied
- Add extra logging for job alerts
