### PR TITLE
Display notification when user 'saves' a draft job from the review page

### DIFF
--- a/app/controllers/hiring_staff/schools_controller.rb
+++ b/app/controllers/hiring_staff/schools_controller.rb
@@ -6,6 +6,8 @@ class HiringStaff::SchoolsController < HiringStaff::BaseController
     @vacancy_presenter = SchoolVacanciesPresenter.new(@school, @sort, params[:type])
     @awaiting_feedback_count = @school.vacancies.awaiting_feedback.count
 
+    render_draft_saved_message if params[:from_review]
+
     flash.now[:notice] = I18n.t('messages.jobs.feedback.awaiting', count: @awaiting_feedback_count) if
       @awaiting_feedback_count.positive?
   end
@@ -44,5 +46,10 @@ class HiringStaff::SchoolsController < HiringStaff::BaseController
 
   def sort_order
     params[:type] == 'draft' ? (params[:sort_order] || 'desc') : params[:sort_order]
+  end
+
+  def render_draft_saved_message
+    vacancy = current_school.vacancies.find(params[:from_review])
+    flash.now[:success] = I18n.t('messages.jobs.draft_saved_html', job_title: vacancy&.job_title)
   end
 end

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -30,7 +30,7 @@
     = link_to t('jobs.submit_listing.button'), school_job_publish_path(@vacancy.id), method: :post, class: 'govuk-button govuk-button--secondary submit-listing-without-preview-gtm', id: 'vacancy-review-submit'
 
     %br
-    = render 'hiring_staff/vacancies/back_to_manage_jobs'
+    = link_to t('buttons.back_to_manage_jobs'), jobs_with_type_school_path('draft', from_review: @vacancy.id), class: 'govuk-link govuk-link--no-visited-state'
 
   .govuk-grid-column-one-third
     - if %w(create review).include?(@vacancy.state)

--- a/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature 'Hiring staff can preview a vacancy' do
 
     scenario 'users can navigate back to manage jobs page' do
       click_on I18n.t('buttons.back_to_manage_jobs')
-      expect(page).to have_current_path(jobs_with_type_school_path('draft'))
+      expect(page).to have_current_path(jobs_with_type_school_path('draft', from_review: vacancy.id))
       expect(page).to have_content(I18n.t('schools.jobs.index', school: school.name))
       expect(page).to have_content(I18n.t('buttons.create_job'))
     end


### PR DESCRIPTION
This PR adds an endpoint that redirects the user to the appropriate tab on the schools page, with a success notification.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-865

## Changes in this PR
- Add endpoint and update link on review page
