### PR TITLE
TEVA-873 Delete conduit after DB sync

### DIFF
--- a/bin/sync-db
+++ b/bin/sync-db
@@ -5,7 +5,9 @@ cf7 api $CF_API_ENDPOINT
 cf7 auth
 
 cf7 target -o $CF_ORG -s $CF_SPACE_ORIGIN
-cf7 conduit "$CF_POSTGRES_SERVICE_ORIGIN" -- pg_dump -x --no-owner -c -f backup.sql
+cf7 conduit "$CF_POSTGRES_SERVICE_ORIGIN" --app-name teaching-vacancies-conduit-production -- pg_dump -x --no-owner -c -f backup.sql
+cf7 delete -f teaching-vacancies-conduit-production
 
 cf7 target -o $CF_ORG -s $CF_SPACE_TARGET
-cf7 conduit "$CF_POSTGRES_SERVICE_TARGET" -- psql < backup.sql
+cf7 conduit "$CF_POSTGRES_SERVICE_TARGET" --app-name teaching-vacancies-conduit-staging -- psql < backup.sql
+cf7 delete -f teaching-vacancies-conduit-staging


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-873

## Changes in this PR:
Conduit may fail to delete if the job takes a long time. We can see this
error in the sync job:
 * failed to delete __conduit_zud2wg5f__ app, please delete it manually
To avoid this issue, we delete it explicitly after using it.

## How to review
It can be run locally but it takes a long time. The pg actions may be replaced by fake commands.