### PR TITLE
Applying for the job - listing page changes

### DIFF
--- a/app/frontend/styles/components/key_dates_sidebar.scss
+++ b/app/frontend/styles/components/key_dates_sidebar.scss
@@ -51,8 +51,3 @@ ul.key-dates-timeline {
     }
   }
 }
-
-.vacancy-apply-link {
-  margin-bottom: 0;
-  width: 100%;
-}

--- a/app/frontend/styles/components/vacancy.scss
+++ b/app/frontend/styles/components/vacancy.scss
@@ -78,4 +78,9 @@
       }
     }
   }
+
+  .vacancy-apply-link {
+    margin-bottom: 0;
+    width: auto;
+  }
 }

--- a/app/models/concerns/vacancy_application_detail_validations.rb
+++ b/app/models/concerns/vacancy_application_detail_validations.rb
@@ -5,7 +5,6 @@ module VacancyApplicationDetailValidations
     validates :contact_email, presence: true
     validates :contact_email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i }, if: :contact_email?
 
-    validates :application_link, presence: true
     validates :application_link, url: true, if: :application_link?
   end
 end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -31,6 +31,14 @@ class VacancyPresenter < BasePresenter
     end
   end
 
+  def school_visits
+    simple_format(model.school_visits) if model.school_visits.present?
+  end
+
+  def how_to_apply
+    simple_format(model.how_to_apply) if model.how_to_apply.present?
+  end
+
   def education
     simple_format(model.education) if model.education.present?
   end

--- a/app/views/hiring_staff/vacancies/application_details/show.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/show.html.haml
@@ -27,9 +27,8 @@
         rows: 10
 
       = f.govuk_url_field :application_link,
-        label: { text: t('helpers.fieldset.application_details_form.application_link_html'), size: 's' },
-        hint_text: t('helpers.hint.application_details_form.application_link'),
-        required: true
+        label: { text: t('helpers.fieldset.application_details_form.application_link'), size: 's' },
+        hint_text: t('helpers.hint.application_details_form.application_link')
 
       = render 'hiring_staff/vacancies/vacancy_form_partials/submit', f: f
 

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_application_details.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_application_details.html.haml
@@ -25,7 +25,4 @@
     %dt.app-check-your-answers__question#application_link
       %h4.govuk-heading-s= t('jobs.application_link')
     %dd.app-check-your-answers__answer
-      = link_to @vacancy.application_link, class: 'govuk-link', 'aria-label': t('jobs.aria_labels.application_link_url', url: @vacancy.application_link) do
-        %span.govuk-body-m.govuk-link= t('jobs.application_link_url')
-        %br
-        %span.govuk-body-s.govuk-link= @vacancy.application_link
+      = link_to @vacancy.application_link, @vacancy.application_link, class: 'govuk-link', 'aria-label': t('jobs.aria_labels.application_link_url'), 'target': '_blank'

--- a/app/views/shared/vacancy/_jobseeker_view.html.haml
+++ b/app/views/shared/vacancy/_jobseeker_view.html.haml
@@ -4,12 +4,12 @@
       .banner-warning= t('jobs.expired')
 
 .govuk-grid-row.govuk-grid-column-full
-  %h1.govuk-heading-l{ class: 'govuk-!-margin-bottom-2' }
+  %h1.govuk-heading-xl{ class: 'govuk-!-margin-bottom-2' }
     = @vacancy.job_title
   %h4.govuk-caption-l.job-caption{ class: 'govuk-!-margin-top-0' }
     = @vacancy.location
 
-.govuk-grid-row 
+.govuk-grid-row
 
   = render '/vacancies/key_dates_sidebar'
 

--- a/app/views/vacancies/_job_details_section.html.haml
+++ b/app/views/vacancies/_job_details_section.html.haml
@@ -42,9 +42,13 @@
       %h4.govuk-heading-s= t('jobs.experience')
       %p= @vacancy.experience
 
