### PR TITLE
Location suggestion spike

### DIFF
--- a/app/controllers/api/location_suggestion_controller.rb
+++ b/app/controllers/api/location_suggestion_controller.rb
@@ -3,7 +3,11 @@ class Api::LocationSuggestionController < Api::ApplicationController
   before_action :check_valid_params, only: %i[show]
 
   def show
-    suggestions, matched_terms = LocationSuggestion.new(location).suggest_locations
+    begin
+      suggestions, matched_terms = LocationSuggestion.new(location).suggest_locations
+    rescue HTTParty::ResponseError, LocationSuggestion::GooglePlacesAutocompleteError => e
+      return render(json: { error: e }, status: :bad_request)
+    end
 
     render json: {
       query: location,

--- a/app/controllers/api/location_suggestion_controller.rb
+++ b/app/controllers/api/location_suggestion_controller.rb
@@ -1,0 +1,25 @@
+class Api::LocationSuggestionController < Api::ApplicationController
+  before_action :verify_json_request, only: %i[show]
+  before_action :check_valid_params, only: %i[show]
+
+  def show
+    suggestions, matched_terms = LocationSuggestion.new(location).suggest_locations
+
+    render json: {
+      query: location,
+      suggestions: suggestions,
+      matched_terms: matched_terms
+    }
+  end
+
+  private
+
+  def location
+    params[:location]
+  end
+
+  def check_valid_params
+    return render(json: { error: 'Missing location input' }, status: :bad_request) if location.nil?
+    return render(json: { error: 'Insufficient location input' }, status: :bad_request) if location.length < 3
+  end
+end

--- a/app/services/location_suggestion.rb
+++ b/app/services/location_suggestion.rb
@@ -1,5 +1,6 @@
 class LocationSuggestion
   MINIMUM_LOCATION_INPUT_LENGTH = 3
+  NUMBER_OF_SUGGESTIONS = 5
 
   class InsufficientLocationInput < StandardError; end
   class MissingLocationInput < StandardError; end
@@ -14,11 +15,11 @@ class LocationSuggestion
   end
 
   def suggest_locations
-    predictions = get_suggestions_from_google['predictions'].take(5)
+    predictions = get_suggestions_from_google['predictions'].take(NUMBER_OF_SUGGESTIONS)
     suggestions = predictions.map { |prediction| prediction['description'] }
-    matched_terms = predictions.map {
+    matched_terms = predictions.map do
       |prediction| prediction['terms'].select { |term| term['offset'] == 0 }.map { |hit| hit['value'] }
-    }
+    end
     return suggestions, matched_terms
   end
 

--- a/app/services/location_suggestion.rb
+++ b/app/services/location_suggestion.rb
@@ -1,0 +1,49 @@
+class LocationSuggestion
+  MINIMUM_LOCATION_INPUT_LENGTH = 3
+
+  class InsufficientLocationInput < StandardError; end
+  class MissingLocationInput < StandardError; end
+  class GooglePlacesAutocompleteError < StandardError; end
+
+  attr_accessor :location_input
+
+  def initialize(location_input)
+    raise MissingLocationInput if location_input.nil?
+    raise InsufficientLocationInput if location_input.length < MINIMUM_LOCATION_INPUT_LENGTH
+    self.location_input = location_input
+  end
+
+  def suggest_locations
+    predictions = get_suggestions_from_google['predictions'].take(5)
+    suggestions = predictions.map { |prediction| prediction['description'] }
+    matched_terms = predictions.map {
+      |prediction| prediction['terms'].select { |term| term['offset'] == 0 }.map { |hit| hit['value'] }
+    }
+    return suggestions, matched_terms
+  end
+
+  private
+
+  def request_url
+    "https://maps.googleapis.com/maps/api/place/autocomplete/json?#{build_google_query.to_query}"
+  end
+
+  def get_suggestions_from_google
+    response = HTTParty.get(request_url)
+    raise HTTParty::ResponseError, 'Something went wrong' unless response.success?
+    parsed_response = JSON.parse(response.body)
+    raise GooglePlacesAutocompleteError, parsed_response['error_message'] if
+      parsed_response.keys.include?('error_message')
+    parsed_response
+  end
+
+  def build_google_query
+    {
+      key: GOOGLE_PLACES_AUTOCOMPLETE_KEY,
+      language: 'en',
+      input: location_input,
+      components: 'country:uk',
+      type: 'geocode'
+    }
+  end
+end

--- a/app/services/location_suggestion.rb
+++ b/app/services/location_suggestion.rb
@@ -20,7 +20,7 @@ class LocationSuggestion
     matched_terms = predictions.map do
       |prediction| prediction['terms'].select { |term| term['offset'] == 0 }.map { |hit| hit['value'] }
     end
-    return suggestions, matched_terms
+    [suggestions, matched_terms]
   end
 
   private

--- a/config/initializers/google_api.rb
+++ b/config/initializers/google_api.rb
@@ -2,6 +2,7 @@ require 'google/apis/indexing_v3'
 
 GOOGLE_API_JSON_KEY = ENV.fetch('GOOGLE_API_JSON_KEY', '')
 GOOGLE_ANALYTICS_PROFILE_ID = ENV.fetch('GOOGLE_ANALYTICS_PROFILE_ID', '')
+GOOGLE_PLACES_AUTOCOMPLETE_KEY = ENV.fetch('GOOGLE_PLACES_AUTOCOMPLETE_KEY', '')
 
 if GOOGLE_API_JSON_KEY.empty? || JSON.parse(GOOGLE_API_JSON_KEY).empty?
   return Rails.logger.info('***No GOOGLE_API_JSON_KEY set')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     scope 'v:api_version', api_version: /[1]/ do
       resources :jobs, only: %i[index show], controller: 'vacancies'
       get '/coordinates(/:location)', to: 'coordinates#show'
+      get '/location_suggestion(/:location)', to: 'location_suggestion#show'
     end
   end
 

--- a/spec/controllers/api/location_suggestion_controller_spec.rb
+++ b/spec/controllers/api/location_suggestion_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Api::LocationSuggestionController, type: :controller do
+  let(:json) { JSON.parse(response.body, symbolize_names: true) }
+  let(:location) { 'lo' }
+
+  before(:each, :json) do
+    request.accept = 'application/json'
+  end
+
+  describe 'GET /api/v1/location_suggestion/lon?format=html' do
+    it 'returns status :not_found as only JSON format is allowed' do
+      get :show, params: { api_version: 1, location: location }, format: :html
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'GET /api/v1/location_suggestion/lon?format=json', json: true do
+    context 'location is nil' do
+      it 'returns status :bad_request' do
+        get :show, params: { api_version: 1 }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(json[:error]).to eql('Missing location input')
+      end
+    end
+
+    context 'location is less than 3 characters long' do
+      it 'returns status :bad_request' do
+        get :show, params: { api_version: 1, location: location }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(json[:error]).to eql('Insufficient location input')
+      end
+    end
+
+    context 'location is 3 or more characters long' do
+      let(:location) { 'pla' }
+      let(:suggestions) { ['first playful place, UK', 'second place, UK'] }
+      let(:matched_terms) { [['playful', 'place'], ['place']] }
+
+      let(:location_suggestion) { double(LocationSuggestion) }
+
+      before do
+        allow(LocationSuggestion).to receive(:new).with(location).and_return(location_suggestion)
+        allow(location_suggestion).to receive(:suggest_locations).and_return([suggestions, matched_terms])
+      end
+
+      it 'returns status :ok' do
+        get :show, params: { api_version: 1, location: location }
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:query]).to eql(location)
+        expect(json[:suggestions]).to eql(suggestions)
+        expect(json[:matched_terms]).to eql(matched_terms)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/location_suggestion_controller_spec.rb
+++ b/spec/controllers/api/location_suggestion_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::LocationSuggestionController, type: :controller do
   let(:json) { JSON.parse(response.body, symbolize_names: true) }
