### PR TITLE
GOVUKDesignSystemFormBuilder config

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,8 @@ class ApplicationController < ActionController::Base
   include AuthenticationConcerns
   include Ip
 
+  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+
   def check
     render json: { status: 'OK' }, status: :ok
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,8 +13,6 @@ class ApplicationController < ActionController::Base
   include AuthenticationConcerns
   include Ip
 
-  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
-
   def check
     render json: { status: 'OK' }, status: :ok
   end

--- a/app/views/general_feedback/new.html.haml
+++ b/app/views/general_feedback/new.html.haml
@@ -3,7 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @feedback, url: feedback_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h2.govuk-heading-l
         = t('feedback.heading')

--- a/app/views/general_feedback/new.html.haml
+++ b/app/views/general_feedback/new.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @feedback, url: feedback_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @feedback, url: feedback_path do |f|
       = f.govuk_error_summary
 
       %h2.govuk-heading-l

--- a/app/views/hiring_staff/identifications/_signin.html.haml
+++ b/app/views/hiring_staff/identifications/_signin.html.haml
@@ -1,3 +1,3 @@
 - home = false if local_assigns[:home].nil?
-= form_for :identifications, url: identifications_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+= form_for :identifications, url: identifications_path do |f|
   = f.govuk_submit t('sign_in.link'), classes: home ? 'identifications-button' : ''

--- a/app/views/hiring_staff/terms_and_conditions/show.html.haml
+++ b/app/views/hiring_staff/terms_and_conditions/show.html.haml
@@ -3,7 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @terms_and_conditions_form, url: terms_and_conditions_path, html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h1.govuk-heading-xl= t('terms_and_conditions.page_title')
       %p= t('terms_and_conditions.intro')

--- a/app/views/hiring_staff/terms_and_conditions/show.html.haml
+++ b/app/views/hiring_staff/terms_and_conditions/show.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @terms_and_conditions_form, url: terms_and_conditions_path, html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @terms_and_conditions_form, url: terms_and_conditions_path, html: { method: "patch" } do |f|
       = f.govuk_error_summary
 
       %h1.govuk-heading-xl= t('terms_and_conditions.page_title')

--- a/app/views/hiring_staff/vacancies/application_details/show.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/show.html.haml
@@ -9,7 +9,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @application_details_form, url: school_job_application_details_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h2.govuk-heading-l
         = t('jobs.application_details')

--- a/app/views/hiring_staff/vacancies/application_details/show.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/show.html.haml
@@ -8,7 +8,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @application_details_form, url: school_job_application_details_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @application_details_form, url: school_job_application_details_path(@vacancy.id), html: { method: "patch" } do |f|
       = f.govuk_error_summary
 
       %h2.govuk-heading-l

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -7,7 +7,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @copy_form, url: school_job_copy_path, data: { vacancy_state: 'copy' }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h2.govuk-heading-l
         = t('jobs.new_job_listing_details')
@@ -29,7 +29,7 @@
           job_role_options,
           :itself,
           :itself,
-          legend: { text: t('helpers.fieldset.job_specification_form.job_roles_html'), size: 's' },
+          legend: { text: t('helpers.fieldset.job_specification_form.job_roles_html') },
           hint_text: t('helpers.hint.job_specification_form.job_roles')
 
       - unless @vacancy.about_school.present?
@@ -41,19 +41,19 @@
           required: true
 
       = f.govuk_date_field :publish_on,
-        legend: { text: t('helpers.fieldset.important_dates_form.publish_on_html'), size: 's' },
+        legend: { text: t('helpers.fieldset.important_dates_form.publish_on_html') },
         hint_text: t('helpers.hint.important_dates_form.publish_on')
 
       = f.govuk_date_field :expires_on,
