### PR TITLE
Add correct margin to CTA link on listing page

### DIFF
--- a/app/views/vacancies/_job_details_section.html.haml
+++ b/app/views/vacancies/_job_details_section.html.haml
@@ -51,7 +51,7 @@
     %p= @vacancy.how_to_apply
 
   - if @vacancy.application_link.present?
-    = link_to t('jobs.apply'), new_job_interest_path(@vacancy.id), target: '_blank', class: 'govuk-button vacancy-apply-link mb1', 'aria-label': t('jobs.aria_labels.apply_link')
+    = link_to t('jobs.apply'), new_job_interest_path(@vacancy.id), target: '_blank', class: 'govuk-button vacancy-apply-link govuk-!-margin-bottom-5', 'aria-label': t('jobs.aria_labels.apply_link')
 
   - if @vacancy.documents.any?
     %h4.govuk-heading-s= t('jobs.supporting_documents')


### PR DESCRIPTION
This PR adds the correct margin class to the CTA on the listing page.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-876

## Changes in this PR:
- Add correct margin class to the link

## Screenshots of UI changes:
### Before
![image](https://user-images.githubusercontent.com/25187547/84477267-449e2a00-ac87-11ea-9f97-fa95162e9e1d.png)

### After
![image](https://user-images.githubusercontent.com/25187547/84477172-220c1100-ac87-11ea-8774-7d8578ff9b5d.png)

