### PR TITLE
Fix translation file bug

### DIFF
--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -23,13 +23,13 @@
       %p.govuk-body-l=t('subscriptions.next_steps')
 
       = f.govuk_email_field :email,
-        label: { text: t('subscriptions.email.label_html'), size: 's' },
-        hint_text: t('subscriptions.email.hint'),
+        label: { text: t('subscriptions.labels.email_html'), size: 's' },
+        hint_text: t('subscriptions.hints.email'),
         required: true
 
       = f.govuk_text_field :reference,
-        label: { text: t('subscriptions.reference.label_html'), size: 's' },
-        hint_text: t('subscriptions.reference.hint'),
+        label: { text: t('subscriptions.labels.reference_html'), size: 's' },
+        hint_text: t('subscriptions.hints.reference'),
         required: true
 
       = recaptcha_v3(action: 'subscription')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -586,12 +586,12 @@ en:
         expiry_text_html: "Your job alert subscription will end on %{date}."
     manage: Manage your subscription
     unsubscribe: Unsubscribe
-    email:
-      label_html: Email address
-      hint: Enter your email address. We'll only use it to send you job alerts.
-    reference:
-      label_html: Your reference
-      hint: This text will appear in the subject line of emails for this job alert subscription. Feel free to change it.
+    labels:
+      email_html: Email address (<span class="text-red">Required</span>)
+      reference_html: Your reference (<span class="text-red">Required</span>)
+    hints:
+      email: Enter your email address. We'll only use it to send you job alerts.
+      reference: This text will appear in the subject line of emails for this job alert subscription. Feel free to change it.
   job_alerts:
     confirmation:
       email:


### PR DESCRIPTION
This PR addresses a bug where duplicate entries meant job alert confirmation emails would not render correctly.

## Changes in this PR
- Rename labels in translation file

## Next steps
- Raise a ticket for refactoring translation files