### PR TITLE
Add subjects array to vacancy

### DIFF
--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -55,12 +55,13 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   def job_specification_form_params
     persist_nqt_job_role_to_nqt_attribute(:job_specification_form)
     strip_empty_checkboxes(:job_specification_form, [:working_patterns, :job_roles])
+    convert_subject_ids_to_subjects_array
     params.require(:job_specification_form)
           .permit(:state, :job_title,
                   :subject_id, :first_supporting_subject_id, :second_supporting_subject_id,
                   :starts_on, :ends_on,
                   :newly_qualified_teacher,
-                  working_patterns: [], job_roles: [])
+                  job_roles: [], working_patterns: [], subjects: [])
           .merge(completed_step: current_step)
   end
 
@@ -76,5 +77,13 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
 
   def next_step
     school_job_pay_package_path(@vacancy&.id.present? ? @vacancy.id : session_vacancy_id)
+  end
+
+  def convert_subject_ids_to_subjects_array
+    subjects = params.require(:job_specification_form)
+                     .values_at(:subject_id, :first_supporting_subject_id, :second_supporting_subject_id)
+                     .reject(&:blank?)
+                     .map { |subject_id| Subject.find(subject_id).name }
+    params[:job_specification_form][:subjects] = subjects
   end
 end

--- a/db/migrate/20200521075215_add_subjects_to_vacancies.rb
+++ b/db/migrate/20200521075215_add_subjects_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddSubjectsToVacancies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :vacancies, :subjects, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_19_151545) do
+ActiveRecord::Schema.define(version: 2020_05_21_075215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -229,6 +229,7 @@ ActiveRecord::Schema.define(version: 2020_05_19_151545) do
     t.integer "completed_step"
     t.text "about_school"
     t.string "state", default: "create"
+    t.string "subjects", array: true
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["expiry_time"], name: "index_vacancies_on_expiry_time"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"

--- a/lib/tasks/convert_subject_fields_to_subject_array.rake
+++ b/lib/tasks/convert_subject_fields_to_subject_array.rake
@@ -1,0 +1,39 @@
+namespace :data do
+  desc 'Convert subject fields to string array for vacancies without the new subject field'
+  namespace :convert_subject_fields do
+    task vacancies: :environment do
+      updated_count = 0
+      should_be_updated_count = Vacancy.where("subjects is NULL or subjects = '{}'").count
+
+      Rails.logger.info(
+        "Conversion of subject fields to string array has been started for #{should_be_updated_count} vacancies"
+      )
+      Rollbar.log(
+        :info,
+        "Conversion of subject fields to string array has been started for #{should_be_updated_count} vacancies"
+      )
+
+      Vacancy.where("subjects is NULL or subjects = '{}'").in_batches(of: 100).each_record do |vacancy|
+        subject_name = vacancy.subject.present? ? vacancy.subject.name : nil
+        first_subject_name = vacancy.first_supporting_subject.present? ? vacancy.first_supporting_subject.name : nil
+        second_subject_name = vacancy.second_supporting_subject.present? ? vacancy.second_supporting_subject.name : nil
+
+        subjects = [subject_name, first_subject_name, second_subject_name].reject(&:blank?)
+
+        # rubocop:disable Rails/SkipsModelValidations
+        vacancy.update_columns(subjects: subjects)
+        # rubocop:enable Rails/SkipsModelValidations
+        updated_count += 1
+        Rails.logger.info("Updated vacancy: #{vacancy.job_title} with subjects: #{subjects}")
+      end
+
+      Rails.logger.info(
+        "Conversion of subject fields to string arrays has been completed for #{updated_count} vacancies"
+      )
+      Rollbar.log(
+        :info,
+        "Conversion of subject fields to string arrays has been completed for #{updated_count} vacancies"
+      )
+    end
+  end
+end

--- a/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
+++ b/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
@@ -47,6 +47,29 @@ RSpec.describe HiringStaff::Vacancies::JobSpecificationController, type: :contro
     end
   end
 
+  describe '#convert_subject_ids_to_subjects_array' do
+    let(:subject) { create(:subject) }
+    let(:first_supporting_subject) { create(:subject) }
+    let(:second_supporting_subject) { create(:subject) }
+
+    let(:params) do
+      {
+        job_specification_form: {
+          subject_id: subject.id,
+          first_supporting_subject_id: first_supporting_subject.id,
+          second_supporting_subject_id: second_supporting_subject.id
+        }
+      }
+    end
+
+    it 'converts subject ids to a string array of subject names' do
+      post :create, params: params
+      expect(controller.params[:job_specification_form][:subjects]).to eql(
+        [subject.name, first_supporting_subject.name, second_supporting_subject.name]
+      )
+    end
+  end
+
   describe '#create' do
     context 'job role is suitable for NQT' do
       let(:params) do


### PR DESCRIPTION
## Jira ticket URL
[TEVA-631](https://dfedigital.atlassian.net/browse/TEVA-631)

## Changes in this PR:
- Add a postgresql string array column for subjects to the vacancy table
- Add a rake task to convert existing subject fields to the new subjects field
- On vacancy save, update the new subjects field
- Index the subjects field in Algolia

## Next steps:
- Add fancy checkbox input and filter
- Update review page
- Update jobseeker page

