### PR TITLE
Correct sign out messages

### DIFF
--- a/app/controllers/hiring_staff/base_controller.rb
+++ b/app/controllers/hiring_staff/base_controller.rb
@@ -10,6 +10,7 @@ class HiringStaff::BaseController < ApplicationController
   helper_method :current_school
 
   include AuthenticationConcerns
+  include ActionView::Helpers::DateHelper
 
   def redirect_to_root_if_read_only
     redirect_to root_path if ReadOnlyFeature.enabled?
@@ -50,5 +51,9 @@ class HiringStaff::BaseController < ApplicationController
     url = URI.parse("#{ENV['DFE_SIGN_IN_ISSUER']}/session/end")
     url.query = { post_logout_redirect_uri: auth_dfe_signout_url, id_token_hint: session[:id_token] }.to_query
     url.to_s
+  end
+
+  def timeout_period_as_string
+    distance_of_time_in_words(TIMEOUT_PERIOD).gsub('about ', '')
   end
 end

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -20,9 +20,11 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
 
   def destroy
     if session[:signing_out_for_inactivity]
-      flash_message = { notice: I18n.t('messages.access.signed_out_for_inactivity') }
+      flash_message = { notice: I18n.t(
+        'messages.access.signed_out_for_inactivity',
+        duration: timeout_period_as_string) }
     else
-      flash_message = { notice: I18n.t('messages.access.signed_out') }
+      flash_message = { success: I18n.t('messages.access.signed_out') }
     end
     session.destroy
     redirect_to new_identifications_path, flash_message

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -666,8 +666,8 @@ en:
       view:
         only_published: You can only view published jobs
     access:
-      signed_out_for_inactivity: You have been signed out due to inactivity
-      signed_out: You have been signed out
+      signed_out_for_inactivity: You have been signed out because you have been inactive for %{duration}
+      signed_out: You have signed out
     feedback:
       submitted: Your feedback has been successfully submitted
     subscriptions:

--- a/spec/features/hiring_staff_session_timeout_spec.rb
+++ b/spec/features/hiring_staff_session_timeout_spec.rb
@@ -23,7 +23,8 @@ RSpec.feature 'Hiring staff session' do
       expect(page.current_url).to include CGI.escape(auth_dfe_signout_url)
       visit auth_dfe_signout_path
 
-      expect(page).to have_content(I18n.t('messages.access.signed_out_for_inactivity'))
+      expect(page).to have_content('signed out')
+      expect(page).to have_content('inactive')
     end
   end
 


### PR DESCRIPTION
Something small to fix while waiting for something else.

This brings the sign out messages more in line with [the Figma](https://www.figma.com/file/goShR6eaBmuQDoi4d9grmZ/Sprint-57?node-id=0%3A1
), but instead of saying '60 minutes' it says '1 hour', because the output of the available DateHelper method `distance_of_time_in_words` says `"about 1 hour"` (I `gsub`bed the 'about' away). I slightly preferred this approach over having two constants to maintain (one for the Duration object and the other for the human-readable string).

I tried adjusting the timeout period to see if it could cope with it:

<img width="978" alt="Screenshot 2020-06-23 at 16 44 32" src="https://user-images.githubusercontent.com/60350599/85428710-89726c80-b575-11ea-807d-4eb9a8ed365b.png">
