### PR TITLE
Don't display jobs sort field on subscriptions page

### DIFF
--- a/app/presenters/subscription_presenter.rb
+++ b/app/presenters/subscription_presenter.rb
@@ -44,6 +44,7 @@ class SubscriptionPresenter < BasePresenter
   def search_criteria_field(field, value)
     return if field.eql?('radius')
     return if field.eql?('location_category')
+    return if field.eql?('jobs_sort')
 
     return render_location_filter(
       search_criteria_to_h['location_category'], value, search_criteria_to_h['radius']

--- a/spec/presenters/subscription_presenter_spec.rb
+++ b/spec/presenters/subscription_presenter_spec.rb
@@ -141,4 +141,22 @@ RSpec.describe SubscriptionPresenter do
       end
     end
   end
+
+  describe '#search_criteria_field' do
+    it 'does not return the radius field' do
+      expect(presenter.send(:search_criteria_field, 'radius', 'some radius')).to eql(nil)
+    end
+
+    it 'does not return the location_category field' do
+      expect(presenter.send(:search_criteria_field, 'location_category', 'some location category')).to eql(nil)
+    end
+
+    it 'does not return the jobs_sort field' do
+      expect(presenter.send(:search_criteria_field, 'jobs_sort', 'search_replica')).to eql(nil)
+    end
+
+    it 'returns a field:value hash' do
+      expect(presenter.send(:search_criteria_field, 'random_field', 'value')).to eql({ 'random_field': 'value' })
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes a bug that rendered a useless field to the user when creating job alerts. It also adds a small test.

![image](https://user-images.githubusercontent.com/25187547/85671525-dcedd300-b6b9-11ea-8dac-0798eb33c6ed.png)

## Changes in this PR:
- Do not render jobs_sort field
- Add small test for this piece of untested code

