### PR TITLE
SPIKE: Quick and dirty client-side polygon search

### DIFF
--- a/app/controllers/api/location_polygons_controller.rb
+++ b/app/controllers/api/location_polygons_controller.rb
@@ -1,0 +1,19 @@
+class Api::LocationPolygonsController < Api::ApplicationController
+  before_action :verify_json_request, only: %i[show]
+
+  def show
+    location_polygon = LocationPolygon.find_by(name: location)
+
+    render json: {
+      location: location,
+      polygon: location_polygon&.boundary,
+      success: location_polygon.present?
+    }
+  end
+
+  private
+
+  def location
+    params[:location]
+  end
+end

--- a/app/frontend/src/lib/api.js
+++ b/app/frontend/src/lib/api.js
@@ -1,7 +1,13 @@
 import axios from 'axios';
 
-export const getGeolocatedCoordinates = query => {
-    return axios.get(`/api/v1/coordinates/${query}?format=json`).then(response => {
-        return response.data;
-    });
+export const getGeolocatedCoordinates = (query) => {
+  return axios.get(`/api/v1/coordinates/${query}?format=json`).then((response) => {
+    return response.data;
+  });
+};
+
+export const getLocationPolygon = (query) => {
+  return axios.get(`/api/v1/location_polygons/${query}?format=json`).then((response) => {
+    return response.data;
+  });
 };

--- a/app/frontend/src/search/client.js
+++ b/app/frontend/src/search/client.js
@@ -3,7 +3,7 @@ import instantsearch from 'instantsearch.js';
 
 import { getFilters, getQuery } from './query';
 import { getKeyword } from './ui/input/keyword';
-import { getCoords } from './ui/input/location';
+import { getCoords, getPolygon } from './ui/input/location';
 import { getRadius } from './ui/input/radius';
 
 // This is the public API key which can be safely used in your frontend code.
@@ -30,11 +30,19 @@ export const onSearch = (helper) => {
     helper.setState(getNewState(helper.state, { aroundLatLng: getCoords() }));
   }
 
+  if (getPolygon()) {
+    helper.setState(getNewState(helper.state, { insidePolygon: getPolygon() }));
+  }
+
   if (getRadius()) {
     helper.setState(getNewState(helper.state, { aroundRadius: getRadius() }));
-    helper.setQuery(getKeyword());
   } else {
     helper.setState(getNewState(helper.state, { aroundRadius: 'all' }));
+  }
+
+  if (getRadius() || getPolygon()) {
+    helper.setQuery(getKeyword());
+  } else {
     helper.setQuery(getQuery());
   }
 

--- a/app/frontend/src/search/ui/form.js
+++ b/app/frontend/src/search/ui/form.js
@@ -17,3 +17,11 @@ export const removeGeocodeAttributes = () => {
   removeDataAttribute(document.querySelector('#location'), 'coordinates');
   removeDataAttribute(document.querySelector('#radius'), 'radius');
 };
+
+export const setPolygonAttributes = (polygon) => {
+  setDataAttribute(document.querySelector('#location'), 'polygon', `${polygon}`);
+};
+
+export const removePolygonAttributes = () => {
+  removeDataAttribute(document.querySelector('#location'), 'polygon');
+};

--- a/app/frontend/src/search/ui/input/location.js
+++ b/app/frontend/src/search/ui/input/location.js
@@ -1,13 +1,22 @@
-import { setGeocodeAttributes, removeGeocodeAttributes } from '../form';
+import {
+  setGeocodeAttributes, removeGeocodeAttributes, setPolygonAttributes, removePolygonAttributes,
+} from '../form';
 import { enableRadiusSelect, disableRadiusSelect } from './radius';
-import { getGeolocatedCoordinates } from '../../../lib/api';
+import { getGeolocatedCoordinates, getLocationPolygon } from '../../../lib/api';
 
 export const onSubmit = (query, locations, client) => {
   client.helper.setPage(0); // if the search input changes, the page should be reset to 0
+  removePolygonAttributes();
   if (shouldNotGeocode(query, locations)) {
     disableRadiusSelect();
     removeGeocodeAttributes();
-    client.refresh();
+    getLocationPolygon(query).then((polygon) => {
+      if (polygon.success) {
+        polygonSuccess(polygon.polygon, client);
+      } else {
+        client.refresh();
+      }
+    });
   } else {
     getGeolocatedCoordinates(query).then((coords) => {
       geocodeSuccess(coords, client);
@@ -25,4 +34,11 @@ export const geocodeSuccess = (coords, client) => {
   }
 };
 
+export const polygonSuccess = (polygon, client) => {
+  setPolygonAttributes(polygon);
+  client.refresh();
+};
+
 export const getCoords = () => document.querySelector('#location').dataset.coordinates;
+
+export const getPolygon = () => document.querySelector('#location').dataset.polygon;

--- a/app/models/location_polygon.rb
+++ b/app/models/location_polygon.rb
@@ -1,0 +1,6 @@
+class LocationPolygon < ApplicationRecord
+  scope :cities, -> { where(location_type: 'cities') }
+  scope :counties, -> { where(location_type: 'counties') }
+  scope :local_authorities, -> { where(location_type: 'local_authorities') }
+  scope :regions, -> { where(location_type: 'regions') }
+end

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -46,3 +46,5 @@
       .pagination-results
         = paginate @vacancies_search.vacancies
       %p.govuk-body#vacancies-stats-bottom{ 'aria-label': 'Number of results' }
+
+= javascript_pack_tag 'search'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     scope 'v:api_version', api_version: /[1]/ do
       resources :jobs, only: %i[index show], controller: 'vacancies'
       get '/coordinates(/:location)', to: 'coordinates#show'
+      get '/location_polygons(/:location)', to: 'location_polygons#show'
     end
   end
 

--- a/db/migrate/20200623081123_create_location_polygons.rb
+++ b/db/migrate/20200623081123_create_location_polygons.rb
@@ -1,0 +1,10 @@
+class CreateLocationPolygons < ActiveRecord::Migration[5.2]
+  def change
+    create_table :location_polygons, id: :uuid do |t|
+      t.string :name, null: false
+      t.string :location_type
+      t.float :boundary, array: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_12_192733) do
+ActiveRecord::Schema.define(version: 2020_06_23_081123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -96,6 +96,14 @@ ActiveRecord::Schema.define(version: 2020_06_12_192733) do
   create_table "leaderships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.index ["title"], name: "index_leaderships_on_title", unique: true
+  end
+
+  create_table "location_polygons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "location_type"
+    t.float "boundary", array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "regions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/fetch_location_polygon_boundary_data.rake
+++ b/lib/tasks/fetch_location_polygon_boundary_data.rake
@@ -1,0 +1,53 @@
+LOCATION_POLYGON_SETTINGS = {
+  regions: {
+    api: 'https://ons-inspire.esriuk.com/arcgis/rest/services/Administrative_Boundaries/Regions_December_2019_Boundaries_EN_BFC/MapServer/0/query?where=1%3D1&outFields=rgn19nm,shape&outSR=4326&f=json',
+    name_key: 'rgn19nm'
+  },
+  counties: {
+    api: 'https://ons-inspire.esriuk.com/arcgis/rest/services/Administrative_Boundaries/Counties_December_2019_Boundaries_EN_BFC/MapServer/0/query?where=1%3D1&outFields=cty19nm,shape&outSR=4326&f=json',
+    name_key: 'cty19nm'
+  },
+  local_authorities: {
+    api: 'https://ons-inspire.esriuk.com/arcgis/rest/services/Administrative_Boundaries/Local_Authority_Districts_December_2019_Boundaries_UK_BFC/MapServer/0/query?where=1%3D1&outFields=lad19nm,shape&outSR=4326&f=json',
+    name_key: 'lad19nm'
+  }
+}
+
+namespace :data do
+  desc 'Fetch location polygon boundary data from ONS'
+  namespace :fetch_location_polygons_from_api do
+    task regions: :environment do
+      fetch_and_process_api(:regions)
+    end
+
+    task counties: :environment do
+      fetch_and_process_api(:counties)
+    end
+
+    task local_authorities: :environment do
+      fetch_and_process_api(:local_authorities)
+    end
+  end
+end
+
+def fetch_and_process_api(location_type)
+  response = HTTParty.get(LOCATION_POLYGON_SETTINGS[location_type][:api])
+  (response['features'] || []).each do |region_response|
+    region_name = region_response.dig('attributes', LOCATION_POLYGON_SETTINGS[location_type][:name_key])
+    geometry_rings = region_response.dig('geometry', 'rings')
+
+    # The first ring tends to contain far more points than subsequent rings.
+    # Boundary should be visualised to check how it should be used.
+    # If algolia searches by polygon are slow, these boundaries could be downsampled significantly.
+    points = []
+    geometry_rings[0].each do |point|
+      points.push(*point.reverse) # API returns coords in an unconventional lng,lat order
+    end
+
+    LocationPolygon.create(
+      name: region_name,
+      location_type: location_type.to_s,
+      boundary: points
+    )
+  end
+end


### PR DESCRIPTION
This PR should be closed and not merged. It is intended to give visibility to the work carried out in the spike and provide a foundation for the future work on this feature.

The basic principle of how polygon search should work is as follows:
- Polygon data is stored for various locations. This data should come from a reliable source, and needn't be updated regularly
- An algolia search filter `insidePolygon` is applied to searches where appropriate
- If there are no polygon matches, carry out textual/radius search where appropriate

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-871

## Changes in this PR
- Task to import regions/counties/local authorities boundary data
- LocationPolygon model which stores boundary data
- API endpoint to serve boundary data for a given location
- Client-side implementation of an insidePolygon search

## Results
Currently, a search for 'North East' returns jobs that aren't in the North East, for instance 
![image](https://user-images.githubusercontent.com/25187547/85431161-0d7a2380-b579-11ea-929f-dec499daaef4.png)
Polygon search improves this, since a textual search is not being carried out, with only results that are in the North East region (by Office for National Statistics definition) returned.

## Downsampling polygons
The initial London polygon contained 26491 points. 
**API polygon request total response time**: 230.24 ms
**Client search request total response time**: 740.10 ms
**Algolia search request processingTimeMS**: 40 ms

![image](https://user-images.githubusercontent.com/25187547/85537465-e7519380-b60b-11ea-8462-97f2d21031ae.png)

A downsampled polygon with tolerance=0.001 and high_quality=true contained only 623 points, but the corresponding search returned the same results.
**API polygon request total response time**: 83.98 ms
**Client search request total response time**: 161.35 ms
**Algolia search request processingTimeMS**: 3 ms

![image](https://user-images.githubusercontent.com/25187547/85537998-61821800-b60c-11ea-9ce9-089b6545ec0a.png)

## Next steps
- Confirm accuracy of polygon data
- Obtain source of truth for Cities boundary data
- Downsample polygon data (e.g https://github.com/odlp/simplify_rb) sufficiently to achieve acceptable response times, without sacrificing search accuracy. This might not be necessary, since there are different resolutions of boundary data available.
- Implement fully tested and functional polygon search for client and server search
