### PR TITLE
use correct teacher vacancies algolia read key

### DIFF
--- a/app/frontend/src/search/client.js
+++ b/app/frontend/src/search/client.js
@@ -6,7 +6,7 @@ import { getFilters, getQuery } from './query';
 
 // This is the public API key which can be safely used in your frontend code.
 // This key is usable for search queries and list the indices you've got access to.
-export const search = algoliasearch('QM2YE0HRBW', '20b88d28047d5e3d60437993ad3d9c50');
+export const search = algoliasearch('QM2YE0HRBW', '4082ba44346a92023eac1f794d739dd1');
 
 export const searchClient = indexName => instantsearch({
     indexName: indexName,


### PR DESCRIPTION
front end was using a read API key set up under a personal email, this changes it to be the teacher vacancies read key. the former will then be deleted entirely from algolia dashboard