### PR TITLE
Set the correct default sorting strategy per scenario

### DIFF
--- a/app/services/vacancy_algolia_alert_builder.rb
+++ b/app/services/vacancy_algolia_alert_builder.rb
@@ -13,11 +13,9 @@ class VacancyAlgoliaAlertBuilder < VacancyAlgoliaSearchBuilder
                          "expires_at_timestamp > #{expired_now_filter}"
     self.filter_array = []
 
-    self.sort_by = subscription_hash[:jobs_sort]
-
     build_subscription_filters(subscription_hash)
     build_search_filter
-
+    initialize_sort_by(subscription_hash[:jobs_sort])
     initialize_location(subscription_hash[:location_category], subscription_hash[:location], subscription_hash[:radius])
     initialize_search
   end

--- a/app/services/vacancy_algolia_search_builder.rb
+++ b/app/services/vacancy_algolia_search_builder.rb
@@ -20,10 +20,10 @@ class VacancyAlgoliaSearchBuilder
                          "publication_date_timestamp <= #{published_today_filter} AND "\
                          "expires_at_timestamp > #{expired_now_filter}"
 
-    self.sort_by = params[:jobs_sort] if valid_sort?(params[:jobs_sort])
     self.hits_per_page = params[:per_page] || DEFAULT_HITS_PER_PAGE
     self.page = params[:page]
 
+    initialize_sort_by(params[:jobs_sort])
     initialize_location(params[:location_category], params[:location], params[:radius])
     initialize_search
   end
@@ -110,6 +110,15 @@ class VacancyAlgoliaSearchBuilder
 
   def build_search_query
     self.search_query = [keyword, location_category].reject(&:blank?).join(' ')
+  end
+
+  def initialize_sort_by(jobs_sort_param)
+    # A blank `sort_by` results in a search on the main index, Vacancy.
+    if jobs_sort_param.blank? || !valid_sort?(jobs_sort_param)
+      self.sort_by = keyword.blank? ? 'publish_on_desc' : ''
+    else
+      self.sort_by = jobs_sort_param
+    end
   end
 
   def build_location_filter

--- a/spec/controllers/hiring_staff/identifications_controller_spec.rb
+++ b/spec/controllers/hiring_staff/identifications_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe HiringStaff::IdentificationsController, type: :controller do
   describe '#create' do
+    before { allow(AuthenticationFallback).to receive(:enabled?).and_return(false) }
     it 'redirects to DfE Sign in' do
       post :create
       expect(response).to redirect_to(new_dfe_path)

--- a/spec/controllers/hiring_staff/sign_in/dfe/sessions_controller_spec.rb
+++ b/spec/controllers/hiring_staff/sign_in/dfe/sessions_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe HiringStaff::SignIn::Dfe::SessionsController, type: :controller do
   describe '#new' do
+    before { allow(AuthenticationFallback).to receive(:enabled?).and_return(false) }
     it 'redirects to Dfe' do
       get :new
       expect(response).to redirect_to('/auth/dfe') # From here we trust Omniauth

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -121,6 +121,21 @@ RSpec.describe VacanciesController, type: :controller do
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql("Vacancy_#{sort}")
         end
       end
+
+      context 'when parameters do not include a keyword' do
+        let(:params) do
+          {
+            keyword: '',
+            location: 'Torquay',
+            jobs_sort: ''
+          }
+        end
+
+        it 'sets the search replica on VacancyAlgoliaSearchBuilder to the default sort strategy: newest listing' do
+          subject
+          expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql('Vacancy_publish_on_desc')
+        end
+      end
     end
 
     context 'feature flagging' do

--- a/spec/services/vacancy_algolia_search_builder_spec.rb
+++ b/spec/services/vacancy_algolia_search_builder_spec.rb
@@ -1,5 +1,17 @@
 require 'rails_helper'
 
+RSpec.shared_examples 'a search in the base Vacancy index' do
+  it 'does not use any search replica' do
+    expect(subject.search_replica).to be_nil
+  end
+end
+
+RSpec.shared_examples 'a search in the default search replica' do
+  it 'uses the default search replica' do
+    expect(subject.search_replica).to eql('Vacancy_publish_on_desc')
+  end
+end
+
 RSpec.describe VacancyAlgoliaSearchBuilder do
   subject { described_class.new(params) }
 
@@ -20,13 +32,9 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
     }
   end
 
-  context '#initialize' do
+  describe '#initialize' do
     context '#keyword' do
-      let(:params) do
-        {
-          keyword: keyword
-        }
-      end
+      let(:params) { { keyword: keyword } }
 
       it 'adds keyword to the search query' do
         expect(subject.search_query).to eql(keyword)
@@ -35,11 +43,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
 
     context '#location' do
       context 'location category specified' do
-        let(:params) do
-          {
-            location_category: location_category
-          }
-        end
+        let(:params) { { location_category: location_category } }
 
         it 'adds location to the search query and not the location filter' do
           expect(subject.search_query).to eql(location_category)
