### PR TITLE
Update .gitignore to include other certificate from keybase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ config/localhost/https/*.key
 config/localhost/https/*.crt
 localhost.key
 localhost.crt
+rootCA.pem
 
 # GCP development credentails
 serviceAccount.json


### PR DESCRIPTION
The teacher-vacancy-service isn't where this file lives anyway, but still, better safe than sound.