### PR TITLE
resolve some inconsistencies in search results

### DIFF
--- a/app/frontend/src/lib/utils.js
+++ b/app/frontend/src/lib/utils.js
@@ -25,7 +25,7 @@ export const extractQueryParams = (url, keys) => {
 
 export const stringMatchesPostcode = postcode => {
     postcode = postcode.replace(/\s/g, '');
-    const regex = /^[A-Z]{1,2}[0-9]{1,2} ?[0-9][A-Z]{2}$/i;
+    const regex = /^[A-Za-z]{1,2}[0-9]{1,2}[A-Za-z]? ?[0-9][A-Z]{2}$/i;
     return regex.test(postcode);
 };
 

--- a/app/frontend/src/lib/utils.test.js
+++ b/app/frontend/src/lib/utils.test.js
@@ -30,7 +30,10 @@ describe('stringMatchesPostcode', () => {
         'SE18 2BT',
         'SE182BT',
         'B2 5ST',
-        'B25ST'
+        'B25ST',
+        'SW1A 1AA',
+        'SW1A 1aa',
+        'Sw1A 1aA'
     ];
 
     test('matches a correct postcode', () => {

--- a/app/frontend/src/search/hits.js
+++ b/app/frontend/src/search/hits.js
@@ -84,7 +84,7 @@ export const templates = {
     {{ job_title }}
     </a>
     </h2>
-  <p>{{ school.name }}, {{ school.town }}, {{ school.region }}.</p>
+  <p>{{ school.name }}, {{ school.town }}, {{ school.county }}.</p>
   <dl>
 <dt>Salary</dt>
 <dd class="double">

--- a/app/views/vacancies/_sorting_options.html.haml
+++ b/app/views/vacancies/_sorting_options.html.haml
@@ -1,9 +1,8 @@
 .govuk-grid-row.sortable-links
-  .govuk-grid-column-one-half
-    = form_tag('', method: :get, id: 'jobs_sort_form') do
-      - search_criteria.each do |filter, value|
-        - unless filter == :jobs_sort
-          = hidden_field_tag filter, value
-      = label_tag 'jobs_sort_select', t('jobs.sort_by.label'), class: "govuk-label inline", id: 'jobs_sort_label'
-      = select_tag 'jobs_sort', options_for_select(job_sorting_options, @vacancies_search.sort_by), class: 'govuk-select govuk-input--width-10', id: 'jobs_sort_select'
-      = submit_tag t('jobs.sort_by.submit'), class: 'govuk-button', id: 'submit_job_sort'
+  = form_tag('', method: :get, id: 'jobs_sort_form') do
+    - search_criteria.each do |filter, value|
+      - unless filter == :jobs_sort
+        = hidden_field_tag filter, value
+    = label_tag 'jobs_sort_select', t('jobs.sort_by.label'), class: "govuk-label inline", id: 'jobs_sort_label'
+    = select_tag 'jobs_sort', options_for_select(job_sorting_options, @vacancies_search.sort_by), class: 'govuk-select govuk-input--width-10', id: 'jobs_sort_select'
+    = submit_tag t('jobs.sort_by.submit'), class: 'govuk-button govuk-!-margin-0', id: 'submit_job_sort'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,8 +219,8 @@ en:
     job_count_plural_without_search: 'There are %{count} jobs listed'
     job_count: '%{count} job matches your search'
     job_count_plural: '%{count} jobs match your search'
-    job_count_with_location_category: '%{count} teaching job in %{location}'
-    job_count_plural_with_location_category: '%{count} teaching jobs in %{location}'
+    job_count_with_location_category: '%{count} job match near %{location}'
+    job_count_plural_with_location_category: '%{count} jobs match near %{location}'
     no_jobs:
       intro: 'You might find matching jobs by:'
       suggestions:


### PR DESCRIPTION
this resolves some minor inconsistencies observed in search results

- better positioning of sort submit button in server rendered page
- align headings between SS and CS to reduce initial flash
- SS uses county in vacancy search results, make CS use the same

changes can be viewed https://teaching-vacancies-dev.london.cloudapps.digital/