-  -if @vacancy.benefits.present?
+  - if @vacancy.benefits.present?
     %h4.govuk-heading-s= t('jobs.benefits')
     %p= @vacancy.benefits
+
+  - if @vacancy.how_to_apply.present?
+    %h4.govuk-heading-s= t('jobs.applying_for_the_job')
+    %p= @vacancy.how_to_apply
 
   - if @vacancy.documents.any?
     %h4.govuk-heading-s= t('jobs.supporting_documents')

--- a/app/views/vacancies/_job_details_section.html.haml
+++ b/app/views/vacancies/_job_details_section.html.haml
@@ -1,5 +1,5 @@
 %section#job-details.govuk-tabs__panel.no-border-override
-  %h3.govuk-heading-m
+  %h3.govuk-heading-l
     = t('jobs.job_details')
   %table.govuk-table{ ariadescribedby: "Job details" }
     %tbody.govuk-table__body

--- a/app/views/vacancies/_job_details_section.html.haml
+++ b/app/views/vacancies/_job_details_section.html.haml
@@ -50,6 +50,9 @@
     %h4.govuk-heading-s= t('jobs.applying_for_the_job')
     %p= @vacancy.how_to_apply
 
+  - if @vacancy.application_link.present?
+    = link_to t('jobs.apply'), new_job_interest_path(@vacancy.id), target: '_blank', class: 'govuk-button vacancy-apply-link mb1', 'aria-label': t('jobs.aria_labels.apply_link')
+
   - if @vacancy.documents.any?
     %h4.govuk-heading-s= t('jobs.supporting_documents')
     .supporting-docs

--- a/app/views/vacancies/_key_dates_sidebar.html.haml
+++ b/app/views/vacancies/_key_dates_sidebar.html.haml
@@ -3,7 +3,7 @@
     - unless @vacancy.expired?
       %h3.govuk-heading-s
         = SchoolVacancyPresenter.new(@vacancy).days_to_apply
-    %ul.key-dates-timeline
+    %ul.key-dates-timeline{ class: 'govuk-!-margin-bottom-0' }
       - if @vacancy.starts_on.present?
         %li.key-dates-timeline__item
           %h3.key-dates-timeline__title.govuk-heading-s
@@ -20,5 +20,3 @@
           = t('jobs.publish_on')
         %p.key-dates-timeline__by
           = format_date(@vacancy.publish_on)
-    - if @vacancy.application_link.present?
-      = link_to t('jobs.apply'), new_job_interest_path(@vacancy.id), target: '_blank', class: 'govuk-button vacancy-apply-link mb1', 'aria-label': t('jobs.aria_labels.apply_link')

--- a/app/views/vacancies/_school_overview_section.html.haml
+++ b/app/views/vacancies/_school_overview_section.html.haml
@@ -1,5 +1,5 @@
 %section#school-overview.govuk-tabs__panel.no-border-override
-  %h3.govuk-heading-m
+  %h3.govuk-heading-l
     = t('schools.school_overview')
   %table.govuk-table
     %tbody.govuk-table__body

--- a/app/views/vacancies/_school_overview_section.html.haml
+++ b/app/views/vacancies/_school_overview_section.html.haml
@@ -49,6 +49,11 @@
       = t('schools.info', school: @vacancy.school.name)
     %p= @vacancy.about_school
 
+  - if @vacancy.school_visits.present?
+    %h4.govuk-heading-s
+      = t('jobs.school_visits_heading', school: @vacancy.school.name)
+    %p= @vacancy.school_visits
+
   %h4.govuk-heading-s
     = t('schools.school_location')
   %p= @vacancy.school.full_address

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -41,8 +41,7 @@ en:
       blank: Enter a contact email
       invalid: Enter an email address in the correct format, like name@example.com
     application_link:
