### PR TITLE
Switch off noisy CORS logging

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,5 +1,7 @@
-# Configure Rack::Cors https://github.com/cyu/rack-cors
-Rails.application.config.middleware.insert_before 0, Rack::Cors, debug: true, logger: (-> { Rails.logger }) do
+# https://github.com/cyu/rack-cors
+# rubocop:disable Metrics/LineLength
+Rails.application.config.middleware.insert_before 0, Rack::Cors, debug: Rails.env.test?, logger: (-> { Rails.logger }) do
+  # rubocop:enable Metrics/LineLength
   allow do
     # Allow all domains access to jobs API
     origins '*'


### PR DESCRIPTION
We received an email from Papertrail that we'd exceeded log limits 21 days in advance of the next billing period. CORS logging is not used and easily switch-back-on-able.

<img width="926" alt="Screenshot 2020-06-16 at 11 28 26" src="https://user-images.githubusercontent.com/60350599/84763754-99fa7400-afc4-11ea-9572-bc74ffdae0a6.png">
