### PR TITLE
Import trust data

### DIFF
--- a/app/jobs/import_school_group_data_job.rb
+++ b/app/jobs/import_school_group_data_job.rb
@@ -1,0 +1,9 @@
+require 'import_school_group_data'
+
+class ImportSchoolGroupDataJob < ApplicationJob
+  queue_as :import_school_group_data
+
+  def perform
+    ImportSchoolGroupData.new.run!
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -18,6 +18,11 @@ import_school_data:
   class: 'UpdateSchoolsDataFromSourceJob'
   queue: import_school_data
 
+import_school_group_data:
+  cron: '0 22 * * *'
+  class: 'ImportSchoolGroupDataJob'
+  queue: import_school_group_data
+
 remove_vacancies_that_expired_yesterday:
   cron: '0 03 * * *'
   class: 'RemoveVacanciesThatExpiredYesterday'

--- a/lib/import_school_group_data.rb
+++ b/lib/import_school_group_data.rb
@@ -24,9 +24,12 @@ class ImportSchoolGroupData
   end
 
   def create_school_groups(row)
-    SchoolGroup.transaction do
-      school_group = convert_to_school_group(row)
-      school_group.save
+    # Only import MAT data
+    if row['Group Type (code)'] == '06'
+      SchoolGroup.transaction do
+        school_group = convert_to_school_group(row)
+        school_group.save
+      end
     end
   end
 

--- a/lib/import_school_group_data.rb
+++ b/lib/import_school_group_data.rb
@@ -1,0 +1,47 @@
+require 'csv'
+require 'httparty'
+
+CSV_URL = 'https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/allgroupsdata.csv'
+TEMP_CSV_FILE_LOCATION = './tmp/school-groups-data.csv'
+
+class ImportSchoolGroupData
+  def run!
+    save_csv_file
+    CSV.foreach(TEMP_CSV_FILE_LOCATION, headers: true, encoding: 'windows-1251:utf-8').each do |row|
+      SchoolGroup.transaction do
+        school_group = convert_to_school_group(row)
+        school_group.save
+      end
+    end
+
+    File.delete(TEMP_CSV_FILE_LOCATION)
+  end
+
+  private
+
+  def convert_to_school_group(row)
+    school_group = SchoolGroup.find_or_initialize_by(uid: row['Group UID'])
+    set_gias_data_as_json(school_group, row)
+
+    school_group
+  end
+
+  def set_gias_data_as_json(school_group, row)
+    gias_hash = {}
+    row.each { |element| gias_hash[element.first] = element.last }
+    # The gias_data column is type `json`. It automatically converts the ruby hash to json.
+    school_group.gias_data = gias_hash
+  end
+
+  def save_csv_file(url = CSV_URL, location = TEMP_CSV_FILE_LOCATION)
+    request = HTTParty.get(url)
+
+    if request.code == 200
+      File.write(location, request.body, mode: 'wb')
+    elsif request.code == 404
+      raise HTTParty::ResponseError, 'SchoolGroup CSV file not found.'
+    else
+      raise HTTParty::ResponseError, 'Unexpected problem downloading SchoolGroup CSV file.'
+    end
+  end
+end

--- a/spec/jobs/import_school_group_data_job_spec.rb
+++ b/spec/jobs/import_school_group_data_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ImportSchoolGroupDataJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the import_school_group_data queue' do
+    expect(job.queue_name).to eq('import_school_group_data')
+  end
+
+  it 'executes perform' do
+    import_school_group_data = double(:mock)
+    expect(ImportSchoolGroupData).to receive(:new).and_return(import_school_group_data)
+    expect(import_school_group_data).to receive(:run!)
+
+    perform_enqueued_jobs { job }
+  end
+end

