### PR TITLE
Custom Cloudfront caching for 404 end 500 errors

### DIFF
--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -22,6 +22,16 @@ resource "aws_cloudfront_distribution" "default" {
   }
 
   custom_error_response {
+    error_code            = "404"
+    error_caching_min_ttl = "10"
+  }
+
+  custom_error_response {
+    error_code            = "500"
+    error_caching_min_ttl = "60"
+  }
+
+  custom_error_response {
     error_code            = "503"
     error_caching_min_ttl = "60"
     response_code         = "503"


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-889

## Changes in this PR:
By default it is 5 min. This has created a small downtime on 9/06.
We reduce it to avoid waiting for longer than expected.

## How to test
- Query the app, it should return 200
- Stop the app
- It should return 404
- Start it and wait 10s
- It should return 200

- [x] Terraform deployment required?