@@ -49,11 +53,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
 
       context 'location specified' do
         context 'no radius specified' do
-          let(:params) do
-            {
-              location: location
-            }
-          end
+          let(:params) { { location: location } }
 
           it 'carries out geographical search around a coordinate location with the default radius' do
             expect(subject.search_query).not_to include(location)
@@ -66,12 +66,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
 
         context 'radius specified' do
           let(:radius) { 30 }
-          let(:params) do
-            {
-              location: location,
-              radius: radius
-            }
-          end
+          let(:params) { { location: location, radius: radius } }
 
           it 'carries out geographical search around a coordinate location with the specified radius' do
             expect(subject.search_query).not_to include(location)
@@ -84,11 +79,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
       end
 
       context 'location specified that is also a location category' do
-        let(:params) do
-          {
-            location: location_category
-          }
-        end
+        let(:params) { { location: location_category } }
 
         it 'adds the location to the search query' do
           expect(subject.search_query).to eql(location_category)
@@ -97,56 +88,109 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
       end
     end
 
-    context '#sort' do
-      context 'no sort specified' do
-        let(:params) do
-          {}
+    describe '#sort' do
+      let(:keyword) { nil }
+      let(:jobs_sort) { nil }
+      let(:params) do
+        { keyword: keyword, location: location, jobs_sort: jobs_sort }
+      end
+
+      describe 'default sort strategies per scenario when no sort strategy is specified' do
+        context 'and a keyword is specified' do
+          let(:keyword) { 'maths teacher' }
+          context 'and a location is specified' do
+            it_behaves_like 'a search in the base Vacancy index'
+          end
+
+          context 'and a location is NOT specified' do
+            let(:location) { nil }
+            it_behaves_like 'a search in the base Vacancy index'
+          end
+
+          context 'and a location is NOT specified (empty string)' do
+            let(:location) { '' }
+            it_behaves_like 'a search in the base Vacancy index'
+          end
         end
 
-        it 'does not use a search replica' do
-          expect(subject.search_replica).to be_nil
+        context 'and a keyword is NOT specified' do
+          context 'and a location is specified' do
+            it_behaves_like 'a search in the default search replica'
+          end
+
+          context 'and a location is NOT specified' do
+            let(:location) { nil }
+            it_behaves_like 'a search in the default search replica'
+
+            context 'with jobs_sort param present but empty' do
+              let(:jobs_sort) { '' }
+              it_behaves_like 'a search in the default search replica'
+            end
+          end
+
+          context 'and a location is NOT specified (empty string)' do
+            let(:location) { '' }
+            it_behaves_like 'a search in the default search replica'
+
+            context 'with jobs_sort param present but empty' do
+              let(:jobs_sort) { '' }
+              it_behaves_like 'a search in the default search replica'
+            end
+          end
+        end
+
+        context 'and a keyword is NOT specified (empty string)' do
+          let(:keyword) { '' }
+          context 'and a location is specified' do
+            it_behaves_like 'a search in the default search replica'
+          end
+
+          context 'and a location is NOT specified' do
+            let(:location) { nil }
+            it_behaves_like 'a search in the default search replica'
+
+            context 'with jobs_sort param present but empty' do
+              let(:jobs_sort) { '' }
+              it_behaves_like 'a search in the default search replica'
+            end
+          end
+
+          context 'and a location is NOT specified (empty string)' do
+            let(:location) { '' }
+            it_behaves_like 'a search in the default search replica'
+
+            context 'with jobs_sort param present but empty' do
+              let(:jobs_sort) { '' }
+              it_behaves_like 'a search in the default search replica'
+            end
+          end
         end
       end
 
-      context 'default sort specified' do
-        let(:params) do
-          {
-            jobs_sort: ''
-          }
-        end
-
-        it 'does not use a search replica' do
-          expect(subject.search_replica).to be_nil
-        end
+      context 'when an invalid sort strategy is specified' do
+        let(:jobs_sort) { 'worst_listing' }
+        it_behaves_like 'a search in the default search replica'
       end
 
-      context 'invalid sort specified' do
-        let(:params) do
-          {
-            jobs_sort: 'bad_sort'
-          }
+      context 'when a valid non-default sort strategy is specified' do
+        let(:jobs_sort) { 'expiry_time_desc' }
+
+        it 'uses the specified search replica' do
+          expect(subject.search_replica).to eql('Vacancy_expiry_time_desc')
         end
 
-        it 'does not use a search replica' do
-          expect(subject.search_replica).to be_nil
-        end
-      end
+        context 'and a keyword is specified' do
+          let(:keyword) { 'maths teacher' }
 
-      context 'valid sort specified' do
-        let(:params) do
-          {
-            jobs_sort: 'publish_on_desc'
-          }
-        end
-
-        it 'uses the correct search replica' do
-          expect(subject.search_replica).to eql('Vacancy_publish_on_desc')
+          it 'uses the specified search replica' do
+            expect(subject.search_replica).to eql('Vacancy_expiry_time_desc')
+          end
         end
       end
     end
   end
 
