### PR TITLE
Update kaminari templates for new pagination design

### DIFF
--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -5,5 +5,5 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
-%li.pagination__item
-  = link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, class: 'pagination__link'
+%li
+  = link_to_unless current_page.last?, 'Next', url, rel: 'next', remote: remote, class: 'pagination__item pagination--next'

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -6,5 +6,5 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
-%li.pagination__item{ class: "page#{' current' if page.current?}" }
-  = link_to_unless page.current?, page, url, { remote: remote, rel: page.rel }
+%li
+  = link_to page, url, remote: remote, rel: page.rel, class: "pagination__item#{' current' if page.current?}"

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -8,12 +8,8 @@
 = paginator.render do
   %nav#pagination-hits{"aria-label" => "Pagination", :role => "navigation"}
     %ul.pagination.pagination-server
-      = first_page_tag unless current_page.first?
       = prev_page_tag unless current_page.first?
       - each_page do |page|
         - if page.display_tag?
           = page_tag page
-        - elsif !page.was_truncated?
-          = gap_tag
       = next_page_tag unless current_page.last?
-      = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -5,5 +5,5 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
-%li.pagination__item
-  = link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: 'pagination__link'
+%li
+  = link_to_unless current_page.first?, 'Previous', url, rel: 'prev', remote: remote, class: 'pagination__item pagination--prev'

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 25
+  config.default_per_page = 10
   config.max_per_page = nil
-  config.window = 4
+  config.window = 2
   config.outer_window = 0
   config.left = 0
   config.right = 0


### PR DESCRIPTION
This PR updates kaminari templates so that server and client side pagination follow the same design exactly.

## Changes in this PR:
- Remove first and last links
- Change window to 2
- Update styling
