### PR TITLE
Revert "Add more school info to Algolia indexing"

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -88,13 +88,10 @@ class Vacancy < ApplicationRecord
       { name: self.school.name,
         address: self.school.address,
         county: self.school.county,
-        detailed_school_type: self.school.detailed_school_type&.label,
         local_authority: self.school.local_authority,
         phase: self.school.phase,
         postcode: self.school.postcode,
-        religious_character: self.school.gias_data['ReligiousCharacter (name)'],
-        region: self.school.region&.name,
-        school_type: self.school.school_type&.label&.singularize,
+        region: self.school.region.name,
         town: self.school.town }
     end
 


### PR DESCRIPTION
Reverts DFE-Digital/teacher-vacancy-service#1551

This is to get back the ability to run Vacancy.reindex while we fix the issue that prevents it after #1551.