### PR TITLE
Change all 1-element arrays to strings

### DIFF
--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -92,7 +92,8 @@ class ExportTablesToBigQuery
       # being nullable.
       data = '' if c.name == 'hired_status' && data.nil?
       # This prevents an error whereby BigQuery rejects arrays of exactly one element.
-      data = data.to_s if c.is_a?(Array) && c.length == 1
+      data = data.to_s if c.name == 'job_roles'
+      data = data.to_s if c.name == 'subjects'
       data = data.to_s if c.name == 'working_patterns'
       data = data.to_s(:db) if !data.nil? && (c.type == :datetime || c.type == :date)
       @bigquery_data[c.name] = data

--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -92,7 +92,7 @@ class ExportTablesToBigQuery
       # being nullable.
       data = '' if c.name == 'hired_status' && data.nil?
       # This prevents an error whereby BigQuery rejects arrays of exactly one element.
-      data = data.to_s if c.name == 'job_roles'
+      data = data.to_s if c.is_a?(Array) && c.length == 1
       data = data.to_s if c.name == 'working_patterns'
       data = data.to_s(:db) if !data.nil? && (c.type == :datetime || c.type == :date)
       @bigquery_data[c.name] = data


### PR DESCRIPTION
    Change all 1-element arrays to strings

    We've recently change the the way we handle subjects in the vacancy
    table. This has resulted in a group of records with single-element
    arrays, which BQ does not like. To prevent this from happening again,
    I've added the code in this commit.