-        legend: { text: t('helpers.fieldset.important_dates_form.expires_on_html'), size: 's' },
+        legend: { text: t('helpers.fieldset.important_dates_form.expires_on_html') },
         hint_text: t('helpers.hint.important_dates_form.expires_on')
 
       = render 'hiring_staff/vacancies/expiry_time_field', f: f
 
       = f.govuk_date_field :starts_on,
-        legend: { text: t('helpers.fieldset.important_dates_form.starts_on'), size: 's' },
+        legend: { text: t('helpers.fieldset.important_dates_form.starts_on') },
         hint_text: t('helpers.hint.important_dates_form.starts_on')
 
-      = f.govuk_submit t('buttons.save_and_continue'), classes: 'govuk-!-margin-bottom-5'
+      = f.govuk_submit classes: 'govuk-!-margin-bottom-5'
 
     = link_to t('buttons.cancel_copy'), school_path, class: 'govuk-link govuk-link--no-visited-state govuk-!-font-size-19'

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -6,7 +6,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @copy_form, url: school_job_copy_path, data: { vacancy_state: 'copy' }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @copy_form, url: school_job_copy_path, data: { vacancy_state: 'copy' } do |f|
       = f.govuk_error_summary
 
       %h2.govuk-heading-l

--- a/app/views/hiring_staff/vacancies/documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/documents/show.html.haml
@@ -8,7 +8,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @documents_form, url: school_job_documents_path(@vacancy.id), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @documents_form, url: school_job_documents_path(@vacancy.id) do |f|
       = f.govuk_error_summary
 
       %h2.govuk-heading-l

--- a/app/views/hiring_staff/vacancies/documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/documents/show.html.haml
@@ -9,7 +9,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @documents_form, url: school_job_documents_path(@vacancy.id), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h2.govuk-heading-l
         = t('jobs.supporting_documents')

--- a/app/views/hiring_staff/vacancies/important_dates/show.html.haml
+++ b/app/views/hiring_staff/vacancies/important_dates/show.html.haml
@@ -8,7 +8,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @important_dates_form, url: school_job_important_dates_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @important_dates_form, url: school_job_important_dates_path(@vacancy.id), html: { method: "patch" } do |f|
       = f.govuk_error_summary
 
       %h2.govuk-heading-l

--- a/app/views/hiring_staff/vacancies/important_dates/show.html.haml
+++ b/app/views/hiring_staff/vacancies/important_dates/show.html.haml
@@ -9,7 +9,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @important_dates_form, url: school_job_important_dates_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h2.govuk-heading-l
         = t('jobs.important_dates')
@@ -26,17 +26,17 @@
           = f.govuk_date_field :publish_on
       - else
         = f.govuk_date_field :publish_on,
-          legend: { text: t('helpers.fieldset.important_dates_form.publish_on_html'), size: 's' },
+          legend: { text: t('helpers.fieldset.important_dates_form.publish_on_html') },
           hint_text: t('helpers.hint.important_dates_form.publish_on')
 
       = f.govuk_date_field :expires_on,
-        legend: { text: t('helpers.fieldset.important_dates_form.expires_on_html'), size: 's' },
+        legend: { text: t('helpers.fieldset.important_dates_form.expires_on_html') },
         hint_text: t('helpers.hint.important_dates_form.expires_on')
 
       = render 'hiring_staff/vacancies/expiry_time_field', f: f
 
       = f.govuk_date_field :starts_on,
-        legend: { text: t('helpers.fieldset.important_dates_form.starts_on'), size: 's' },
+        legend: { text: t('helpers.fieldset.important_dates_form.starts_on') },
         hint_text: t('helpers.hint.important_dates_form.starts_on')
 
       = render 'hiring_staff/vacancies/vacancy_form_partials/submit', f: f

--- a/app/views/hiring_staff/vacancies/job_specification/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/show.html.haml
@@ -11,7 +11,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @job_specification_form, url: @job_specification_url, html: { method: @job_specification_url_method }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h2.govuk-heading-l
         = t('jobs.job_details')
