### PR TITLE
Disable verification of authenticity token

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -2,6 +2,7 @@ class SubscriptionsController < ApplicationController
   include ParameterSanitiser
 
   before_action :check_email_alerts_feature_flag, except: :unsubscribe
+  skip_before_action :verify_authenticity_token, only: :create
 
   def new
     subscription = Subscription.new(search_criteria: search_criteria_params.to_json)


### PR DESCRIPTION
Some users submit the email alert subscription form with a new session
Probably because they close and reopen the browser. We can disable that
check because we already use the captcha verification on that page

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-881
