### PR TITLE
Algolia integration tests per pr

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,6 @@
 name: Integration Test
 
-on: [pull-request]
+on: [pull_request]
 
 jobs:
   backend-search-tests:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,6 @@
 name: Integration Test
 
-on: [push]
+on: [pull-request]
 
 jobs:
   backend-search-tests:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: [push]
+on:
+  push:
+    branches:
+      - '**'
+      - '!master'
 
 jobs:
   backend-lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push]
+on:
+  push:
+    branches:
+      - '**'
+      - '!master'
 
 jobs:
   backend-tests:

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -44,7 +44,7 @@ class Vacancy < ApplicationRecord
   # rubocop:disable Metrics/BlockLength
   # rubocop:disable Metrics/LineLength
   # There must be a better way to pass these settings to the block, but everything seems to break
-  algoliasearch index_name: Rails.env.test? ? 'Vacancy_test' : 'Vacancy', auto_index: Rails.env.production?, auto_remove: Rails.env.production?, synchronous: Rails.env.test?, disable_indexing: !(Rails.env.production? || Rails.env.test?) do
+  algoliasearch index_name: Rails.env.test? ? "Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}" : 'Vacancy', auto_index: Rails.env.production?, auto_remove: Rails.env.production?, synchronous: Rails.env.test?, disable_indexing: !(Rails.env.production? || Rails.env.test?) do
     attributes :job_roles, :job_title, :salary, :working_patterns
 
     attribute :expires_at do
@@ -118,19 +118,19 @@ class Vacancy < ApplicationRecord
 
     attributesForFaceting [:job_roles, :working_patterns, :school, :listing_status]
 
-    add_replica Rails.env.test? ? 'Vacancy_test_publish_on_desc' : 'Vacancy_publish_on_desc', inherit: true do
+    add_replica Rails.env.test? ? "Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_publish_on_desc" : 'Vacancy_publish_on_desc', inherit: true do
       ranking ['desc(publication_date_timestamp)']
     end
 
-    add_replica Rails.env.test? ? 'Vacancy_test_publish_on_asc' : 'Vacancy_publish_on_asc', inherit: true do
+    add_replica Rails.env.test? ? "Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_publish_on_asc" : 'Vacancy_publish_on_asc', inherit: true do
       ranking ['asc(publication_date_timestamp)']
     end
 
-    add_replica Rails.env.test? ? 'Vacancy_test_expiry_time_desc' : 'Vacancy_expiry_time_desc', inherit: true do
+    add_replica Rails.env.test? ? "Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_expiry_time_desc" : 'Vacancy_expiry_time_desc', inherit: true do
       ranking ['desc(expires_at_timestamp)']
     end
 
-    add_replica Rails.env.test? ? 'Vacancy_test_expiry_time_asc' : 'Vacancy_expiry_time_asc', inherit: true do
+    add_replica Rails.env.test? ? "Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_expiry_time_asc" : 'Vacancy_expiry_time_asc', inherit: true do
       ranking ['asc(expires_at_timestamp)']
     end
   end

--- a/app/services/vacancy_algolia_search_builder.rb
+++ b/app/services/vacancy_algolia_search_builder.rb
@@ -101,7 +101,7 @@ class VacancyAlgoliaSearchBuilder
   end
 
   def test_search_replica
-    Rails.env.test? ? 'test' : ''
+    Rails.env.test? ? "test#{ENV.fetch('GITHUB_RUN_ID', '')}" : ''
   end
 
   def published_today_filter

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe VacanciesController, type: :controller do
         it 'sets the search replica on VacancyAlgoliaSearchBuilder' do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql(
-            "Vacancy_test_#{sort}"
+            "Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_#{sort}"
           )
         end
       end
@@ -112,7 +112,7 @@ RSpec.describe VacanciesController, type: :controller do
         it 'sets the search replica on VacancyAlgoliaSearchBuilder' do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql(
-            "Vacancy_test_#{sort}"
+            "Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_#{sort}"
           )
         end
       end
@@ -123,7 +123,7 @@ RSpec.describe VacanciesController, type: :controller do
         it 'sets the search replica on VacancyAlgoliaSearchBuilder' do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql(
-            "Vacancy_test_#{sort}"
+            "Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_#{sort}"
           )
         end
       end
@@ -134,7 +134,7 @@ RSpec.describe VacanciesController, type: :controller do
         it 'sets the search replica on VacancyAlgoliaSearchBuilder' do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql(
-            "Vacancy_test_#{sort}"
+            "Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_#{sort}"
           )
         end
       end

--- a/spec/services/vacancy_algolia_search_builder_spec.rb
+++ b/spec/services/vacancy_algolia_search_builder_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
         end
 
         it 'uses the correct search replica' do
-          expect(subject.search_replica).to eql('Vacancy_test_publish_on_desc')
+          expect(subject.search_replica).to eql("Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_publish_on_desc")
         end
       end
     end


### PR DESCRIPTION
This PR intends to avoid integration-test check failures when branches are pushed simultaneously by naming indices per run ID and running integration-test checks only on pull request. 

## Changes in this PR:
- Run test and lint checks on all branch pushes except master
- Run integration-test checks on PR and name algolia indices by run ID

## Next steps
- Periodically delete test indices [TEVA-826](https://dfedigital.atlassian.net/browse/TEVA-826)
