### PR TITLE
Remove search pack tag and search imports

### DIFF
--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -5,7 +5,6 @@ import 'styles/application.scss';
 
 import Rails from 'rails-ujs';
 
-import 'src/locationAutocomplete';
 import 'src/addTitleToGoogleMapsIframe';
 import 'src/addVacancyStateToDataLayer';
 import 'src/deleteAccordionControl';
@@ -19,7 +18,6 @@ import 'src/googleOptimise';
 import 'src/googleTagManagerUrlSnippet';
 import 'src/removeCommaFromNumber';
 import 'src/shareUrl';
-import 'src/sortJobList';
 import 'src/subjectsFilter';
 import 'src/submitFeedback';
 import 'src/uploadDocuments';

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -37,4 +37,3 @@
 .pagination-results
   = paginate @vacancies_search.vacancies
   %p.govuk-body#vacancies-stats-bottom{ 'aria-label': 'Number of results' }
-= javascript_pack_tag 'search'


### PR DESCRIPTION
This PR disables the client search package while we bring testing under control and build confidence in the client search.

## Changes in this PR:
- Remove package tag from the index template
- Remove import of two client search files that existed outside of the main search package
