### PR TITLE
Add vacancies-stats to the search page

### DIFF
--- a/app/frontend/src/search/index.js
+++ b/app/frontend/src/search/index.js
@@ -4,7 +4,7 @@ import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import '../polyfill/classlist.polyfill';
 
-import { connectSearchBox, connectAutocomplete, connectHits, connectSortBy, connectMenu } from 'instantsearch.js/es/connectors';
+import { connectSearchBox, connectAutocomplete, connectHits, connectSortBy, connectMenu, connectStats } from 'instantsearch.js/es/connectors';
 import { hits, pagination, configure } from 'instantsearch.js/es/widgets';
 
 import { templates, renderContent } from './hits';
@@ -13,6 +13,7 @@ import { searchClient } from './client';
 import { renderSearchBox } from './ui/input';
 import { renderAutocomplete } from '../lib/autocomplete';
 import { renderSortSelect } from './ui/sort';
+import { renderStats } from './ui/stats';
 import { renderRadiusSelect, enableRadiusSelect, disableRadiusSelect } from './ui/radius';
 import { locations } from './data/locations';
 import { updateUrlQueryParams, stringMatchesPostcode, removeDataAttribute, setDataAttribute } from '../lib/utils';
@@ -29,6 +30,8 @@ if (document.querySelector('#vacancies-hits')) {
     const autocomplete = connectAutocomplete(renderAutocomplete);
     const heading = connectHits(renderContent);
     const sortBy = connectSortBy(renderSortSelect);
+    const statsBottom = connectStats(renderStats);
+    const statsTop = connectStats(renderStats);
     const locationRadius = connectMenu(renderRadiusSelect);
 
     const locationSearchBox = searchBox({
@@ -111,6 +114,12 @@ if (document.querySelector('#vacancies-hits')) {
         heading({
             container: document.querySelector('#job-count'),
             threshold: SEARCH_THRESHOLD,
+        }),
+        statsBottom({
+            container: document.querySelector('#vacancies-stats-bottom'),
+        }),
+        statsTop({
+            container: document.querySelector('#vacancies-stats-top'),
         }),
         hits({
             container: '#vacancies-hits',

--- a/app/frontend/src/search/ui/stats.js
+++ b/app/frontend/src/search/ui/stats.js
@@ -9,9 +9,11 @@ export const renderStats = (renderOptions, isFirstRender) => {
   let last = constructLastResultNumber(nbPages, page, nbHits, hitsPerPage);
   let first = constructFirstResultNumber(nbPages, page, hitsPerPage);
 
-  widgetParams.container.innerHTML = `
-    Showing <span class="govuk-!-font-weight-bold">${first}</span> to <span class="govuk-!-font-weight-bold">${last}</span> of <span class="govuk-!-font-weight-bold">${nbHits}</span> ${results}
-  `;
+  if (nbHits) {
+    widgetParams.container.innerHTML = `
+      Showing <span class="govuk-!-font-weight-bold">${first}</span> to <span class="govuk-!-font-weight-bold">${last}</span> of <span class="govuk-!-font-weight-bold">${nbHits}</span> ${results}
+    `;
+  }
 };
 
 export const constructResults = (results) => {

--- a/app/frontend/src/search/ui/stats.js
+++ b/app/frontend/src/search/ui/stats.js
@@ -13,6 +13,8 @@ export const renderStats = (renderOptions, isFirstRender) => {
     widgetParams.container.innerHTML = `
       Showing <span class="govuk-!-font-weight-bold">${first}</span> to <span class="govuk-!-font-weight-bold">${last}</span> of <span class="govuk-!-font-weight-bold">${nbHits}</span> ${results}
     `;
+  } else {
+    widgetParams.container.innerHTML = '';
   }
 };
 

--- a/app/frontend/src/search/ui/stats.js
+++ b/app/frontend/src/search/ui/stats.js
@@ -1,0 +1,35 @@
+export const renderStats = (renderOptions, isFirstRender) => {
+  const { nbHits, nbPages, page, hitsPerPage, widgetParams } = renderOptions;
+
+  if (isFirstRender) {
+    return;
+  }
+
+  let results = constructResults(nbHits);
+  let last = constructLastResultNumber(nbPages, page, nbHits, hitsPerPage);
+  let first = constructFirstResultNumber(nbPages, page, hitsPerPage);
+
+  widgetParams.container.innerHTML = `
+    Showing <span class="govuk-!-font-weight-bold">${first}</span> to <span class="govuk-!-font-weight-bold">${last}</span> of <span class="govuk-!-font-weight-bold">${nbHits}</span> ${results}
+  `;
+};
+
+export const constructResults = (results) => {
+  if (results === 1) {
+    return 'result';
+  } else {
+    return 'results';
+  }
+};
+
+export const constructLastResultNumber = (pages, page, results, resultsPerPage) => {
+  if (pages === 0) {
+    return 0;
+  } else if (page + 1 === pages) {
+    return results;
+  } else {
+    return (page + 1) * resultsPerPage;
+  }
+};
+
+export const constructFirstResultNumber = (pages, page, resultsPerPage) => pages === 0 ? 0 : page * resultsPerPage + 1;

--- a/app/frontend/src/search/ui/stats.test.js
+++ b/app/frontend/src/search/ui/stats.test.js
@@ -1,0 +1,41 @@
+import { renderStats, constructResults, constructLastResultNumber, constructFirstResultNumber } from './stats';
+
+describe('renderStats', () => {
+  test('returns a function', () => {
+    expect(typeof renderStats).toBe('function');
+  });
+});
+
+describe('constructResults', () => {
+  test('returns result if 1 result', () => {
+    expect(constructResults(1)).toBe('result');
+  });
+
+  test('returns results if more than 1 result', () => {
+    expect(constructResults(100)).toBe('results');
+  });
+});
+
+describe('constructLastResult', () => {
+  test('returns 0 if no pages', () => {
+    expect(constructLastResultNumber(0, 0, 0, 10)).toBe(0);
+  });
+
+  test('returns correct number of results if last page', () => {
+    expect(constructLastResultNumber(1, 0, 8, 10)).toBe(8);
+  });
+
+  test('returns correct number of results', () => {
+    expect(constructLastResultNumber(10, 1, 100, 10)).toBe(20);
+  });
+});
+
+describe('constructFirstResult', () => {
+  test('returns 0 if no pages', () => {
+    expect(constructFirstResultNumber(0, 0, 0)).toBe(0);
+  });
+
+  test('returns correct number of results', () => {
+    expect(constructFirstResultNumber(5, 2, 10)).toBe(21);
+  });
+});

--- a/app/frontend/styles/components/pagination.scss
+++ b/app/frontend/styles/components/pagination.scss
@@ -79,3 +79,27 @@ ul.pagination {
   }
 }
 
+#pagination-hits {
+  display: inline-block;
+  margin-left: 16rem;
+
+  @media (max-width: 1019px) {
+    display: block;
+    margin-left: 0;
+  }
+}
+
+.pagination-results {
+  #vacancies-stats-bottom {
+    display: block;
+    margin-bottom: 0;
+    margin-top: 1rem;
+    text-align: center;
+
+    @media (min-width: 1020px) {
+      float: right;
+      margin-top: 1.9rem;
+    }
+  }
+}
+

--- a/app/frontend/styles/components/pagination.scss
+++ b/app/frontend/styles/components/pagination.scss
@@ -94,7 +94,7 @@ ul.pagination {
     display: block;
     margin-bottom: 0;
     margin-top: 1rem;
-    text-align: center;
+    text-align: left;
 
     @media (min-width: 1020px) {
       float: right;

--- a/app/frontend/styles/components/sortable_links.scss
+++ b/app/frontend/styles/components/sortable_links.scss
@@ -44,4 +44,10 @@
       margin-top: 0.5rem;
     }
   }
+
+  #vacancies-stats-bottom {
+    @media (max-width: 1019px) {
+      text-align: left;
+    }
+  }
 }

--- a/app/frontend/styles/components/sortable_links.scss
+++ b/app/frontend/styles/components/sortable_links.scss
@@ -17,6 +17,7 @@
 .sortable-links {
   @extend .govuk-body-s;
   margin-bottom: $govuk-gutter;
+  width: auto;
 
   a {
     @extend .sortable-link;
@@ -25,6 +26,22 @@
     &.active {
       @include govuk-font(16, $weight: bold);
       text-decoration: none;
+    }
+  }
+
+  form {
+    display: inline-block;
+  }
+}
+
+.sort-results {
+  #vacancies-stats-top {
+    margin-bottom: 0;
+    margin-top: 1rem;
+
+    @media (min-width: 1020px) {
+      float: right;
+      margin-top: 0.5rem;
     }
   }
 }