-  context '#build_stats' do
+  describe '#build_stats' do
     let(:params) { {} }
     let(:page) { 0 }
     let(:pages) { 6 }
@@ -180,7 +224,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
     end
   end
 
-  context '#call' do
+  describe '#call' do
     let!(:expired_now) { Time.zone.now }
     let(:sort_by) { '' }
     let(:search_replica) { nil }

--- a/spec/services/vacancy_algolia_search_builder_spec.rb
+++ b/spec/services/vacancy_algolia_search_builder_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
       end
     end
 
-    describe '#sort' do
+    context 'sorting' do
       let(:keyword) { nil }
       let(:jobs_sort) { nil }
       let(:params) do

--- a/spec/services/vacancy_algolia_search_builder_spec.rb
+++ b/spec/services/vacancy_algolia_search_builder_spec.rb
@@ -90,76 +90,34 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
 
     context 'sorting' do
       let(:keyword) { nil }
-      let(:jobs_sort) { nil }
+      let(:jobs_sort) { '' }
       let(:params) do
         { keyword: keyword, location: location, jobs_sort: jobs_sort }
       end
 
-      describe 'default sort strategies per scenario when no sort strategy is specified' do
-        context 'and a keyword is specified' do
+      describe 'default sort strategies per scenario when: no sort strategy is specified,' do
+        context 'and a keyword is specified,' do
           let(:keyword) { 'maths teacher' }
-          context 'and a location is specified' do
+          context 'and a location is specified,' do
             it_behaves_like 'a search in the base Vacancy index'
           end
 
-          context 'and a location is NOT specified' do
+          context 'and a location is NOT specified,' do
             let(:location) { nil }
-            it_behaves_like 'a search in the base Vacancy index'
-          end
-
-          context 'and a location is NOT specified (empty string)' do
-            let(:location) { '' }
             it_behaves_like 'a search in the base Vacancy index'
           end
         end
 
-        context 'and a keyword is NOT specified' do
-          context 'and a location is specified' do
+        context 'and a keyword is NOT specified,' do
+          context 'and a location is specified,' do
             it_behaves_like 'a search in the default search replica'
           end
 
-          context 'and a location is NOT specified' do
+          context 'and a location is NOT specified,' do
             let(:location) { nil }
             it_behaves_like 'a search in the default search replica'
 
-            context 'with jobs_sort param present but empty' do
-              let(:jobs_sort) { '' }
-              it_behaves_like 'a search in the default search replica'
-            end
-          end
-
-          context 'and a location is NOT specified (empty string)' do
-            let(:location) { '' }
-            it_behaves_like 'a search in the default search replica'
-
-            context 'with jobs_sort param present but empty' do
-              let(:jobs_sort) { '' }
-              it_behaves_like 'a search in the default search replica'
-            end
-          end
-        end
-
-        context 'and a keyword is NOT specified (empty string)' do
-          let(:keyword) { '' }
-          context 'and a location is specified' do
-            it_behaves_like 'a search in the default search replica'
-          end
-
-          context 'and a location is NOT specified' do
-            let(:location) { nil }
-            it_behaves_like 'a search in the default search replica'
-
-            context 'with jobs_sort param present but empty' do
-              let(:jobs_sort) { '' }
-              it_behaves_like 'a search in the default search replica'
-            end
-          end
-
-          context 'and a location is NOT specified (empty string)' do
-            let(:location) { '' }
-            it_behaves_like 'a search in the default search replica'
-
-            context 'with jobs_sort param present but empty' do
+            context 'with jobs_sort param present but empty,' do
               let(:jobs_sort) { '' }
               it_behaves_like 'a search in the default search replica'
             end
@@ -167,19 +125,19 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
         end
       end
 
-      context 'when an invalid sort strategy is specified' do
+      context 'when an invalid sort strategy is specified,' do
         let(:jobs_sort) { 'worst_listing' }
         it_behaves_like 'a search in the default search replica'
       end
 
-      context 'when a valid non-default sort strategy is specified' do
+      context 'when a valid non-default sort strategy is specified,' do
         let(:jobs_sort) { 'expiry_time_desc' }
 
         it 'uses the specified search replica' do
           expect(subject.search_replica).to eql('Vacancy_expiry_time_desc')
         end
 
-        context 'and a keyword is specified' do
+        context 'and a keyword is specified,' do
           let(:keyword) { 'maths teacher' }
 
           it 'uses the specified search replica' do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-898

## Changes in this PR:

> Scenario A: If the user searches by keyword & location, we sort vacancies by most relevant
> 
> Scenario B: If the user searches by location only, we sort by newest job listing
> 
> Scenario C: If the user clicks search without entering search terms, we show them all vacancies, with the heading 'There are x jobs listed' and we sort by newest job listing
