### PR TITLE
Update identifications form to use GOVUKDesignSystemFormBuilder

### DIFF
--- a/app/views/hiring_staff/identifications/_signin.html.haml
+++ b/app/views/hiring_staff/identifications/_signin.html.haml
@@ -1,0 +1,3 @@
+- home = false if local_assigns[:home].nil?
+= form_for :identifications, url: identifications_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+  = f.govuk_submit t('sign_in.link'), classes: home ? 'identifications-button' : ''

--- a/app/views/hiring_staff/identifications/new.html.haml
+++ b/app/views/hiring_staff/identifications/new.html.haml
@@ -14,8 +14,7 @@
 
     %p= t('pages.home.signin.description')
 
-    = simple_form_for :identifications, url: identifications_path, method: :post do |f|
-      = f.submit t('sign_in.link'), class: 'govuk-button'
+    = render 'hiring_staff/identifications/signin'
 
     %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 

--- a/app/views/pages/home/_signin.html.haml
+++ b/app/views/pages/home/_signin.html.haml
@@ -10,7 +10,7 @@
   - if ENV['FEATURE_SIGN_IN_ALERT'].to_s == 'true'
     = link_to t('sign_in.link'), new_identifications_path, class: 'govuk-button identifications-button'
   - else
-    = simple_form_for :identifications, url: identifications_path, defaults: { input_html: { class: 'text' } }, method: :post do |f|
-      = f.submit t('sign_in.link'), class: 'govuk-button identifications-button'
+    = render 'hiring_staff/identifications/signin', home: true
+
   %p= t('.signin_guidance_html', link: link_to(t('.signin_link'), new_identifications_path))
 


### PR DESCRIPTION
This PR is part of ongoing work to implement GOVUKDesignSystemFormBuilder throughout the application.

## Changes in this PR:
- Update the identifications form to use GOVUKDesignSystemFormBuilder