### PR TITLE
Remove Timecop and replace with Rails time helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,6 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rspec-rails'
-  gem 'timecop'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,7 +479,6 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
-    timecop (0.9.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uber (0.1.0)
@@ -589,7 +588,6 @@ DEPENDENCIES
   skylight
   spring
   spring-watcher-listen (~> 2.0.0)
-  timecop
   tzinfo-data
   validate_url (~> 1.0.8)
   web-console (>= 3.3.0)

--- a/spec/features/hiring_staff_session_timeout_spec.rb
+++ b/spec/features/hiring_staff_session_timeout_spec.rb
@@ -9,26 +9,26 @@ RSpec.feature 'Hiring staff session' do
   end
 
   after do
-    Timecop.return
+    travel_back
   end
 
   it 'expires after 8 hours and redirects to login page' do
     visit new_school_job_path
 
-    Timecop.travel(8.hours)
+    travel 9.hours do
+      click_on I18n.t('buttons.save_and_continue')
 
-    click_on I18n.t('buttons.save_and_continue')
-
-    expect(page.current_path).to eq new_identifications_path
+      expect(page.current_path).to eq new_identifications_path
+    end
   end
 
   it 'doesn\'t expire before 8 hours' do
     visit new_school_job_path
 
-    Timecop.travel(1.hour)
+    travel 1.hour do
+      click_on I18n.t('buttons.save_and_continue')
 
-    click_on I18n.t('buttons.save_and_continue')
-
-    expect(page.current_path).to eq job_specification_school_job_path
+      expect(page.current_path).to eq job_specification_school_job_path
+    end
   end
 end

--- a/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
@@ -30,19 +30,19 @@ RSpec.feature 'Job seekers can apply for a vacancy' do
     vacancy = create(:vacancy, :published)
     visit job_path(vacancy)
 
-    timestamp = Time.zone.now.iso8601
+    freeze_time do
+      timestamp = Time.zone.now.iso8601
 
-    express_interest_event = {
-      datestamp: timestamp.to_s,
-      vacancy_id: vacancy.id,
-      school_urn: vacancy.school.urn,
-      application_link: vacancy.application_link
-    }
+      express_interest_event = {
+        datestamp: timestamp.to_s,
+        vacancy_id: vacancy.id,
+        school_urn: vacancy.school.urn,
+        application_link: vacancy.application_link
+      }
 
-    expect(AuditExpressInterestEventJob).to receive(:perform_later)
-      .with(express_interest_event)
+      expect(AuditExpressInterestEventJob).to receive(:perform_later)
+        .with(express_interest_event)
 
-    Timecop.freeze(timestamp) do
       click_on I18n.t('jobs.apply')
     end
   end

--- a/spec/features/job_seekers_can_manage_their_subscription.rb
+++ b/spec/features/job_seekers_can_manage_their_subscription.rb
@@ -14,14 +14,12 @@ RSpec.feature 'A job seeker can manage their subscription' do
   end
 
   context 'with an old token' do
-    let(:token) do
-      Timecop.travel(-7.days) { subscription.token }
-    end
-
     scenario 'cannot see subscription details' do
-      visit subscription_path(token)
+      travel 7.days do
+        visit subscription_path(token)
 
-      expect(page).to have_text('Manage your subscription')
+        expect(page).to have_text('Manage your subscription')
+      end
     end
   end
 end

--- a/spec/features/job_seekers_can_unsubscribe_from_subscriptions_spec.rb
+++ b/spec/features/job_seekers_can_unsubscribe_from_subscriptions_spec.rb
@@ -92,12 +92,12 @@ RSpec.feature 'A job seeker can unsubscribe from subscriptions' do
   end
 
   context 'with an old token' do
-    let(:token) do
-      Timecop.travel(-3.days) { subscription.token }
-    end
+    let(:token) { subscription.token }
 
     scenario 'still returns 200' do
-      expect(page.status_code).to eq(200)
+      travel 3.days do
+        expect(page.status_code).to eq(200)
+      end
     end
   end
 end

--- a/spec/jobs/send_expired_vacancy_feedback_email_prompts_job_spec.rb
+++ b/spec/jobs/send_expired_vacancy_feedback_email_prompts_job_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe SendExpiredVacancyFeedbackEmailJob, type: :job do
   end
 
   def send_expired_vacancy_feedback_emails(after = 2.weeks)
-    Timecop.travel(Time.zone.now + after) do
+    travel after do
       perform_enqueued_jobs { job }
     end
   end

--- a/spec/lib/dfe_sign_in_api_spec.rb
+++ b/spec/lib/dfe_sign_in_api_spec.rb
@@ -47,7 +47,7 @@ RSpec.shared_examples 'a DFE Sign In endpoint' do
     end
 
     it 'sets a token in the header of the request' do
-      Timecop.freeze(Time.zone.now) do
+      freeze_time do
         expected_token = generate_jwt_token
 
         stub_api_response_for_page(1)

--- a/spec/lib/performance_platform_sender_spec.rb
+++ b/spec/lib/performance_platform_sender_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe PerformancePlatformSender::Base do
     subject { described_class.by_type(type).call(date: date_to_upload) }
 
     it 'will submit transaction data' do
-      Timecop.freeze(runtime) do
+      freeze_time do
         stub_const('PP_TRANSACTIONS_BY_CHANNEL_TOKEN', 'not-nil')
 
         two_days_ago = Date.current.beginning_of_day.in_time_zone - 2.days

--- a/spec/mailers/subscription_spec.rb
+++ b/spec/mailers/subscription_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe SubscriptionMailer, type: :mailer do
 
   before(:each) do
     stub_const('NOTIFY_SUBSCRIPTION_CONFIRMATION_TEMPLATE', '')
-    Timecop.travel('2019-01-01')
+    travel_to Time.zone.local(2019, 01, 01, 01, 01, 01)
   end
 
-  after(:each) { Timecop.return }
+  after(:each) { travel_back }
 
   let(:email) { 'an@email.com' }
   let(:subscription) do

--- a/spec/models/general_feedback_spec.rb
+++ b/spec/models/general_feedback_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe GeneralFeedback, type: :model do
     let(:email) { 'hello@research.com' }
 
     let(:feedback) do
-      Timecop.freeze(created_at) do
+      travel_to created_at do
         create(:general_feedback, visit_purpose: visit_purpose,
                                   visit_purpose_comment: visit_purpose_comment,
                                   comment: comment,

--- a/spec/models/vacancy_publish_feedback_spec.rb
+++ b/spec/models/vacancy_publish_feedback_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe VacancyPublishFeedback, type: :model do
     let(:email) { 'user@email.com' }
 
     let(:feedback) do
-      Timecop.freeze(created_at) do
+      travel_to created_at do
         create(:vacancy_publish_feedback, user: user, vacancy: vacancy, rating: rating, comment: comment,
                                           user_participation_response: user_participation_response, email: email)
       end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -501,7 +501,7 @@ RSpec.describe Vacancy, type: :model do
     it { expect(stats_updated_at).to be_nil }
 
     it 'saves the time that the stats updated at' do
-      Timecop.freeze(2019, 1, 1, 10, 4, 3) do
+      travel_to(Time.zone.local('2019, 1, 1, 10, 4, 3')) do
         expired_job.update(listed_elsewhere: :listed_paid, hired_status: :hired_tvs)
 
         expect(stats_updated_at).to eq(Time.current)
@@ -509,7 +509,7 @@ RSpec.describe Vacancy, type: :model do
     end
 
     it 'does not update the stats when you are updating the job summary' do
-      Timecop.freeze(2019, 1, 1, 10, 4, 3) do
+      travel_to(Time.zone.local('2019, 1, 1, 10, 4, 3')) do
         expired_job.update(job_summary: 'I am description')
 
         expect(stats_updated_at).to be_nil

--- a/spec/services/authorisation_spec.rb
+++ b/spec/services/authorisation_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe Authorisation do
 
     before(:each) do
       stub_authorisation_step
-      Timecop.travel(stubbed_time)
+      travel_to stubbed_time
     end
 
     after(:each) do
-      Timecop.return
+      travel_back
     end
 
     it 'stores the role_ids' do

--- a/spec/services/copy_vacancy_spec.rb
+++ b/spec/services/copy_vacancy_spec.rb
@@ -25,16 +25,14 @@ RSpec.describe CopyVacancy do
     it 'does not change the original vacancy' do
       # Needed to compare a FactoryBot object fields for updated_at and created_at
       # and against the record it creates in Postgres.
-      Timecop.freeze(Time.zone.local(2008, 9, 1, 12, 0, 0))
+      travel_to(Time.zone.local(2008, 9, 1, 12, 0, 0)) do
+        vacancy = create(:vacancy, job_title: 'Maths teacher')
 
-      vacancy = create(:vacancy, job_title: 'Maths teacher')
+        described_class.new(vacancy).call
 
-      described_class.new(vacancy).call
-
-      expect(Vacancy.find(vacancy.id).attributes == vacancy.attributes)
-        .to eq(true)
-
-      Timecop.return
+        expect(Vacancy.find(vacancy.id).attributes == vacancy.attributes)
+          .to eq(true)
+      end
     end
 
     context '#documents' do
@@ -125,7 +123,7 @@ RSpec.describe CopyVacancy do
       end
 
       it 'should not copy the weekly page views update time of a vacancy' do
-        Timecop.freeze(Time.zone.today - 5.days) do
+        travel_to(Time.zone.today - 5.days) do
           expect(Vacancy.find(result.id).weekly_pageviews_updated_at).to eq(Time.zone.now)
         end
       end
@@ -135,7 +133,7 @@ RSpec.describe CopyVacancy do
       end
 
       it 'should not copy the weekly page views update time of a vacancy' do
-        Timecop.freeze(Time.zone.today - 5.days) do
+        travel_to(Time.zone.today - 5.days) do
           expect(Vacancy.find(result.id).total_pageviews_updated_at).to eq(Time.zone.now)
         end
       end
@@ -145,7 +143,7 @@ RSpec.describe CopyVacancy do
       end
 
       it 'should not copy the weekly page views update time of a vacancy' do
-        Timecop.freeze(Time.zone.today - 5.days) do
+        travel_to(Time.zone.today - 5.days) do
           expect(Vacancy.find(result.id).total_get_more_info_clicks_updated_at).to eq(Time.zone.now)
         end
       end

--- a/spec/services/vacancy_algolia_search_builder_spec.rb
+++ b/spec/services/vacancy_algolia_search_builder_spec.rb
@@ -181,16 +181,14 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
   end
 
   context '#call' do
-    @expired_now = Time.zone.now.to_datetime.to_i
-    Timecop.freeze(@expired_now)
-
+    let!(:expired_now) { Time.zone.now }
     let(:sort_by) { '' }
     let(:search_replica) { nil }
     let(:default_hits_per_page) { 10 }
     let(:search_filter) do
       'listing_status:published AND '\
       "publication_date_timestamp <= #{Time.zone.today.to_datetime.to_i} AND "\
-      "expires_at_timestamp > #{@expired_now}"
+      "expires_at_timestamp > #{expired_now.to_datetime.to_i}"
     end
     let(:page) { 1 }
 
@@ -206,9 +204,14 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
     let(:vacancies) { double('vacancies').as_null_object }
 
     before do
-      allow_any_instance_of(VacancyAlgoliaSearchBuilder).to receive(:expired_now_filter).and_return(@expired_now)
+      travel_to(expired_now)
+      allow_any_instance_of(VacancyAlgoliaSearchBuilder)
+        .to receive(:expired_now_filter)
+        .and_return(expired_now.to_datetime.to_i)
       mock_algolia_search(vacancies, algolia_search_query, algolia_search_args)
     end
+
+    after { travel_back }
 
     context 'a location category search' do
       let(:location) { 'London' }

--- a/spec/support/shared_examples/counter.rb
+++ b/spec/support/shared_examples/counter.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples Counter do
     end
 
     it 'saves the time the total clicks were updated' do
-      Timecop.freeze do
+      freeze_time do
         counter.persist!
 
         expect(model.send("#{described_class.persisted_column}_updated_at")).to eq(Time.zone.now)

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
Came across the fact that Timecop's functionality has now been brought in-house by Rails. My branch touched it and it wasn't too large of a change so I did it as part of my ticket. Separate PR because why not.

## Changes in this PR:

- Remove unnecessary dependency