-      blank: Enter a link for jobseekers to apply
-      url: Enter an application link in the correct format, like http://www.school.ac.uk
+      url: Enter a link in the correct format, like http://www.school.ac.uk
   job_summary_errors: &job_summary_errors
     job_summary:
       blank: Enter a job summary

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,7 +110,7 @@ en:
         contact_email_html: "Contact email (<span class='text-red'>Required</span>)"
         school_visits: School visits
         how_to_apply: How to apply
-        application_link_html: "Link for jobseekers to learn more and apply (<span class='text-red'>Required</span>)"
+        application_link: Link to online application
       job_summary_form:
         job_summary_html: "Job summary (<span class='text-red'>Required</span>)"
         about_school_html: "About %{school} (<span class='text-red'>Required</span>)"
@@ -149,8 +149,7 @@ en:
         school_visits: Explain how a candidate can arrange a visit to the school (give a phone number if possible)
         how_to_apply: Explain how to apply for the job, referring to any relevant documents
         application_link: >-
-          Enter the URL for the page on your school trust's website that gives further details on the job
-          and how to apply
+          Leave this blank unless candidates can apply directly on the school or council website
       job_summary_form:
         job_summary: >-
           Give a brief summary of the job that job seekers can quickly scan.
@@ -336,9 +335,7 @@ en:
     submit: 'Publish now'
     submit_future: 'Confirm and submit job'
     apply: 'Get more information'
-    application_link: 'Link for jobseekers to learn more and apply'
-    no_application_link: 'No application link given'
-    application_link_url: 'Link for jobseekers to learn more and apply (link opens external website in a new window)'
+    application_link: Link to online application
     application_deadline_hour: 'Hour'
     application_deadline_min: 'Minute'
     application_deadline_meridiem: 'am or pm'
@@ -394,17 +391,12 @@ en:
       change_job_summary: 'Change job summary'
       apply_link: 'Learn more about this role and how to apply for it (link opens external website in a new window)'
       contact_email_link: 'Email link for job contact email — %{email}'
-      application_link_url: >-
-        Link for jobseekers to learn more and apply (link opens external website in a new window) — %{url}
       flexible_working: 'Flexible working'
       sort_by_link: Sort jobs by %{column} in %{order}ending order
     form_hints:
       deadline_date: 'For example, %{date}'
       publication_date: 'For example, %{date}'
       contact_email: 'This email address will be shown publicly as a point of contact'
-      application_link: >-
-        Enter the URL for the page on your school or trust’s website that gives further details on the job
-        and how to apply.
       application_deadline_time: 'For example, 9:00 am or 5:00 pm'
     form_warnings:
       working_pattern: >-
@@ -488,7 +480,7 @@ en:
     school_location: 'School location'
     phase: 'Education phase'
     type: 'School type'
-    website: 'Website'
+    website: 'School website'
     search_label: 'School name'
     description: 'Description'
     school_age: 'School age'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,7 +285,9 @@ en:
     contact_email_subject: '%{job} job enquiry'
     contact_email_body: 'Regarding the job at %{url}'
     school_visits: 'School visit instructions'
+    school_visits_heading: 'Arranging a visit to %{school}'
     how_to_apply: 'Application instructions'
+    applying_for_the_job: Applying for the job
     deadline_date: 'Date application is due'
     deadline_time_html: "Time application is due (<span class='text-red'>Required</span>)"
     time_at: ' at '

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -334,7 +334,7 @@ en:
       to the best of your knowledge, correct.
     submit: 'Publish now'
     submit_future: 'Confirm and submit job'
-    apply: 'Get more information'
+    apply: 'More on how to apply'
     application_link: Link to online application
     application_deadline_hour: 'Hour'
     application_deadline_min: 'Minute'

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -349,8 +349,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         click_on I18n.t('buttons.update_job')
 
         within_row_for(text: I18n.t('jobs.application_link')) do
-          expect(page).to have_content(
-            I18n.t('activemodel.errors.models.application_details_form.attributes.application_link.url'))
+          expect(page).to have_content(I18n.t('application_details_errors.application_link.url'))
         end
       end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -405,11 +405,6 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content(
             I18n.t('activemodel.errors.models.application_details_form.attributes.contact_email.blank'))
         end