-  let(:location) { 'lo' }
+  let(:location) { 'pla' }
 
   before(:each, :json) do
     request.accept = 'application/json'
@@ -17,6 +17,12 @@ RSpec.describe Api::LocationSuggestionController, type: :controller do
   end
 
   describe 'GET /api/v1/location_suggestion/lon?format=json', json: true do
+    let(:location_suggestion) { double(LocationSuggestion) }
+
+    before do
+      allow(LocationSuggestion).to receive(:new).with(location).and_return(location_suggestion)
+    end
+
     context 'location is nil' do
       it 'returns status :bad_request' do
         get :show, params: { api_version: 1 }
@@ -27,6 +33,8 @@ RSpec.describe Api::LocationSuggestionController, type: :controller do
     end
 
     context 'location is less than 3 characters long' do
+      let(:location) { 'pl' }
+
       it 'returns status :bad_request' do
         get :show, params: { api_version: 1, location: location }
 
@@ -36,14 +44,10 @@ RSpec.describe Api::LocationSuggestionController, type: :controller do
     end
 
     context 'location is 3 or more characters long' do
-      let(:location) { 'pla' }
       let(:suggestions) { ['first playful place, UK', 'second place, UK'] }
       let(:matched_terms) { [['playful', 'place'], ['place']] }
 
-      let(:location_suggestion) { double(LocationSuggestion) }
-
       before do
