### PR TITLE
Save and return later functionality

### DIFF
--- a/app/controllers/hiring_staff/schools_controller.rb
+++ b/app/controllers/hiring_staff/schools_controller.rb
@@ -2,7 +2,7 @@ class HiringStaff::SchoolsController < HiringStaff::BaseController
   def show
     @multiple_schools = session_has_multiple_schools?
     @school = SchoolPresenter.new(current_school)
-    @sort = VacancySort.new.update(column: params[:sort_column], order: params[:sort_order])
+    @sort = VacancySort.new.update(column: sort_column, order: sort_order)
     @vacancy_presenter = SchoolVacanciesPresenter.new(@school, @sort, params[:type])
     @awaiting_feedback_count = @school.vacancies.awaiting_feedback.count
   end
@@ -33,5 +33,13 @@ class HiringStaff::SchoolsController < HiringStaff::BaseController
 
   def session_has_multiple_schools?
     session.key?(:multiple_schools) && session[:multiple_schools] == true
+  end
+
+  def sort_column
+    params[:type] == 'draft' ? (params[:sort_column] || 'created_at') : params[:sort_column]
+  end
+
+  def sort_order
+    params[:type] == 'draft' ? (params[:sort_order] || 'desc') : params[:sort_order]
   end
 end

--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -44,12 +44,21 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
     vacancy
   end
 
-  def redirect_to_next_step_if_save_and_continue(vacancy_id, job_title = nil)
-    if params[:commit] == I18n.t('buttons.save_and_return')
-      update_message = job_title.present? ?
-        I18n.t('messages.jobs.draft_saved_html', job_title: job_title) : I18n.t('messages.jobs.updated')
-      redirect_to jobs_with_type_school_path('draft'), success: update_message
-    elsif params[:commit] == I18n.t('buttons.save_and_continue')
+  def save_vacancy_as_draft_if_save_and_return_later(attributes, vacancy)
+    if params[:commit] == I18n.t('buttons.save_and_return_later')
+      vacancy = update_vacancy(attributes, vacancy)
+      redirect_to_draft(vacancy.id, vacancy.job_title)
+    end
+  end
+
+  def redirect_to_draft(vacancy_id, job_title = nil)
+    update_message = job_title.present? ?
+      I18n.t('messages.jobs.draft_saved_html', job_title: job_title) : I18n.t('messages.jobs.updated')
+    redirect_to jobs_with_type_school_path('draft'), success: update_message
+  end
+
+  def redirect_to_next_step_if_save_and_continue(vacancy_id)
+    if params[:commit] == I18n.t('buttons.save_and_continue')
       redirect_to_next_step(vacancy_id)
     elsif params[:commit] == I18n.t('buttons.update_job')
       redirect_to edit_school_job_path(vacancy_id), success: I18n.t('messages.jobs.updated')

--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -44,8 +44,12 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
     vacancy
   end
 
-  def redirect_to_next_step_if_save_and_continue(vacancy_id)
-    if params[:commit] == I18n.t('buttons.save_and_continue')
+  def redirect_to_next_step_if_save_and_continue(vacancy_id, job_title = nil)
+    if params[:commit] == I18n.t('buttons.save_and_return')
+      update_message = job_title.present? ?
+        I18n.t('messages.jobs.draft_saved_html', job_title: job_title) : I18n.t('messages.jobs.updated')
+      redirect_to jobs_with_type_school_path('draft'), success: update_message
+    elsif params[:commit] == I18n.t('buttons.save_and_continue')
       redirect_to_next_step(vacancy_id)
     elsif params[:commit] == I18n.t('buttons.update_job')
       redirect_to edit_school_job_path(vacancy_id), success: I18n.t('messages.jobs.updated')

--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -1,6 +1,9 @@
 class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacancies::ApplicationController
   before_action :redirect_unless_vacancy
   before_action :set_up_application_details_form, only: %i[update]
+  before_action only: %i[update] do
+    save_vacancy_as_draft_if_save_and_return_later(@application_details_form.params_to_save, @vacancy)
+  end
 
   def show
     @application_details_form = ApplicationDetailsForm.new(@vacancy.attributes.symbolize_keys)

--- a/app/controllers/hiring_staff/vacancies/documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/documents_controller.rb
@@ -13,6 +13,7 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
   before_action :redirect_unless_vacancy
   before_action :redirect_unless_supporting_documents
   before_action only: %i[create] do
+    save_vacancy_as_draft_if_save_and_return_later({}, @vacancy)
     redirect_to_next_step_if_save_and_continue(@vacancy.id)
   end
 

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -24,7 +24,10 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
     if @job_specification_form.complete_and_valid?
       session_vacancy_id ? update_vacancy(job_specification_form_params) : save_vacancy_without_validation
       store_vacancy_attributes(@job_specification_form.vacancy.attributes)
