### PR TITLE
geocode only on submit of form, not when pattern detected onchange

### DIFF
--- a/app/frontend/src/search/index.js
+++ b/app/frontend/src/search/index.js
@@ -40,26 +40,23 @@ if (document.querySelector('#vacancies-hits')) {
             updateUrlQueryParams('location', document.querySelector('#location').value, window.location.href);
             search(query);
         },
-        onChange: (query) => {
-            return new Promise(resolve => {
-                if (stringMatchesPostcode(query) || (query.length && locations.indexOf(query.toLowerCase()) === -1)) {
-                    getGeolocatedCoordinates(query).then(coords => {
-                        if (coords.success) {
-                            enableRadiusSelect();
-                            setDataAttribute(document.querySelector('#location'), 'coordinates', `${coords.lat}, ${coords.lng}`);
-                            setDataAttribute(document.querySelector('#radius'), 'radius', document.querySelector('#radius').value || 10);
-                            resolve();
-                        }
-                    });
-                }
-                
-                disableRadiusSelect();
-                removeDataAttribute(document.querySelector('#location'), 'coordinates');
-                removeDataAttribute(document.querySelector('#radius'), 'radius');
-                resolve();
-            });
-        },
-        onSubmit: () => searchClientInstance.refresh()
+        onSubmit: (query) => {
+            if (shouldGeocode(query, locations)) {
+                getGeolocatedCoordinates(query).then(coords => {
+                    if (coords.success) {
+                        enableRadiusSelect();
+                        setDataAttribute(document.querySelector('#location'), 'coordinates', `${coords.lat}, ${coords.lng}`);
+                        setDataAttribute(document.querySelector('#radius'), 'radius', document.querySelector('#radius').value || 10);
+                        return searchClientInstance.refresh();
+                    }
+                });
+            }
+
+            disableRadiusSelect();
+            removeDataAttribute(document.querySelector('#location'), 'coordinates');
+            removeDataAttribute(document.querySelector('#radius'), 'radius');
+            searchClientInstance.refresh();
+        }
     });
 
     const keywordSearchBox = searchBox({
@@ -71,7 +68,6 @@ if (document.querySelector('#vacancies-hits')) {
             updateUrlQueryParams('keyword', document.querySelector('#keyword').value, window.location.href);
             search(query);
         },
-        onChange: () => new Promise(resolve => resolve()),
         onSubmit: () => searchClientInstance.refresh()
     });
 
@@ -139,4 +135,6 @@ if (document.querySelector('#vacancies-hits')) {
 
     searchClientInstance.start();
 }
+
+export const shouldGeocode = (query, locations) => stringMatchesPostcode(query) || (query.length && locations.indexOf(query.toLowerCase()) === -1);
 

--- a/app/frontend/src/search/ui/input.js
+++ b/app/frontend/src/search/ui/input.js
@@ -10,25 +10,17 @@ export const renderSearchBox = (renderOptions, isFirstRender) => {
             refine(getQuery());
         }
 
-        if (widgetParams.onChange) {
-            widgetParams.onChange(widgetParams.inputElement.value).then(() => refine());
-        }
-
         widgetParams.inputElement.addEventListener('input', () => {
-            if (widgetParams.onChange) {
-                widgetParams.onChange(widgetParams.inputElement.value).then(() => enableSubmitButton(widgetParams.container));
-            }
+            enableSubmitButton(widgetParams.container);
         });
 
         widgetParams.inputElement.addEventListener('change', () => {
-            if (widgetParams.onChange) {
-                widgetParams.onChange(widgetParams.inputElement.value).then(() => enableSubmitButton(widgetParams.container));
-            }
+            enableSubmitButton(widgetParams.container);
         });
 
         widgetParams.container.addEventListener('submit', (e) => {
             e.preventDefault();
-            widgetParams.onSubmit();
+            widgetParams.onSubmit(widgetParams.inputElement.value);
         });
     }
 };

--- a/app/frontend/src/search/ui/radius.js
+++ b/app/frontend/src/search/ui/radius.js
@@ -9,6 +9,8 @@ export const renderRadiusSelect = (renderOptions, isFirstRender) => {
         });
     }
 
+    disableRadiusSelect();
+
     query ? updateUrlQueryParams(widgetParams.key, query) : false;
 };
 


### PR DESCRIPTION
to mitigate unneccesary gelocation requests now that we dont have instant search functionality and we need to geocode any string that doesnt fall within the predefined list of locations, this changes behaviour to geocode only on submit of form, not when pattern detected onchange