### PR TITLE
Increase production worker memory limit to 1.5G

### DIFF
--- a/paas/worker/manifest-production.yml
+++ b/paas/worker/manifest-production.yml
@@ -8,7 +8,7 @@ applications:
     command: bundle exec sidekiq -C config/sidekiq.yml
     health-check-type: process
     instances: 2
-    memory: 1G
+    memory: 1.5G
     no-route: true
     services:
       - teaching-vacancies-postgres-production


### PR DESCRIPTION
We had a failure 15th of June at 3AM so we just increased the memory limit for now. 

With Grafana we will be able to have more information to debug the problem.