### PR TITLE
Use smaller batches for indexing. Index school type and job summary.

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -38,6 +38,7 @@ class Vacancy < ApplicationRecord
   include Redis::Objects
 
   include AlgoliaSearch
+  AlgoliaSearch::IndexSettings::DEFAULT_BATCH_SIZE = 100
 
   # For guidance on sanity-checking an indexing change, read documentation/algolia_sanity_check.md
 
@@ -68,6 +69,10 @@ class Vacancy < ApplicationRecord
       self.status
     end
 
+    attribute :job_summary do
+      self.job_summary&.truncate(256)
+    end
+
     attribute :newly_qualified_teacher_status do
       self.newly_qualified_teacher
     end
@@ -85,14 +90,16 @@ class Vacancy < ApplicationRecord
     end
 
     attribute :school do
-      { name: self.school.name,
-        address: self.school.address,
-        county: self.school.county,
-        local_authority: self.school.local_authority,
-        phase: self.school.phase,
-        postcode: self.school.postcode,
-        region: self.school.region.name,
-        town: self.school.town }
+      school = self.school
+      { name: school.name,
+        county: school.county,
+        detailed_school_type: school.detailed_school_type&.label,
+        local_authority: school.local_authority,
+        phase: school.phase,
+        religious_character: school.gias_data['ReligiousCharacter (name)'],
+        region: school.region&.name,
+        school_type: school.school_type&.label&.singularize,
+        town: school.town }
     end
 
     attribute :second_supporting_subject do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-821

## Changes in this PR:

- Batch reindexing in batches of 100 rather than 1000
- Remove school address and postcode from search index
- Add school type including religious character (reimplementing reverted #1551)
- Add a truncated job_summary, as this is now possible, and was on Chris' desiderata for the new search weightings.
- Split `job_roles` into 4 string attributes for filtering.
- Tested `Vacancy.reindex` by using a Vacancy_staging index.

## Next steps:

- [ ] ssh into production and run `Vacancy.reindex`
- [ ] delete index `Vacancy_staging` and replicas of it
