### PR TITLE
Correct 'sort by' is selected dependent on search scenario

### DIFF
--- a/app/frontend/src/search/ui/sort.js
+++ b/app/frontend/src/search/ui/sort.js
@@ -8,7 +8,7 @@ export const renderSortSelectInput = (renderOptions, isFirstRender) => {
 
     if (document.querySelector('#jobs_sort_select')) {
       document.querySelector('#jobs_sort_select').addEventListener('change', (event) => {
-        refine(getSearchReplicaName(event.target.value));
+        refine(getSearchIndexName(event.target.value));
       });
     }
   }
@@ -22,4 +22,10 @@ export const renderSortSelectInput = (renderOptions, isFirstRender) => {
   }
 };
 
-export const getSearchReplicaName = (selected) => (selected ? `Vacancy_${selected}` : 'Vacancy');
+export const getSearchIndexName = (selected) => {
+  const defaultSearchIndexName = 'Vacancy_publish_on_desc';
+  if (selected === 'most_relevant') {
+    return 'Vacancy';
+  }
+  return selected ? `Vacancy_${selected}` : defaultSearchIndexName;
+};

--- a/app/frontend/src/search/ui/sort.test.js
+++ b/app/frontend/src/search/ui/sort.test.js
@@ -1,4 +1,4 @@
-import { renderSortSelectInput, getSearchReplicaName } from './sort';
+import { renderSortSelectInput, getSearchIndexName } from './sort';
 
 describe('renderSortSelectInput', () => {
   test('returns a function', () => {
@@ -6,12 +6,17 @@ describe('renderSortSelectInput', () => {
   });
 });
 
-describe('getSearchReplicaName', () => {
-  test('returns Vacancy when no search replica is selected', () => {
-    expect(getSearchReplicaName('')).toBe('Vacancy');
+describe('getSearchIndexName', () => {
+  test('returns the default search replica when no search replica is selected', () => {
+    expect(getSearchIndexName('')).toBe('Vacancy_publish_on_desc');
+    expect(getSearchIndexName(null)).toBe('Vacancy_publish_on_desc');
+  });
+
+  test('returns the base index Vacancy when most_relevant is selected', () => {
+    expect(getSearchIndexName('most_relevant')).toBe('Vacancy');
   });
 
   test('returns correct index when search replica is selected', () => {
-    expect(getSearchReplicaName('this_index')).toBe('Vacancy_this_index');
+    expect(getSearchIndexName('this_index')).toBe('Vacancy_this_index');
   });
 });

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -20,7 +20,7 @@ class Vacancy < ApplicationRecord
   }.merge(FLEXIBLE_WORKING_PATTERN_OPTIONS).freeze
 
   JOB_SORTING_OPTIONS = [
-    [I18n.t('jobs.sort_by.most_relevant'), ''],
+    [I18n.t('jobs.sort_by.most_relevant'), 'most_relevant'],
     [I18n.t('jobs.sort_by.publish_on.descending'), 'publish_on_desc'],
     [I18n.t('jobs.sort_by.expiry_time.descending'), 'expiry_time_desc'],
     [I18n.t('jobs.sort_by.expiry_time.ascending'), 'expiry_time_asc']

--- a/app/services/vacancy_algolia_search_builder.rb
+++ b/app/services/vacancy_algolia_search_builder.rb
@@ -9,6 +9,7 @@ class VacancyAlgoliaSearchBuilder
 
   DEFAULT_RADIUS = 10
   DEFAULT_HITS_PER_PAGE = 10
+  DEFAULT_SORT = 'publish_on_desc'
 
   def initialize(params)
     self.keyword = params[:keyword]
@@ -118,7 +119,9 @@ class VacancyAlgoliaSearchBuilder
   end
 
   def build_search_replica
-    return nil if sort_by.blank?
+    # Returning nil means the search should use the main index, not a replica
+    return nil if sort_by == 'most_relevant'
+    self.sort_by = DEFAULT_SORT if sort_by.blank?
     self.search_replica = ['Vacancy', sort_by].reject(&:blank?).join('_')
   end
 

--- a/spec/controllers/hiring_staff/identifications_controller_spec.rb
+++ b/spec/controllers/hiring_staff/identifications_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe HiringStaff::IdentificationsController, type: :controller do
   describe '#create' do
+    before { allow(AuthenticationFallback).to receive(:enabled?).and_return(false) }
     it 'redirects to DfE Sign in' do
       post :create
       expect(response).to redirect_to(new_dfe_path)

--- a/spec/controllers/hiring_staff/sign_in/dfe/sessions_controller_spec.rb
+++ b/spec/controllers/hiring_staff/sign_in/dfe/sessions_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe HiringStaff::SignIn::Dfe::SessionsController, type: :controller do
   describe '#new' do
+    before { allow(AuthenticationFallback).to receive(:enabled?).and_return(false) }
     it 'redirects to Dfe' do
       get :new
       expect(response).to redirect_to('/auth/dfe') # From here we trust Omniauth

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe VacanciesController, type: :controller do
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql("Vacancy_#{sort}")
         end
       end
+
+      context 'when parameters include the sort by relevancy option' do
+        let(:sort) { 'most_relevant' }
+
+        it 'does not set a search replica on VacancyAlgoliaSearchBuilder' do
+          subject
+          expect(controller.instance_variable_get(:@vacancies_search).search_replica).to be_nil
+        end
+      end
     end
 
     context 'feature flagging' do

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe VacanciesHelper, type: :helper do
     it 'returns an array of vacancy job sorting options' do
       expect(helper.job_sorting_options).to eq(
         [
-          [I18n.t('jobs.sort_by.most_relevant'), ''],
+          [I18n.t('jobs.sort_by.most_relevant'), 'most_relevant'],
           [I18n.t('jobs.sort_by.publish_on.descending'), 'publish_on_desc'],
           [I18n.t('jobs.sort_by.expiry_time.descending'), 'expiry_time_desc'],
           [I18n.t('jobs.sort_by.expiry_time.ascending'), 'expiry_time_asc']

--- a/spec/services/vacancy_algolia_search_builder_spec.rb
+++ b/spec/services/vacancy_algolia_search_builder_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
           {}
         end
 
-        it 'does not use a search replica' do
-          expect(subject.search_replica).to be_nil
+        it 'uses the default search replica' do
+          expect(subject.search_replica).to eql("Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_#{VacancyAlgoliaSearchBuilder::DEFAULT_SORT}")
         end
       end
 
@@ -115,8 +115,8 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
           }
         end
 
-        it 'does not use a search replica' do
-          expect(subject.search_replica).to be_nil
+        it 'uses the default search replica' do
+          expect(subject.search_replica).to eql("Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_#{VacancyAlgoliaSearchBuilder::DEFAULT_SORT}")
         end
       end
 
@@ -127,20 +127,32 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
           }
         end
 
-        it 'does not use a search replica' do
-          expect(subject.search_replica).to be_nil
+        it 'uses the default search replica' do
+          expect(subject.search_replica).to eql("Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_#{VacancyAlgoliaSearchBuilder::DEFAULT_SORT}")
         end
       end
 
       context 'valid sort specified' do
         let(:params) do
           {
-            jobs_sort: 'publish_on_desc'
+            jobs_sort: 'expiry_time_desc'
           }
         end
 
         it 'uses the correct search replica' do
-          expect(subject.search_replica).to eql('Vacancy_publish_on_desc')
+          expect(subject.search_replica).to eql("Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_expiry_time_desc")
+        end
+      end
+
+      context 'sort by relevancy specified' do
+        let(:params) do
+          {
+            jobs_sort: 'most_relevant'
+          }
+        end
+
+        it 'uses the correct search replica' do
+          expect(subject.search_replica).to be_nil
         end
       end
     end

--- a/spec/services/vacancy_algolia_search_builder_spec.rb
+++ b/spec/services/vacancy_algolia_search_builder_spec.rb
@@ -98,13 +98,17 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
     end
 
     context '#sort' do
+      let(:default_search_replica) do
+        "Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_#{VacancyAlgoliaSearchBuilder::DEFAULT_SORT}"
+      end
+
       context 'no sort specified' do
         let(:params) do
           {}
         end
 
         it 'uses the default search replica' do
-          expect(subject.search_replica).to eql("Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_#{VacancyAlgoliaSearchBuilder::DEFAULT_SORT}")
+          expect(subject.search_replica).to eql(default_search_replica)
         end
       end
 
@@ -116,7 +120,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
         end
 
         it 'uses the default search replica' do
-          expect(subject.search_replica).to eql("Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_#{VacancyAlgoliaSearchBuilder::DEFAULT_SORT}")
+          expect(subject.search_replica).to eql(default_search_replica)
         end
       end
 
@@ -128,7 +132,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
         end
 
         it 'uses the default search replica' do
-          expect(subject.search_replica).to eql("Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_#{VacancyAlgoliaSearchBuilder::DEFAULT_SORT}")
+          expect(subject.search_replica).to eql(default_search_replica)
         end
       end
 

--- a/spec/support/search_helper.rb
+++ b/spec/support/search_helper.rb
@@ -1,5 +1,5 @@
 module SearchHelper
-  DEFAULT_INDEX = 'Vacancy_test_publish_on_desc'
+  DEFAULT_INDEX = "Vacancy_test#{ENV.fetch('GITHUB_RUN_ID', '')}_publish_on_desc"
 
   def mock_algolia_search(result, query, algolia_hash = {})
     arguments_to_algolia = {

--- a/spec/support/search_helper.rb
+++ b/spec/support/search_helper.rb
@@ -1,9 +1,11 @@
 module SearchHelper
+  DEFAULT_INDEX = 'Vacancy_test_publish_on_desc'
+
   def mock_algolia_search(result, query, algolia_hash = {})
     arguments_to_algolia = {
       aroundLatLng: algolia_hash[:aroundLatLng] || nil,
       aroundRadius: algolia_hash[:aroundRadius] || nil,
-      replica: algolia_hash[:replica] || nil,
+      replica: algolia_hash[:replica] || DEFAULT_INDEX,
       hitsPerPage: algolia_hash[:hitsPerPage] || 10,
       filters: algolia_hash[:filters] ||
         "publication_timestamp <= #{Time.zone.today.to_datetime.to_i} AND "\


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-898

## Changes in this PR:

- With this PR we will introduce a 'most_relevant' value to the job sort drop-down, and map it to the base search index, 'Vacancy'.

Scenario A: If the user searches by keyword & location, we sort vacancies by most relevant

Scenario B: If the user searches by location only, we sort by newest job listing

Scenario C: If the user clicks search without entering search terms, we show them all vacancies, with the heading 'There are x jobs listed' and we sort by newest job listing
