### PR TITLE
Update no job listings page content

### DIFF
--- a/app/frontend/styles/components/school.scss
+++ b/app/frontend/styles/components/school.scss
@@ -30,3 +30,10 @@
     width: 100%;
   }
 }
+
+.no-jobs-border {
+  border: 2px dashed $govuk-border-colour;
+  margin-left: 0;
+  margin-right: 0;
+  padding: 20px 20px 0;
+}

--- a/app/views/hiring_staff/schools/_no_vacancies.html.haml
+++ b/app/views/hiring_staff/schools/_no_vacancies.html.haml
@@ -1,19 +1,18 @@
-.govuk-grid-row
+.govuk-grid-row.no-jobs-border{ class: 'govuk-!-margin-top-5 govuk-!-margin-bottom-5' }
   .govuk-grid-column-full
     %h2.govuk-heading-m= t('schools.no_jobs.heading')
 
-    %p
-      = "To"
-      = link_to 'create a good job listing', new_school_job_path(school), class: 'govuk-link'
-      = 'for your school, you will need the following information:'
+    = link_to t('buttons.create_job'), new_school_job_path, class: 'govuk-button govuk-!-margin-bottom-0'
 
-  .govuk-grid-column-one-half
+    %p= t('schools.no_jobs.intro')
+
+  .govuk-grid-column-one-third
     %h2.govuk-heading-s Required
     %ul.govuk-list.govuk-list--bullet
-      - t('schools.no_jobs.bullets.mandatory').each do |bullet|
+      - t('schools.no_jobs.bullets.required').each do |bullet|
         %li= bullet
 
-  .govuk-grid-column-one-half
+  .govuk-grid-column-one-third
     %h2.govuk-heading-s Optional
     %ul.govuk-list.govuk-list--bullet
       - t('schools.no_jobs.bullets.optional').each do |bullet|

--- a/app/views/hiring_staff/schools/show.html.haml
+++ b/app/views/hiring_staff/schools/show.html.haml
@@ -18,8 +18,8 @@
 .govuk-grid-row
   .govuk-grid-column-full
     .govuk-form-group.create-a-job
-      = link_to t('buttons.create_job'), new_school_job_path, class: 'govuk-button'
     - if @school.vacancies.active.any?
+      = link_to t('buttons.create_job'), new_school_job_path, class: 'govuk-button govuk-!-margin-bottom-0'
       .overflow-scroll
         = render partial: 'vacancies', locals: { school: @school, vacancies: @vacancies }
     - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -499,26 +499,28 @@ en:
     jobs:
       index: 'Jobs at %{school}'
     no_jobs:
-      heading: 'You have no current jobs.'
+      heading: You have no job listings to manage
+      intro: 'To create a job listing for your school, you will need the following information:'
       bullets:
-        mandatory:
-          - 'a job title'
-          - 'a job summary'
-          - 'working patterns'
-          - 'a salary range'
-          - 'educational requirements'
-          - 'qualifications required'
-          - 'experience required'
-          - 'a contact email address'
-          - 'a link to apply online'
-          - 'the deadline for applications'
+        required:
+          - job title
+          - job role
+          - working pattern
+          - salary
+          - date job will be listed
+          - date application is due
+          - time application is due
+          - contact email
+          - job summary
+          - information about the school
         optional:
-          - 'details of employee benefits'
-          - 'the main subject'
-          - 'a pay scale'
-          - 'leadership level'
-          - 'expected start date'
-          - 'end date (for fixed-term jobs)'
+          - subject
+          - employee benefits
+          - date job starts
+          - supporting documents to attach
+          - how to arrange a school visit
+          - how to apply
+          - link to online application
     size:
       enrolled: '%{number} %{pupils} enrolled'
       up_to: 'Up to %{capacity} %{pupils}'

--- a/spec/features/hiring_staff_can_view_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_view_vacancies_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'School viewing vacancies' do
 
     expect(page).to have_content(I18n.t('schools.jobs.index', school: school.name))
     expect(page).not_to have_css('table.vacancies')
-    expect(page).to have_content('You have no current jobs.')
+    expect(page).to have_content(I18n.t('schools.no_jobs.heading'))
   end
 
   scenario 'A school can see a list of vacancies' do


### PR DESCRIPTION
This PR implements some content changes to the page hiring staff see when they first visit the manage jobs page/have no active vacancies.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-607
https://www.figma.com/file/KnFYJyTGiyshGDGr61uEvi/Sprint-53?node-id=0%3A1

## Changes in this PR
- Content changes to the 'no vacancies yet' manage jobs page

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/25187547/83659592-a392dd80-a5bb-11ea-997d-240477f62570.png)

### After
![image](https://user-images.githubusercontent.com/25187547/84144569-5e096100-aa50-11ea-9f30-b46e955bf10d.png)