-      return redirect_to_next_step_if_save_and_continue(@vacancy&.id.present? ? @vacancy.id : session_vacancy_id)
+      return redirect_to_next_step_if_save_and_continue(
+        @vacancy&.id.present? ? @vacancy.id : session_vacancy_id,
+        @vacancy.job_title
+      )
     end
 
     render :show
@@ -35,7 +38,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
       remove_subject_fields(@vacancy) unless @vacancy.subjects.nil?
       update_vacancy(job_specification_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue(@vacancy.id)
+      return redirect_to_next_step_if_save_and_continue(@vacancy.id, @vacancy.job_title)
     end
 
     render :show

--- a/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
@@ -1,5 +1,8 @@
 class HiringStaff::Vacancies::JobSummaryController < HiringStaff::Vacancies::ApplicationController
   before_action :redirect_unless_vacancy
+  before_action only: %i[update] do
+    save_vacancy_as_draft_if_save_and_return_later(job_summary_form_params, @vacancy)
+  end
 
   def show
     @job_summary_form = JobSummaryForm.new(@vacancy.attributes)

--- a/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
@@ -1,5 +1,8 @@
 class HiringStaff::Vacancies::PayPackageController < HiringStaff::Vacancies::ApplicationController
   before_action :redirect_unless_vacancy
+  before_action only: %i[update] do
+    save_vacancy_as_draft_if_save_and_return_later(pay_package_form_params, @vacancy)
+  end
 
   def show
     @pay_package_form = PayPackageForm.new(@vacancy.attributes)

--- a/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
@@ -1,5 +1,8 @@
 class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacancies::ApplicationController
   before_action :redirect_unless_vacancy
+  before_action only: %i[update] do
+    save_vacancy_as_draft_if_save_and_return_later(supporting_documents_form_params, @vacancy)
+  end
 
   def show
     @supporting_documents_form = SupportingDocumentsForm.new(@vacancy.attributes)

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -83,6 +83,7 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
   end
 
   def redirect_to_incomplete_step
+    return redirect_to school_job_job_specification_path(@vacancy.id) unless step_valid?(JobSpecificationForm)
     return redirect_to school_job_pay_package_path(@vacancy.id) unless step_valid?(PayPackageForm)
     return redirect_to school_job_supporting_documents_path(@vacancy.id) unless step_valid?(SupportingDocumentsForm)
     return redirect_to school_job_application_details_path(@vacancy.id) unless step_valid?(ApplicationDetailsForm)

--- a/app/frontend/styles/components/hiring-staff.scss
+++ b/app/frontend/styles/components/hiring-staff.scss
@@ -25,6 +25,22 @@ body.hiring-staff {
   margin-top: 1.5rem;
 }
 
+.button-link {
+  background-color: transparent;
+  border: 0;
+  box-shadow: none;
+  color: $govuk-link-colour;
+  display: block;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.button-link:hover {
+  background-color: transparent;
+  color: $govuk-link-hover-colour;
+  text-decoration: underline;
+}
+
 .hod-checkmark {
   background: rgba(255, 255, 255, 0.1);
   border-radius: 50%;

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -29,7 +29,7 @@
     = link_to t('jobs.submit_listing.button'), school_job_publish_path(@vacancy.id), method: :post, class: 'govuk-button govuk-button--secondary submit-listing-without-preview-gtm', id: 'vacancy-review-submit'
 
     %br
-    = link_to t('buttons.save_and_return'), school_path, class: 'govuk-link'
+    = link_to t('buttons.save_and_return_later'), school_path, class: 'govuk-link'
 
   .govuk-grid-column-one-third
     = render 'hiring_staff/vacancies/sidebar'

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -29,7 +29,7 @@
     = link_to t('jobs.submit_listing.button'), school_job_publish_path(@vacancy.id), method: :post, class: 'govuk-button govuk-button--secondary submit-listing-without-preview-gtm', id: 'vacancy-review-submit'
 
     %br
-    = link_to t('buttons.save_and_return_later'), school_path, class: 'govuk-link'
+    = link_to t('buttons.save_and_return_later'), jobs_with_type_school_path('draft'), class: 'govuk-link'
 
   .govuk-grid-column-one-third
     = render 'hiring_staff/vacancies/sidebar'

--- a/app/views/hiring_staff/vacancies/vacancy_form_partials/_submit.html.haml
+++ b/app/views/hiring_staff/vacancies/vacancy_form_partials/_submit.html.haml
@@ -1,5 +1,5 @@
-- if @vacancy&.published?
+- if @vacancy&.published? || %w[edit edit_published review].include?(@vacancy&.state)
   = f.govuk_submit t('buttons.update_job'), classes: 'update-listing-gtm'
 - else
   = f.govuk_submit t('buttons.save_and_continue'), classes: 'govuk-!-margin-bottom-5 save-listing-gtm'
-  = f.govuk_submit t('buttons.save_and_return'), secondary: true, classes: 'button-link save-and-return-listing-gtm'
+  = f.govuk_submit t('buttons.save_and_return_later'), secondary: true, classes: 'button-link save-and-return-listing-gtm'

--- a/app/views/hiring_staff/vacancies/vacancy_form_partials/_submit.html.haml
+++ b/app/views/hiring_staff/vacancies/vacancy_form_partials/_submit.html.haml
@@ -1,4 +1,5 @@
 - if @vacancy&.published?
   = f.govuk_submit t('buttons.update_job'), classes: 'update-listing-gtm'
 - else
-  = f.govuk_submit t('buttons.save_and_continue'), classes: 'save-listing-gtm'
+  = f.govuk_submit t('buttons.save_and_continue'), classes: 'govuk-!-margin-bottom-5 save-listing-gtm'
+  = f.govuk_submit t('buttons.save_and_return'), secondary: true, classes: 'button-link save-and-return-listing-gtm'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -605,7 +605,7 @@ en:
     delete: 'Delete'
     dismiss: 'Dismiss'
     find: 'Find'
-    save_and_continue: 'Save and continue'
+    save_and_continue: 'Continue'
     save_and_return: 'Save and return later'
     submit: 'Submit'
     update_job: 'Update job'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -617,6 +617,7 @@ en:
         message: 'Improve your job listing using the new sections and features below'
       delete: The job has been deleted
       updated: 'The job has been updated'
+      draft_saved_html: '<strong>Draft saved</strong> for %{job_title}'
       view:
         only_published: You can only view published jobs
     access:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -606,9 +606,9 @@ en:
     dismiss: 'Dismiss'
     find: 'Find'
     save_and_continue: 'Continue'
-    save_and_return: 'Save and return later'
+    save_and_return_later: 'Save and return later'
     submit: 'Submit'
-    update_job: 'Update job'
+    update_job: 'Update listing'
 
   messages:
     jobs:

--- a/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
@@ -117,7 +117,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
 
         draft_vacancy.contact_email = 'test@email.com'
         draft_vacancy.application_link = 'https://example.com'
-        draft_vacancy.expires_on = DateTime.now + 1.year
+        draft_vacancy.expires_on = draft_vacancy.starts_on - 1.day
         draft_vacancy.expiry_time = Time.zone.now
         draft_vacancy.publish_on = DateTime.now + 1.day
 

--- a/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Hiring staff can preview a vacancy' do
 
     scenario 'users can save and return later' do
       click_on I18n.t('buttons.save_and_return_later')
-      expect(page).to have_current_path(school_path)
+      expect(page).to have_current_path(jobs_with_type_school_path('draft'))
       expect(page).to have_content(I18n.t('schools.jobs.index', school: school.name))
       expect(page).to have_content(I18n.t('buttons.create_job'))
     end

--- a/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Hiring staff can preview a vacancy' do
     scenario 'review page shows preview, submit and save calls to action' do
       expect(page).to have_content(I18n.t('jobs.preview_listing.button'))
       expect(page).to have_content(I18n.t('jobs.submit_listing.button'))
-      expect(page).to have_content(I18n.t('buttons.save_and_return'))
+      expect(page).to have_content(I18n.t('buttons.save_and_return_later'))
     end
 
     scenario 'users can preview the listing' do
@@ -33,7 +33,7 @@ RSpec.feature 'Hiring staff can preview a vacancy' do
     end
 
     scenario 'users can save and return later' do
-      click_on I18n.t('buttons.save_and_return')
+      click_on I18n.t('buttons.save_and_return_later')
       expect(page).to have_current_path(school_path)
       expect(page).to have_content(I18n.t('schools.jobs.index', school: school.name))
       expect(page).to have_content(I18n.t('buttons.create_job'))

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -565,7 +565,7 @@ RSpec.feature 'Creating a vacancy' do
           end
           expect(Vacancy.last.state).to eql('review')
 
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
           expect(Vacancy.last.state).to eql('review')
 
           click_header_link(I18n.t('jobs.job_details'))
@@ -654,7 +654,7 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 6))
 
           fill_in 'job_specification_form[job_title]', with: 'An edited job title'
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
 
           expect(page).to have_content(I18n.t('jobs.review_heading'))
           expect(page).to have_content('An edited job title')
@@ -670,7 +670,7 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 6))
 
           fill_in 'job_specification_form[job_title]', with: 'High school teacher'
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
 
           activity = vacancy.activities.last
           expect(activity.session_id).to eq(session_id)