-
-        within_row_for(text: strip_tags(I18n.t('helpers.fieldset.application_details_form.application_link_html'))) do
-          expect(page).to have_content(
-            I18n.t('activemodel.errors.models.application_details_form.attributes.application_link.blank'))
-        end
       end
 
       scenario 'redirects to the job summary page when submitted successfully' do
@@ -826,7 +821,7 @@ RSpec.feature 'Creating a vacancy' do
           fill_in 'application_details_form[application_link]', with: 'www invalid.domain.com'
           click_on I18n.t('buttons.update_job')
 
-          expect(page).to have_content('Enter an application link in the correct format, like http://www.school.ac.uk')
+          expect(page).to have_content(I18n.t('application_details_errors.application_link.url'))
 
           fill_in 'application_details_form[application_link]', with: 'www.valid-domain.com'
           click_on I18n.t('buttons.update_job')

--- a/spec/features/hiring_staff_can_save_and_return_later_spec.rb
+++ b/spec/features/hiring_staff_can_save_and_return_later_spec.rb
@@ -172,7 +172,7 @@ RSpec.feature 'Hiring staff can save and return later' do
 
         expect(page.current_path).to eql(school_job_application_details_path(created_vacancy.id))
 
-        fill_in 'application_details_form[contact_email]', with: 'email@test.com'
+        fill_in 'application_details_form[application_link]', with: 'some link'
         click_on I18n.t('buttons.save_and_return_later')
 
         expect(page.current_path).to eql(jobs_with_type_school_path('draft'))
@@ -181,7 +181,7 @@ RSpec.feature 'Hiring staff can save and return later' do
         click_on 'Edit'
 
         expect(page.current_path).to eql(school_job_application_details_path(created_vacancy.id))
-        expect(find_field('application_details_form[contact_email]').value).to eql('email@test.com')
+        expect(find_field('application_details_form[application_link]').value).to eql('some link')
       end
     end
 

--- a/spec/features/hiring_staff_can_view_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_view_vacancies_spec.rb
@@ -47,6 +47,6 @@ RSpec.feature 'School viewing vacancies' do
     vacancy = create(:vacancy, school: school, status: 'published')
     visit school_job_path(vacancy.id)
 
-    expect { click_on 'Get more information' }.to change { vacancy.get_more_info_counter.to_i }.by(0)
+    expect { click_on I18n.t('jobs.apply') }.to change { vacancy.get_more_info_counter.to_i }.by(0)
   end
 end

--- a/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Job seekers can apply for a vacancy' do
     vacancy = create(:vacancy, :published, application_link: 'www.google.com')
     visit job_path(vacancy)
 
-    click_on 'Get more information'
+    click_on I18n.t('jobs.apply')
 
     activity = vacancy.activities.last
     expect(activity.key).to eq('vacancy.get_more_information')
@@ -23,7 +23,7 @@ RSpec.feature 'Job seekers can apply for a vacancy' do
     vacancy = create(:vacancy, :published)
     visit job_path(vacancy)
 
-    expect { click_on 'Get more information' }.to change { vacancy.get_more_info_counter.to_i }.by(1)
+    expect { click_on I18n.t('jobs.apply') }.to change { vacancy.get_more_info_counter.to_i }.by(1)
   end
 
   scenario 'it triggers a job to write an express_interest_event to the audit table' do
@@ -43,7 +43,7 @@ RSpec.feature 'Job seekers can apply for a vacancy' do
       .with(express_interest_event)
 
     Timecop.freeze(timestamp) do
-      click_on 'Get more information'
+      click_on I18n.t('jobs.apply')
     end
   end
 end

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'Viewing a single published vacancy' do
       vacancy = create(:vacancy, :job_schema)
       visit job_path(vacancy)
 
-      click_on 'Get more information'
+      click_on I18n.t('jobs.apply')
 
       expect(page.current_url).to eq vacancy.application_link
     end

