### PR TITLE
Remove all option from subjects.yml

### DIFF
--- a/lib/tasks/data/subjects.yml
+++ b/lib/tasks/data/subjects.yml
@@ -1,5 +1,4 @@
 ---
-- ['All or Not applicable', 'applies to examples such as primary school roles']
 - ['Accounting', 'includes Finance and accounting']
 - ['Art and design', '']
 - ['Bengali', '']


### PR DESCRIPTION
This PR removes a redundant option from the subject options list in the create a job journey.

## Changes in this PR
- Remove `All or Not applicable` option following Product/UX feedback

## Next steps
- ssh into production and remove `All or Not applicable` from subjects arrays where vacancies have this option selected