@@ -684,12 +684,12 @@ RSpec.feature 'Creating a vacancy' do
           click_header_link(I18n.t('jobs.job_details'))
 
           fill_in 'job_specification_form[job_title]', with: ''
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
 
           expect(page).to have_content('Enter a job title')
 
           fill_in 'job_specification_form[job_title]', with: 'A new job title'
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
 
           expect(page).to have_content(I18n.t('jobs.review_heading'))
           expect(page).to have_content('A new job title')
@@ -722,7 +722,7 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 6))
           expect(page).to have_content(I18n.t('jobs.upload_file'))
 
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
 
           expect(page).to have_content(I18n.t('jobs.review_heading'))
         end
@@ -737,12 +737,12 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
 
           fill_in 'application_details_form[contact_email]', with: 'not a valid email'
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
 
           expect(page).to have_content('Enter an email address in the correct format, like name@example.com')
 
           fill_in 'application_details_form[contact_email]', with: 'a@valid.email'
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
 
           expect(page).to have_content(I18n.t('jobs.review_heading'))
           expect(page).to have_content('a@valid.email')
@@ -756,12 +756,12 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
 
           fill_in 'application_details_form[application_link]', with: 'www invalid.domain.com'
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
 
           expect(page).to have_content('Enter an application link in the correct format, like http://www.school.ac.uk')
 
           fill_in 'application_details_form[application_link]', with: 'www.valid-domain.com'
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
 
           expect(page).to have_content(I18n.t('jobs.review_heading'))
           expect(page).to have_content('www.valid-domain.com')