--- a/app/services/vacancy_algolia_search_builder.rb
+++ b/app/services/vacancy_algolia_search_builder.rb
@@ -3,7 +3,7 @@ require 'geocoding'
 class VacancyAlgoliaSearchBuilder
   include ActiveModel::Model
 
-  attr_accessor :keyword, :location_category, :location, :radius, :sort_by, :page, :hits_per_page,
+  attr_accessor :keyword, :location_category, :location, :radius, :sort_by, :page, :hits_per_page, :stats,
                 :search_query, :location_filter, :search_replica, :search_filter,
                 :vacancies
 
@@ -35,6 +35,12 @@ class VacancyAlgoliaSearchBuilder
       hitsPerPage: hits_per_page,
       filters: search_filter,
       page: page
+    )
+    self.stats = build_stats(
+      vacancies.raw_answer['page'],
+      vacancies.raw_answer['nbPages'],
+      vacancies.raw_answer['hitsPerPage'],
+      vacancies.raw_answer['nbHits']
     )
   end
 
@@ -69,6 +75,17 @@ class VacancyAlgoliaSearchBuilder
 
   def convert_radius_in_miles_to_metres(radius)
     (radius * 1.60934 * 1000).to_i
+  end
+
+  def build_stats(page, pages, results_per_page, total_results)
+    return [0, 0, 0] unless total_results > 0
+    first_number = page * results_per_page + 1
+    if page + 1 === pages
+      last_number = total_results
+    else
+      last_number = (page + 1) * results_per_page
+    end
+    [first_number, last_number, total_results]
   end
 
   private

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -16,7 +16,7 @@
     .govuk-grid-column-full.vacancies-count
     .sort-results.sortable-links
       = render partial: 'sorting_options', locals: { search_criteria: @vacancies_search.only_active_to_hash, sort: @vacancies_search.sort_by }
