### PR TITLE
Bring preview message in line with Figma

### DIFF
--- a/app/views/hiring_staff/vacancies/_preview_banner.html.haml
+++ b/app/views/hiring_staff/vacancies/_preview_banner.html.haml
@@ -1,5 +1,5 @@
 .govuk-info-summary#preview{ 'aria-labelledby': 'info-summary-title', 'role': 'alert', 'tab-index': -1 }
-  %h2.govuk-info-summary__title#info-summary-title= t('jobs.preview_listing.summary.heading', title: @vacancy.job_title)
+  %h2.govuk-info-summary__title#info-summary-title= t('jobs.preview_listing.summary.heading_html', title: @vacancy.job_title)
   .govuk-info-summary__body
     %p= t('jobs.preview_listing.summary.body_html', count: @vacancy.publish_on.today? ? 0 : 1, date: @vacancy.publish_on.to_s.strip)
     = link_to t('jobs.preview_listing.summary.buttons.submit'), school_job_publish_path(@vacancy.id), method: :post, class: 'govuk-button mb0 submit-listing-with-preview-gtm'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -327,7 +327,7 @@ en:
       button: 'Preview job listing'
       page_title: 'Preview job listing for %{school}'
       summary:
-        heading: 'Preview of %{title}'
+        heading_html: 'Preview of &#8216;%{title}&#8217; job listing'
         body_html:
           zero: >-
             This is how your job listing will appear to jobseekers visiting Teaching Vacancies.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -327,7 +327,7 @@ en:
       button: 'Preview job listing'
       page_title: 'Preview job listing for %{school}'
       summary:
-        heading_html: 'Preview of &#8216;%{title}&#8217; job listing'
+        heading_html: 'Preview of &#8216;%{title}&#8217;'
         body_html:
           zero: >-
             This is how your job listing will appear to jobseekers visiting Teaching Vacancies.

--- a/lib/update_dsi_users_in_db.rb
+++ b/lib/update_dsi_users_in_db.rb
@@ -12,6 +12,11 @@ class UpdateDfeSignInUsers
   def convert_to_users(dsi_users)
     dsi_users.each do |dsi_user|
       User.transaction do
+        # TODO: I think the below find_or_initialize by is resulting in multiple user
+        # records for the same user.
+        # e.g. on staging: User.where(email: "sbm@acornswhitleyfed.cheshire.sch.uk").size => 2
+        # These 2 records have different oids.
+        # I propose that we
         user = User.find_or_initialize_by(oid: dsi_user['userId'])
         user.email = dsi_user['email']
         # When a user is associated with multiple organisations,

--- a/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
@@ -23,7 +23,9 @@ RSpec.feature 'Hiring staff can preview a vacancy' do
     scenario 'users can preview the listing' do
       click_on I18n.t('jobs.preview_listing.button')
       expect(page).to have_current_path(school_job_preview_path(vacancy.id))
-      expect(page).to have_content(I18n.t('jobs.preview_listing.summary.heading', title: vacancy.job_title))
+      within('.govuk-info-summary__title') do
+        expect(page).to have_content(vacancy.job_title)
+      end
     end
 
     scenario 'users can submit the listing' do


### PR DESCRIPTION
I spotted a difference between production and the Figma for sprint 50, which was a 5-minute job so I just did it.

## Figma

See 1.8. https://www.figma.com/file/n2wLtKVQ2imMbjdPSHBRKW/Sprint-50?node-id=0%3A1

## Changes in this PR:

## Screenshots of UI changes:

### Before

<img width="773" alt="Screenshot 2020-06-15 at 17 48 02" src="https://user-images.githubusercontent.com/60350599/84685121-a08bdb80-af31-11ea-8ca0-5c8c859644b4.png">

### After

<img width="773" alt="Screenshot 2020-06-15 at 18 36 57" src="https://user-images.githubusercontent.com/60350599/84688469-4beb5f00-af37-11ea-8f15-9f777b1546d8.png">

## Next steps:

- [x] UX sign-off