@@ -775,7 +775,7 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 6))
 
           fill_in 'application_details_form[contact_email]', with: 'an@email.com'
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
 
           expect(page).to have_content(I18n.t('jobs.review_heading'))
           expect(page).to have_content('an@email.com')
@@ -788,7 +788,7 @@ RSpec.feature 'Creating a vacancy' do
           click_header_link(I18n.t('jobs.application_details'))
 
           fill_in 'application_details_form[contact_email]', with: 'an@email.com'
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.update_job')
 
           activity = vacancy.activities.last
           expect(activity.session_id).to eq(session_id)

--- a/spec/features/hiring_staff_can_save_and_return_later_spec.rb
+++ b/spec/features/hiring_staff_can_save_and_return_later_spec.rb
@@ -1,0 +1,161 @@
+require 'rails_helper'
+
+
+RSpec.feature 'Hiring staff can save and return later' do
+  let(:school) { create(:school) }
+  let(:session_id) { SecureRandom.uuid }
+
+  before do
+    stub_hiring_staff_auth(urn: school.urn, session_id: session_id)
+    @vacancy = VacancyPresenter.new(build(:vacancy, :draft))
+  end
+
+  context 'Create a job journey' do
+    context '#job_details' do
+      scenario 'can save and return later' do
+        visit school_path
+        click_on I18n.t('buttons.create_job')
+
+        expect(page.current_path).to eql(job_specification_school_job_path)
+        expect(page).to have_content(I18n.t('jobs.create_a_job', school: school.name))
+        expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 6))
+        within('h2.govuk-heading-l') do
+          expect(page).to have_content(I18n.t('jobs.job_details'))
+        end
+
+        fill_in 'job_specification_form[job_title]', with: @vacancy.job_title
+        click_on I18n.t('buttons.save_and_return_later')
+        created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
+
+        expect(page.current_path).to eql(jobs_with_type_school_path('draft'))
+        expect(page.body).to include(I18n.t('messages.jobs.draft_saved_html', job_title: @vacancy.job_title))
+
+        click_on 'Edit'
+
+        expect(page.current_path).to eql(school_job_job_specification_path(created_vacancy.id))
+        expect(find_field('job_specification_form[job_title]').value).to eql(@vacancy.job_title)
+      end
+    end
+
+    context '#pay_package' do
+      scenario 'can save and return later' do
+        visit school_path
+        click_on I18n.t('buttons.create_job')
+
+        fill_in_job_specification_form_fields(@vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+        created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
+
+        expect(page.current_path).to eql(school_job_pay_package_path(created_vacancy.id))
+
+        fill_in 'pay_package_form[benefits]', with: @vacancy.benefits
+        click_on I18n.t('buttons.save_and_return_later')
+
+        expect(page.current_path).to eql(jobs_with_type_school_path('draft'))
+        expect(page.body).to include(I18n.t('messages.jobs.draft_saved_html', job_title: @vacancy.job_title))
+
+        click_on 'Edit'
+
+        expect(page.current_path).to eql(school_job_pay_package_path(created_vacancy.id))
+        expect(find_field('pay_package_form[benefits]').value).to eql(@vacancy.benefits)
+      end
+    end
+
+    context '#supporting_documents' do
+      scenario 'can save and return later' do
+        visit school_path
+        click_on I18n.t('buttons.create_job')
+
+        fill_in_job_specification_form_fields(@vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+        created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
+
+        fill_in_pay_package_form_fields(@vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        expect(page.current_path).to eql(school_job_supporting_documents_path(created_vacancy.id))
+
+        click_on I18n.t('buttons.save_and_return_later')
+
+        expect(page.current_path).to eql(jobs_with_type_school_path('draft'))
+        expect(page.body).to include(I18n.t('messages.jobs.draft_saved_html', job_title: @vacancy.job_title))
+
+        click_on 'Edit'
+
+        expect(page.current_path).to eql(school_job_supporting_documents_path(created_vacancy.id))
+        expect(find_field('supporting-documents-form-supporting-documents-yes-field').checked?).to eql(false)
+        expect(find_field('supporting-documents-form-supporting-documents-no-field').checked?).to eql(false)
+      end
+    end
+
+    context '#application_details' do
+      scenario 'can save and return later' do
+        visit school_path
+        click_on I18n.t('buttons.create_job')
+
+        fill_in_job_specification_form_fields(@vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+        created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
+
+        fill_in_pay_package_form_fields(@vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        select_no_for_supporting_documents
+        click_on I18n.t('buttons.save_and_continue')
+
+        expect(page.current_path).to eql(school_job_application_details_path(created_vacancy.id))
+
+        yesterday = 1.day.ago
+        fill_in 'application_details_form[expires_on(3i)]', with: yesterday.day
+        fill_in 'application_details_form[expires_on(2i)]', with: yesterday.month
+        fill_in 'application_details_form[expires_on(1i)]', with: yesterday.year
+        click_on I18n.t('buttons.save_and_return_later')
+
+        expect(page.current_path).to eql(jobs_with_type_school_path('draft'))
+        expect(page.body).to include(I18n.t('messages.jobs.draft_saved_html', job_title: @vacancy.job_title))
+
+        click_on 'Edit'
+
+        expect(page.current_path).to eql(school_job_application_details_path(created_vacancy.id))
+        expect(find_field('application_details_form[expires_on(3i)]').value).to eql(yesterday.day.to_s)
+        expect(find_field('application_details_form[expires_on(2i)]').value).to eql(yesterday.month.to_s)
+        expect(find_field('application_details_form[expires_on(1i)]').value).to eql(yesterday.year.to_s)
+      end
+    end
+
+    context '#job_summary' do
+      scenario 'can save and return later' do
+        visit school_path
+        click_on I18n.t('buttons.create_job')
+
+        fill_in_job_specification_form_fields(@vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+        created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
+
+        fill_in_pay_package_form_fields(@vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        select_no_for_supporting_documents
+        click_on I18n.t('buttons.save_and_continue')
+
+        fill_in_application_details_form_fields(@vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+
+        expect(page.current_path).to eql(school_job_job_summary_path(created_vacancy.id))
+
+        fill_in 'job_summary_form[job_summary]', with: ''
+        fill_in 'job_summary_form[about_school]', with: @vacancy.about_school
+        click_on I18n.t('buttons.save_and_return_later')
+
+        expect(page.current_path).to eql(jobs_with_type_school_path('draft'))
+        expect(page.body).to include(I18n.t('messages.jobs.draft_saved_html', job_title: @vacancy.job_title))
+
+        click_on 'Edit'
+
+        expect(page.current_path).to eql(school_job_job_summary_path(created_vacancy.id))
+        expect(find_field('job_summary_form[job_summary]').value).to eql('')
+        expect(find_field('job_summary_form[about_school]').value).to eql(@vacancy.about_school)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR allows hiring staff to save a listing as a draft, retaining what they have entered without any validation.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-539

## Changes in this PR
- Add save and return later button and functionality
- Update CTA throughout the create a job/edit/review processes

## Screenshots of UI changes:
![image](https://user-images.githubusercontent.com/25187547/83430567-c98a7780-a42d-11ea-963a-575e55cc15e9.png)
![image](https://user-images.githubusercontent.com/25187547/83430610-d73ffd00-a42d-11ea-9270-c70aecc0f961.png)