--- a/spec/lib/import_school_group_data_spec.rb
+++ b/spec/lib/import_school_group_data_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+require 'import_school_group_data'
+
+RSpec.describe ImportSchoolGroupData do
+  let(:subject) { ImportSchoolGroupData.new }
+
+  let(:csv_url) { 'https://csv_endpoint.csv/magic_endpoint/test.csv' }
+  let(:temp_file_location) { '/some_temporary_location/test.csv' }
+
+  let(:row) { { 'Group UID': uid } }
+  let(:school_group) { double('school_group') }
+  let(:uid) { 'test_uid' }
+
+  before do
+    stub_const("#{ImportSchoolGroupData}::CSV_URL", csv_url)
+    stub_const("#{ImportSchoolGroupData}::TEMP_CSV_FILE_LOCATION", temp_file_location)
+  end
+
+  context '#convert_to_school_group' do
+    before do
+      allow(SchoolGroup).to receive(:find_or_initialize_by).with(
+        hash_including(uid: row['Group UID'])).and_return(school_group)
+      allow(subject).to receive(:set_gias_data_as_json).with(school_group, row)
+    end
+
+    it 'calls set_gias_data_as_json' do
+      expect(subject).to receive(:set_gias_data_as_json).with(school_group, row)
+      subject.send(:convert_to_school_group, row)
+    end
+  end
+
+  context '#save_csv_file' do
+    let(:request_body) { 'Not found' }
+
+    before do
+      stub_request(:get, csv_url).to_return(body: request_body, status: request_status)
+    end
+
+    context 'csv file is unavailable' do
+      let(:request_status) { 404 }
+
+      it 'raises an HTTP error' do
+        expect { subject.send(:save_csv_file) }.to raise_error do
+          HTTParty::ResponseError.new('SchoolGroup CSV file not found.')
+        end
+      end
+    end
+
+    context 'an unexpected response is returned' do
+      let(:request_status) { 500 }
+
+      it 'raises an HTTP error' do
+        expect { subject.send(:save_csv_file) }.to raise_error do
+          HTTParty::ResponseError.new('Unexpected problem downloading SchoolGroup CSV file.')
+        end
+      end
+    end
+
+    context 'the request is OK' do
+      let(:request_status) { 200 }
+
+      before do
+        allow(File).to receive(:write).with(temp_file_location, request_body, hash_including(mode: 'wb'))
+      end
+
+      it 'opens a file' do
+        expect(File).to receive(:write).with(temp_file_location, request_body, hash_including(mode: 'wb'))
+        subject.send(:save_csv_file)
+      end
+    end
+  end
+end

--- a/spec/lib/import_school_group_data_spec.rb
+++ b/spec/lib/import_school_group_data_spec.rb
@@ -7,16 +7,11 @@ RSpec.describe ImportSchoolGroupData do
   let(:csv_url) { 'https://csv_endpoint.csv/magic_endpoint/test.csv' }
   let(:temp_file_location) { '/some_temporary_location/test.csv' }
 
-  let(:row) { { 'Group UID': uid } }
-  let(:school_group) { double('school_group') }
-  let(:uid) { 'test_uid' }
-
-  before do
-    stub_const("#{ImportSchoolGroupData}::CSV_URL", csv_url)
-    stub_const("#{ImportSchoolGroupData}::TEMP_CSV_FILE_LOCATION", temp_file_location)
-  end
-
   context '#convert_to_school_group' do
+    let(:row) { { 'Group UID': uid } }
+    let(:school_group) { double('school_group') }
+    let(:uid) { 'test_uid' }
+
     before do
       allow(SchoolGroup).to receive(:find_or_initialize_by).with(
         hash_including(uid: row['Group UID'])).and_return(school_group)
@@ -40,7 +35,7 @@ RSpec.describe ImportSchoolGroupData do
       let(:request_status) { 404 }
 
       it 'raises an HTTP error' do
-        expect { subject.send(:save_csv_file) }.to raise_error do
+        expect { subject.send(:save_csv_file, csv_url, temp_file_location) }.to raise_error do
           HTTParty::ResponseError.new('SchoolGroup CSV file not found.')
         end
       end
@@ -50,7 +45,7 @@ RSpec.describe ImportSchoolGroupData do
       let(:request_status) { 500 }
 
       it 'raises an HTTP error' do
-        expect { subject.send(:save_csv_file) }.to raise_error do
+        expect { subject.send(:save_csv_file, csv_url, temp_file_location) }.to raise_error do
           HTTParty::ResponseError.new('Unexpected problem downloading SchoolGroup CSV file.')
         end
       end
@@ -65,7 +60,7 @@ RSpec.describe ImportSchoolGroupData do
 
       it 'opens a file' do
         expect(File).to receive(:write).with(temp_file_location, request_body, hash_including(mode: 'wb'))
-        subject.send(:save_csv_file)
+        subject.send(:save_csv_file, csv_url, temp_file_location)
       end
     end
   end


### PR DESCRIPTION
This PR creates a daily job and task for importing SchoolGroup data into the database. 

The task downloads data from [two .csv files](https://get-information-schools.service.gov.uk/Downloads). `All group records` and `All group links records`. Currently the data retrieved is insufficient (due to a bug), however this has been raised with the GIAS team and should be resolved. 

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-684

## Changes in this PR
- Daily job that runs a task to parse .csv files from GIAS in order to create SchoolGroups and create SchoolGroupMembership relationships between Schools and SchoolGroups

## Next steps
- Implement methods/tasks to parse the GIAS data json for MATs and populate useful fields on SchoolGroup records
