### PR TITLE
Use presenters for index (front end changes from #1598)

### DIFF
--- a/app/frontend/src/search/hits.js
+++ b/app/frontend/src/search/hits.js
@@ -69,14 +69,6 @@ export const hideServerMarkup = () => {
   }
 };
 
-export const snakeCaseToHumanReadable = value => value.toLowerCase().replace(/_/g, ' ');
-
-export const transform = items => items.map(item => ({
-  ...item,
-  working_patterns: Array.isArray(item.working_patterns) ? item.working_patterns.map(snakeCaseToHumanReadable).join(', ') : item.working_patterns,
-  school_region: item.school.region || item.school.county
-}));
-
 export const templates = {
   item: `
 <article class="vacancy" role="article">
@@ -85,7 +77,7 @@ export const templates = {
     {{ job_title }}
     </a>
     </h2>
-  <p>{{ school.name }}, {{ school.town }}, {{ school_region }}.</p>
+  <p>{{ location }}</p>
   <dl>
 <dt>Salary</dt>
 <dd class="double">
@@ -97,7 +89,7 @@ export const templates = {
 </dd>
 <dt>Working pattern</dt>
 <dd class="double">
-{{ working_patterns }}
+{{ working_patterns_for_display }}
 </dd>
 <dt>Closing date</dt>
 <dd class="double">

--- a/app/frontend/src/search/hits.test.js
+++ b/app/frontend/src/search/hits.test.js
@@ -1,56 +1,8 @@
-import { snakeCaseToHumanReadable, createCapitalisedStringWithPrefix, transform, getJobAlertLink, getJobAlertLinkParam } from './hits';
-
-describe('snakeCaseToHumanReadable', () => {
-    test('formats an array of snake case strings for display', () => {
-        expect(snakeCaseToHumanReadable('Secondary_girls_school')).toBe('secondary girls school');
-    });
-});
+import { createCapitalisedStringWithPrefix, getJobAlertLink, getJobAlertLinkParam } from './hits';
 
 describe('createCapitalisedStringWithPrefix', () => {
     test('returns a string of capitalized words after a prefix', () => {
         expect(createCapitalisedStringWithPrefix('176 jobs near', 'babylon gardens')).toBe('176 jobs near Babylon Gardens');
-    });
-});
-
-describe('transform', () => {
-    test('converts each vacancy in array to renderable values', () => {
-
-        const items = [
-            {
-                working_patterns: ['pattern 1', 'pattern 2'],
-                somethingElse: 'abc',
-                school: {
-                    region : 'south east',
-                    county : 'kent'
-                }
-            },
-            {
-                working_patterns: 'pattern 3',
-                somethingElse: 'xyz',
-                school: {
-                    county : 'surrey'
-                }
-            }
-        ];
-        expect(transform(items)).toStrictEqual([
-            {
-                'somethingElse': 'abc',
-                'working_patterns': 'pattern 1, pattern 2',
-                'school': {
-                    'county': 'kent',
-                    'region': 'south east'
-                },
-                'school_region': 'south east'
-            },
-            {
-                'somethingElse': 'xyz',
-                'working_patterns': 'pattern 3',
-                'school': {
-                    'county': 'surrey'
-                },
-                'school_region': 'surrey'
-            }
-        ]);
     });
 });
 

--- a/app/frontend/src/search/index.js
+++ b/app/frontend/src/search/index.js
@@ -7,7 +7,7 @@ import '../polyfill/classlist.polyfill';
 import { connectSearchBox, connectAutocomplete, connectHits, connectSortBy, connectMenu } from 'instantsearch.js/es/connectors';
 import { hits, pagination, configure } from 'instantsearch.js/es/widgets';
 
-import { transform, templates, renderContent } from './hits';
+import { templates, renderContent } from './hits';
 import { searchClient } from './client';
 
 import { renderSearchBox } from './ui/input';
@@ -114,9 +114,6 @@ if (document.querySelector('#vacancies-hits')) {
         }),
         hits({
             container: '#vacancies-hits',
-            transformItems(items) {
-                return transform(items);
-            },
             templates,
             cssClasses: {
                 list: ['vacancies'],

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -2,6 +2,7 @@ class VacancyPresenter < BasePresenter
   include ActionView::Helpers::TextHelper
   include ActionView::Helpers::UrlHelper
 
+  delegate :location, to: :school
   delegate :working_patterns, to: :model, prefix: true
   delegate :job_roles, to: :model, prefix: true
 
@@ -44,10 +45,6 @@ class VacancyPresenter < BasePresenter
 
   def benefits
     simple_format(model.benefits) if model.benefits.present?
-  end
-
-  def location
-    @location ||= school.location
   end
 
   def expired?

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,5 +1,5 @@
 # Configure Rack::Cors https://github.com/cyu/rack-cors
-Rails.application.config.middleware.insert_before 0, Rack::Cors, debug: true, logger: (-> { Rails.logger }) do
+Rails.application.config.middleware.insert_before 0, Rack::Cors, debug: Rails.env.production?, logger: (-> { Rails.logger }) do
   allow do
     # Allow all domains access to jobs API
     origins '*'

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,5 +1,5 @@
 # Configure Rack::Cors https://github.com/cyu/rack-cors
-Rails.application.config.middleware.insert_before 0, Rack::Cors, debug: Rails.env.production?, logger: (-> { Rails.logger }) do
+Rails.application.config.middleware.insert_before 0, Rack::Cors, debug: true, logger: (-> { Rails.logger }) do
   allow do
     # Allow all domains access to jobs API
     origins '*'

--- a/documentation/algolia_sanity_check.md
+++ b/documentation/algolia_sanity_check.md
@@ -11,4 +11,10 @@ algoliasearch per_environment: true, disable_indexing: Rails.env.production? do
 This creates a separate index called Vacancy_{environment}, and will only
 be run in non-production environments.
 
+Double-check that you aren't about to put data in the real database with:
+
+```ruby
+Vacancy.index.name # should be e.g. Vacancy_staging
+```
+
 You will also need to comment out or adapt the add_replica blocks.


### PR DESCRIPTION
Now that the index changes from #1598 have been deployed, and Vacancy has been reindexed (and synonyms added back in), we can deploy the front end changes from #1598. The description below is copied from #1598.

## Changes in this PR:

- Route indexed vacancy attributes via presenter methods. We want a single source of truth for the presentation of these attributes.
- Visible changes in UI are the inclusion of 'pm/am' in the expiry time, and the capitalization and punctuation of working patterns.

## Screenshots of UI changes:

### Before

([current production](https://teaching-vacancies.service.gov.uk/jobs?utf8=%E2%9C%93&keyword=teacher&location=&commit=Search#vacancy-results))

<img width="921" alt="Screenshot 2020-06-01 at 19 40 28" src="https://user-images.githubusercontent.com/60350599/83442279-d31cdb00-a43f-11ea-86aa-ad69b2c953be.png">

### After 

(on staging)

<img width="611" alt="Screenshot 2020-06-01 at 19 35 25" src="https://user-images.githubusercontent.com/60350599/83442357-f0ea4000-a43f-11ea-842a-ea86d08681b2.png">

## Next steps:

- [x] Run `Vacancy.reindex` (without bang) on production immediately after merging.
- [x] Reindexing will probably knock out the synonyms. The latest JSON of synonyms will be found [here](https://drive.google.com/drive/u/0/folders/1RcwUjcIlpt7WXN9qPmuZKUgXvyvP9EMW) and can be directly uploaded on the Algolia dashboard.