--- a/spec/form_models/application_details_form_spec.rb
+++ b/spec/form_models/application_details_form_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe ApplicationDetailsForm, type: :model do
 
   context 'validations' do
     it { should validate_presence_of(:contact_email).with_message('Enter a contact email') }
-    it { should validate_presence_of(:application_link).with_message('Enter a link for jobseekers to apply') }
 
     describe '#application_link' do
       let(:application_details) { ApplicationDetailsForm.new(application_link: 'not a url') }
@@ -13,7 +12,7 @@ RSpec.describe ApplicationDetailsForm, type: :model do
       it 'checks for a valid url' do
         expect(application_details.valid?).to be false
         expect(application_details.errors.messages[:application_link][0])
-          .to eq('Enter an application link in the correct format, like http://www.school.ac.uk')
+          .to eq(I18n.t('application_details_errors.application_link.url'))
       end
     end
 
@@ -23,7 +22,7 @@ RSpec.describe ApplicationDetailsForm, type: :model do
       it 'checks for a valid email format' do
         expect(application_details.valid?).to be false
         expect(application_details.errors.messages[:contact_email][0])
-          .to eq('Enter an email address in the correct format, like name@example.com')
+          .to eq(I18n.t('application_details_errors.contact_email.invalid'))
       end
     end
   end

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -93,6 +93,24 @@ RSpec.describe VacancyPresenter do
     end
   end
 
+  describe '#school_visits' do
+    it 'sanitizes and transforms school_visits into HTML' do
+      vacancy = build(:vacancy, school_visits: '<script> call();</script>Sanitized content')
+      presenter = VacancyPresenter.new(vacancy)
+
+      expect(presenter.school_visits).to eq('<p> call();Sanitized content</p>')
+    end
+  end
+
+  describe '#how_to_apply' do
+    it 'sanitizes and transforms school_visits into HTML' do
+      vacancy = build(:vacancy, how_to_apply: '<script> call();</script>Sanitized content')
+      presenter = VacancyPresenter.new(vacancy)
+
+      expect(presenter.how_to_apply).to eq('<p> call();Sanitized content</p>')
+    end
+  end
+
   describe '#working_patterns' do
     it 'returns nil if working_patterns is unset' do
       vacancy = VacancyPresenter.new(create(:vacancy,

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -118,7 +118,6 @@ module VacancyHelpers
   def verify_vacancy_show_page_details(vacancy)
     expect(page).to have_content(vacancy.job_title)
     expect(page).to have_content(vacancy.show_job_roles)
-    expect(page.html).to include(vacancy.job_summary)
     expect(page).to have_content(vacancy.show_subjects)
     expect(page).to have_content(vacancy.working_patterns)
 
@@ -128,6 +127,12 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.publish_on.to_s.strip)
     expect(page).to have_content(vacancy.expires_on.to_s.strip)
     expect(page).to have_content(vacancy.starts_on.to_s.strip) if vacancy.starts_on?
+
+    expect(page.html).to include(vacancy.school_visits)
+    expect(page.html).to include(vacancy.how_to_apply)
+
+    expect(page.html).to include(vacancy.job_summary)
+    expect(page.html).to include(vacancy.about_school)
 
     if vacancy.documents.any?
       expect(page).to have_content(I18n.t('jobs.supporting_documents'))


### PR DESCRIPTION
This PR completes the work on the Application details section changes. 

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-541

## Changes in this PR
- Update listings page to expose new school_visits and how_to_apply fields to jobseekers
- Update application link field name and make it optional
- Update review page
- Move and rename the 'Get more information' CTA

## Screenshots of UI changes
### Before
![image](https://user-images.githubusercontent.com/25187547/83898990-9ad31080-a74f-11ea-9c9c-57a3c4435b6a.png)

### After
![image](https://user-images.githubusercontent.com/25187547/83898926-8131c900-a74f-11ea-817e-b67c49c424f3.png)
