### PR TITLE
Only disable radius input on first render

### DIFF
--- a/app/frontend/src/search/ui/radius.js
+++ b/app/frontend/src/search/ui/radius.js
@@ -7,9 +7,8 @@ export const renderRadiusSelect = (renderOptions, isFirstRender) => {
         widgetParams.inputElement.addEventListener('change', event => {
             widgetParams.onSelection(event.target.value);
         });
+        disableRadiusSelect();
     }
-
-    disableRadiusSelect();
 
     query ? updateUrlQueryParams(widgetParams.key, query) : false;
 };


### PR DESCRIPTION
This PR addresses the most severe of the radius select bugs. Radius will display when a geolocated search has been carried out.

## Changes in this PR:
- Fix logic bug that disabled the radius select input every time.