-      %p.govuk-body#vacancies-stats-top{ 'aria-label': 'Number of results' }
+      %p.govuk-body#vacancies-stats-top{ 'aria-label': 'Number of results' }= t('jobs.number_of_results_html', first: @vacancies_search.stats[0], last: @vacancies_search.stats[1], count: @vacancies_search.stats[2])
     #vacancies-hits{ 'aria-label': 'Search results' }
       - if @vacancies.any?
         %ul.vacancies{ 'role': 'list' }

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -16,6 +16,7 @@
     .govuk-grid-column-full.vacancies-count
     .sort-results.sortable-links
       = render partial: 'sorting_options', locals: { search_criteria: @vacancies_search.only_active_to_hash, sort: @vacancies_search.sort_by }
+      %p.govuk-body#vacancies-stats-top{ 'aria-label': 'Number of results' }
     #vacancies-hits{ 'aria-label': 'Search results' }
       - if @vacancies.any?
         %ul.vacancies{ 'role': 'list' }
@@ -34,5 +35,7 @@
           - t('jobs.none_listed', count: Vacancy.listed.count).each do |sentence|
             %p= sentence
 
-= paginate @vacancies_search.vacancies
+.pagination-results
+  = paginate @vacancies_search.vacancies
+  %p.govuk-body#vacancies-stats-bottom{ 'aria-label': 'Number of results' }
 = javascript_pack_tag 'search'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,19 @@ en:
       Find teaching jobs in %{location} on Teaching Vacancies, the free national job site for teachers,
       with no recruitment fees for schools.
     location_search_heading: 'Teaching jobs in %{location}'