-        allow(LocationSuggestion).to receive(:new).with(location).and_return(location_suggestion)
         allow(location_suggestion).to receive(:suggest_locations).and_return([suggestions, matched_terms])
       end
 
@@ -54,6 +58,33 @@ RSpec.describe Api::LocationSuggestionController, type: :controller do
         expect(json[:query]).to eql(location)
         expect(json[:suggestions]).to eql(suggestions)
         expect(json[:matched_terms]).to eql(matched_terms)
+      end
+    end
+
+    context 'LocationSuggestion raises HTTParty::Response error' do
+      before do
+        allow(location_suggestion).to receive(:suggest_locations).and_raise(HTTParty::ResponseError, 'HTTP error')
+      end
+
+      it 'returns status :bad_request' do
+        get :show, params: { api_version: 1, location: location }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(json[:error]).to eql('HTTP error')
+      end
+    end
+
+    context 'LocationSuggestion raises GooglePlacesAutocompleteError' do
+      before do
+        allow(location_suggestion).to receive(:suggest_locations)
+          .and_raise(LocationSuggestion::GooglePlacesAutocompleteError, 'Google error')
+      end
+
+      it 'returns status :bad_request' do
+        get :show, params: { api_version: 1, location: location }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(json[:error]).to eql('Google error')
       end
     end
   end

--- a/spec/services/location_suggestion_spec.rb
+++ b/spec/services/location_suggestion_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe LocationSuggestion do
+  subject { described_class.new(location_input) }
+
+  let(:location_input) { 'plac' }
+
+  context '#initialize' do
+    it 'raises MissingLocationInput error when called with nil location_input' do
+      expect { described_class.new(nil) }.to raise_error(described_class::MissingLocationInput)
+    end
+
+    it 'raises InsufficientLocationInput error when called with location_input less than 3 characters' do
+      expect { described_class.new('l') }.to raise_error(described_class::InsufficientLocationInput)
+    end
+  end
+
+  context '#get_suggestions_from_google' do
+    let(:predictions) { [] }
+    let(:request_body) { { 'predictions': predictions }.to_json }
+    let(:request_status) { 200 }
+    let(:request_url) { 'https://google_endpoint.google/magic_endpoint' }
+    let(:query_hash) { { key: 'test_key', input: location_input } }
+
+    before do
+      allow(subject).to receive(:request_url).and_return(request_url)
+      allow(subject).to receive(:build_google_query).and_return(query_hash)
+      stub_request(:get, request_url).to_return(body: request_body, status: request_status)
+    end
+
+    context 'the request is unsuccessful' do
+      let(:request_status) { 400 }
+
+      it 'raises a HTTParty::ResponseError' do
+        expect { subject.send(:get_suggestions_from_google) }.to raise_error do
+          HTTParty::ResponseError.new('Something went wrong')
+        end
+      end
+    end
+
+    context 'the response contains an error message' do
+      let(:error_message) { 'This is an error' }
+      let(:request_body) { { 'error_message': error_message }.to_json }
+
+      it 'raises a GooglePlacesAutocompleteError' do
+        expect { subject.send(:get_suggestions_from_google) }.to raise_error do
+          described_class::GooglePlacesAutocompleteError.new('Something went wrong')
+        end
+      end
+    end
+
+    context 'the request is successful' do
+      it 'returns the correct response' do
+        expect(subject.send(:get_suggestions_from_google)).to eql(JSON.parse(request_body))
+      end
+    end
+  end
+
+  context '#suggestion_locations' do
+    let(:parsed_response) { { 'predictions': predictions }.deep_stringify_keys }
+    let(:predictions) { [
+      { 'description': 'place, UK',
+        'terms': [{ 'offset': 0, 'value': 'place' }, { 'offset': 5, 'value': 'UK' }] },
+      { 'description': 'different_place, UK',
+        'terms': [{ 'offset': 0, 'value': 'different_place' }, { 'offset': 5, 'value': 'UK' }] }
+    ] }
+
+    let(:suggestions) { ['place, UK', 'different_place, UK'] }
+    let(:matched_terms) { [['place'], ['different_place']] }
+
+    before do
+      allow(subject).to receive(:get_suggestions_from_google).and_return(parsed_response)
+    end
+
+    it 'returns the parsed data' do
+      expect(subject.suggest_locations).to eql([suggestions, matched_terms])
+    end
+  end
+end


### PR DESCRIPTION
This PR is an outcome of the spike, and implements an API endpoint that returns location autocomplete suggestions using the Google Places Autocomplete API.

The matched terms are returned as well as the location description, since the matched term will probably be useful when carrying out location search on the user selection. 

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-924

## Changes in this PR
- Add location suggestion service
- Add location suggestion endpoint

## Next steps
- Set up a production API key
- Use this API in the frontend to render suggestions and subsequently pass them to search
