### PR TITLE
Add job to remove EmergencyLoginKeys monthly

### DIFF
--- a/app/jobs/clear_emergency_login_keys_job.rb
+++ b/app/jobs/clear_emergency_login_keys_job.rb
@@ -1,0 +1,7 @@
+class ClearEmergencyLoginKeysJob < ApplicationJob
+  queue_as :clear_emergency_login_keys
+
+  def perform
+    EmergencyLoginKey.delete_all
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -32,3 +32,8 @@ submit_performance_platform:
   cron: '0 04 * * *'
   class: 'SubmitPerformancePlatformJob'
   queue: submit_performance_platform
+
+clear_emergency_login_keys:
+  cron: '30 0 1 * *'
+  class: 'ClearEmergencyLoginKeysJob'
+  queue: clear_emergency_login_keys

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,45 +1,48 @@
 :queues:
+  - [email_daily_alerts, 4]
   - [mailers, 3]
   - [queue_daily_alerts, 3]
-  - [email_daily_alerts, 4]
-  - [vacancy_statistics, 2]
-  - [performance_platform, 2]
   - [google_indexing, 2]
-  - [import_school_data, 1]
-  - [audit_published_vacancy, 1]
-  - [audit_vacancies, 1]
+  - [performance_platform, 2]
+  - [vacancy_statistics, 2]
   - [audit_express_interest_event, 1]
-  - [audit_search_event, 1]
-  - [audit_vacancy_publish_feedback, 1]
   - [audit_general_feedback, 1]
+  - [audit_published_vacancy, 1]
+  - [audit_search_event, 1]
   - [audit_subscription_creation, 1]
-  - [seed_vacancies_from_api, 1]
-  - [export_users, 1]
+  - [audit_vacancies, 1]
+  - [audit_vacancy_publish_feedback, 1]
+  - [clear_emergency_login_keys, 1]
   - [export_tables, 1]
+  - [export_users, 1]
+  - [import_school_data, 1]
   - [reset_sessions, 1]
+  - [seed_vacancies_from_api, 1]
   - [submit_performance_platform, 1]
   - [update_dsi_users_in_db, 1]
-audit_published_vacancy:
-  :concurrency: 1
-audit_vacancies:
-  :concurrency: 1
-audit_express_interest_event:
-  :concurrency: 1
-audit_search_event:
-  :concurrency: 1
-audit_vacancy_publish_feedback:
-  :concurrency: 1
-audit_general_feedback:
-  :concurrency: 1
-audit_subscription_creation:
-  :concurrency: 1
 mailers:
   :concurrency: 2
 seed_vacancies_from_api:
   :concurrency: 2
-export_users:
+audit_express_interest_event:
+  :concurrency: 1
+audit_general_feedback:
+  :concurrency: 1
+audit_published_vacancy:
+  :concurrency: 1
+audit_search_event:
+  :concurrency: 1
+audit_subscription_creation:
+  :concurrency: 1
+audit_vacancies:
+  :concurrency: 1
+audit_vacancy_publish_feedback:
+  :concurrency: 1
+clear_emergency_login_keys:
   :concurrency: 1
 export_tables:
+  :concurrency: 1
+export_users:
   :concurrency: 1
 reset_sessions:
   :concurrency: 1

--- a/spec/jobs/clear_emergency_keys_job_spec.rb
+++ b/spec/jobs/clear_emergency_keys_job_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'clear_emergency_login_keys_job'
+
+RSpec.describe ClearEmergencyLoginKeysJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the clear_emergency_login_keys queue' do
+    expect(job.queue_name).to eq('clear_emergency_login_keys')
+  end
+
+  it 'deletes all EmergencyLoginKeys' do
+    2.times { create(:emergency_login_key) }
+    expect { perform_enqueued_jobs { job } }
+        .to change { EmergencyLoginKey.all.size }.from(2).to(0)
+  end
+end


### PR DESCRIPTION
## Jira ticket URL

This is the final acceptance criterion on:

https://dfedigital.atlassian.net/browse/TEVA-815

## Changes in this PR:

Adds job to remove EmergencyLoginKeys monthly.

- How often should it run?
- Do we even need this job? (Weighing cost of maintaining it vs its likely utility.)

Including: sorting the sidekiq.yml first by priority and then
alphabetically.