+    number_of_results_html:
+      zero:
+        ''
+      one: >-
+        Showing
+        <span class="govuk-!-font-weight-bold">%{first}</span> to
+        <span class="govuk-!-font-weight-bold">%{last}</span> of
+        <span class="govuk-!-font-weight-bold">%{count}</span> result
+      other: >-
+        Showing
+        <span class="govuk-!-font-weight-bold">%{first}</span> to
+        <span class="govuk-!-font-weight-bold">%{last}</span> of
+        <span class="govuk-!-font-weight-bold">%{count}</span> results
     sort_by:
       label: 'Sort by'
       most_relevant: 'most relevant first'

--- a/spec/services/vacancy_algolia_search_builder_spec.rb
+++ b/spec/services/vacancy_algolia_search_builder_spec.rb
@@ -146,6 +146,40 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
     end
   end
 
+  context '#build_stats' do
+    let(:params) { {} }
+    let(:page) { 0 }
+    let(:pages) { 6 }
+    let(:results_per_page) { 10 }
+    let(:total_results) { 57 }
+
+    it 'returns the correct array' do
+      expect(subject.build_stats(page, pages, results_per_page, total_results)).to eql(
+        [1, 10, total_results]
+      )
+    end
+
+    context 'there are no results' do
+      let(:total_results) { 0 }
+
+      it 'returns the correct array' do
+        expect(subject.build_stats(page, pages, results_per_page, total_results)).to eql(
+          [0, 0, total_results]
+        )
+      end
+    end
+
+    context 'the last page' do
+      let(:page) { 5 }
+
+      it 'returns the correct array' do
+        expect(subject.build_stats(page, pages, results_per_page, total_results)).to eql(
+          [51, total_results, total_results]
+        )
+      end
+    end
+  end
+
   context '#call' do
     @expired_now = Time.zone.now.to_datetime.to_i
     Timecop.freeze(@expired_now)
@@ -169,9 +203,11 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
       }
     end
 
+    let(:vacancies) { double('vacancies').as_null_object }
+
     before do
       allow_any_instance_of(VacancyAlgoliaSearchBuilder).to receive(:expired_now_filter).and_return(@expired_now)
-      mock_algolia_search('vacancies', algolia_search_query, algolia_search_args)
+      mock_algolia_search(vacancies, algolia_search_query, algolia_search_args)
     end
 
     context 'a location category search' do
@@ -182,7 +218,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
 
       it 'carries out search with correct parameters' do
         subject.call
-        expect(subject.vacancies).to eql('vacancies')
+        expect(subject.vacancies).to eql(vacancies)
       end
     end
 
@@ -193,7 +229,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
 
       it 'carries out search with correct criteria' do
         subject.call
-        expect(subject.vacancies).to eql('vacancies')
+        expect(subject.vacancies).to eql(vacancies)
       end
     end
   end


### PR DESCRIPTION
This PR adds a number of results indicator to the search page for client-side search.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-805
https://www.figma.com/file/KnFYJyTGiyshGDGr61uEvi/Sprint-53?node-id=14%3A147

## Changes in this PR:
- Add stats function and plug in to algolia widget
- Update stylesheets to match Figma

## Screenshots of UI changes:
### Before
![image](https://user-images.githubusercontent.com/25187547/84183213-6f1f9580-aa83-11ea-8ad5-07a07ad58d28.png)

### After
![image](https://user-images.githubusercontent.com/25187547/84183345-ad1cb980-aa83-11ea-844f-59e9ff1cc0a7.png)