@@ -32,10 +32,10 @@
         job_role_options,
         :itself,
         :itself,
-        legend: { text: t('helpers.fieldset.job_specification_form.job_roles_html'), size: 's' },
+        legend: { text: t('helpers.fieldset.job_specification_form.job_roles_html') },
         hint_text: t('helpers.hint.job_specification_form.job_roles')
 
-      = f.govuk_fieldset legend: { text: t('helpers.fieldset.job_specification_form.subjects'), size: 's' } do
+      = f.govuk_fieldset legend: { text: t('helpers.fieldset.job_specification_form.subjects') } do
 
         %label{ for: 'job-specification-form-subject-search' }
           %span.govuk-visually-hidden
@@ -57,7 +57,7 @@
         working_pattern_options,
         :last,
         :first,
-        legend: { text: t('helpers.fieldset.job_specification_form.working_pattern_html'), size: 's' },
+        legend: { text: t('helpers.fieldset.job_specification_form.working_pattern_html') },
         hint_text: t('helpers.hint.job_specification_form.working_patterns')
 
       = render 'hiring_staff/vacancies/vacancy_form_partials/submit', f: f

--- a/app/views/hiring_staff/vacancies/job_specification/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/show.html.haml
@@ -10,7 +10,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @job_specification_form, url: @job_specification_url, html: { method: @job_specification_url_method }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @job_specification_form, url: @job_specification_url, html: { method: @job_specification_url_method } do |f|
       = f.govuk_error_summary
 
       %h2.govuk-heading-l

--- a/app/views/hiring_staff/vacancies/job_summary/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_summary/show.html.haml
@@ -9,7 +9,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @job_summary_form, url: school_job_job_summary_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h2.govuk-heading-l
         = t('jobs.job_summary')

--- a/app/views/hiring_staff/vacancies/job_summary/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_summary/show.html.haml
@@ -8,7 +8,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @job_summary_form, url: school_job_job_summary_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @job_summary_form, url: school_job_job_summary_path(@vacancy.id), html: { method: "patch" } do |f|
       = f.govuk_error_summary
 
       %h2.govuk-heading-l

--- a/app/views/hiring_staff/vacancies/pay_package/show.html.haml
+++ b/app/views/hiring_staff/vacancies/pay_package/show.html.haml
@@ -9,7 +9,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @pay_package_form, url: school_job_pay_package_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h2.govuk-heading-l
         = t('jobs.pay_package')

--- a/app/views/hiring_staff/vacancies/pay_package/show.html.haml
+++ b/app/views/hiring_staff/vacancies/pay_package/show.html.haml
@@ -8,7 +8,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @pay_package_form, url: school_job_pay_package_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @pay_package_form, url: school_job_pay_package_path(@vacancy.id), html: { method: "patch" } do |f|
       = f.govuk_error_summary
 
       %h2.govuk-heading-l

--- a/app/views/hiring_staff/vacancies/supporting_documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/supporting_documents/show.html.haml
@@ -8,7 +8,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @supporting_documents_form, url: school_job_supporting_documents_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @supporting_documents_form, url: school_job_supporting_documents_path(@vacancy.id), html: { method: "patch" } do |f|
       = f.govuk_error_summary
 
       %h2.govuk-heading-l

--- a/app/views/hiring_staff/vacancies/supporting_documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/supporting_documents/show.html.haml
@@ -9,7 +9,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @supporting_documents_form, url: school_job_supporting_documents_path(@vacancy.id), html: { method: "patch" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h2.govuk-heading-l
         = t('jobs.supporting_documents')
@@ -20,7 +20,7 @@
         %w[yes no],
         :to_s,
         :capitalize,
-        legend: { text: t('helpers.fieldset.supporting_documents_form.supporting_documents_html'), size: 's' },
+        legend: { text: t('helpers.fieldset.supporting_documents_form.supporting_documents_html') },
         hint_text: t('helpers.hint.supporting_documents_form.supporting_documents')
 
       = render 'hiring_staff/vacancies/vacancy_form_partials/submit', f: f

--- a/app/views/hiring_staff/vacancies/vacancy_form_partials/_submit.html.haml
+++ b/app/views/hiring_staff/vacancies/vacancy_form_partials/_submit.html.haml
@@ -1,5 +1,5 @@
 - if @vacancy&.published? || %w(copy edit edit_published review).include?(@vacancy&.state)
   = f.govuk_submit t('buttons.update_job'), classes: 'update-listing-gtm'
 - else
-  = f.govuk_submit t('buttons.save_and_continue'), classes: 'govuk-!-margin-bottom-5 save-listing-gtm'
+  = f.govuk_submit classes: 'govuk-!-margin-bottom-5 save-listing-gtm'
   = f.govuk_submit t('buttons.save_and_return_later'), secondary: true, classes: 'button-link save-and-return-listing-gtm'

--- a/app/views/hiring_staff/vacancies/vacancy_publish_feedback/new.html.haml
+++ b/app/views/hiring_staff/vacancies/vacancy_publish_feedback/new.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @feedback, url: school_job_feedback_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @feedback, url: school_job_feedback_path do |f|
       = f.govuk_error_summary
 
       %h2.govuk-heading-l

--- a/app/views/hiring_staff/vacancies/vacancy_publish_feedback/new.html.haml
+++ b/app/views/hiring_staff/vacancies/vacancy_publish_feedback/new.html.haml
@@ -3,7 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @feedback, url: school_job_feedback_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h2.govuk-heading-l
         = t('feedback.heading')

--- a/app/views/pages/home/_search.html.haml
+++ b/app/views/pages/home/_search.html.haml
@@ -1,6 +1,6 @@
 %h1.govuk-heading-m= t('jobs.heading')
 
-= form_for VacancyAlgoliaSearchBuilder.new({}), as: '', url: jobs_path(anchor: 'vacancy-results'), method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+= form_for VacancyAlgoliaSearchBuilder.new({}), as: '', url: jobs_path(anchor: 'vacancy-results'), method: :get do |f|
 
   = f.govuk_text_field :keyword,
     label: { text: t('jobs.filters.keyword'), size: 's' },

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -3,7 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @subscription, url: subscriptions_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-      = f.govuk_error_summary t('jobs.errors_present')
+      = f.govuk_error_summary
 
       %h1.govuk-heading-xl
         = t('subscriptions.new.page_description')

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @subscription, url: subscriptions_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for @subscription, url: subscriptions_path do |f|
       = f.govuk_error_summary
 
       %h1.govuk-heading-xl

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module TeacherVacancyService
     end
 
     config.action_view.sanitized_allowed_tags = ['p', 'br', 'strong', 'em', 'ul', 'li', 'h1', 'h2', 'h3', 'h4', 'h5']
+    config.action_view.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
 
     # Settings in config/environments/* take precedence over those
     # specified here.

--- a/config/initializers/govuk_design_system_formbuilder.rb
+++ b/config/initializers/govuk_design_system_formbuilder.rb
@@ -1,0 +1,5 @@
+GOVUKDesignSystemFormBuilder.configure do |conf|
+  conf.default_error_summary_title  = 'Please correct the following errors'
+  conf.default_legend_tag           = 'h3'
+  conf.default_legend_size          = 's'
+end


### PR DESCRIPTION
This PR completes the work to remove simple_form and implement GOVUKDesignSystemFormBuilder as the default form builder in the application. 

There are some failing view specs which are not recognising the default form builder (presumably because there is no interaction with the application controller.

## Changes in this PR
- Add default values in the config
- Set default form builder as [recommended](https://edgeapi.rubyonrails.org/classes/ActionController/FormBuilder.html#method-i-default_form_builder) - this **isn't** respected in view specs
- Set default form builder in the application config - this **is** respected in view specs
