### PR TITLE
Replace obsolete anchor 'vacancy-results' with 'job-count'

### DIFF
--- a/app/frontend/src/lib/utils.test.js
+++ b/app/frontend/src/lib/utils.test.js
@@ -7,17 +7,17 @@ describe('constructNewUrlWithParams', () => {
     expect(constructNewUrlWithParam(
       'location',
       's',
-      'https://jobs?radius=20&location=&job_title=#vacancy-results',
+      'https://jobs?radius=20&location=&job_title=#job-count',
     )).toBe(
-      'https://jobs?radius=20&location=s&job_title=#vacancy-results',
+      'https://jobs?radius=20&location=s&job_title=#job-count',
     );
 
     expect(constructNewUrlWithParam(
       'location',
       'so',
-      'https://jobs?radius=20&location=s&job_title=#vacancy-results',
+      'https://jobs?radius=20&location=s&job_title=#job-count',
     )).toBe(
-      'https://jobs?radius=20&location=so&job_title=#vacancy-results',
+      'https://jobs?radius=20&location=so&job_title=#job-count',
     );
   });
 });
@@ -74,7 +74,7 @@ describe('convertEpochToUnixTimestamp', () => {
 
 describe('extractQueryParams', () => {
   test('extracts specified query parameters as object of key values from a url string', () => {
-    const url = '/jobs?utf8=%E2%9C%93&keyword=physics&location=london&jobs_sort=&commit=Search#vacancy-results';
+    const url = '/jobs?utf8=%E2%9C%93&keyword=physics&location=london&jobs_sort=&commit=Search#job-count';
     expect(extractQueryParams(url, ['keyword', 'location'])).toStrictEqual({ keyword: 'physics', location: 'london' });
     expect(extractQueryParams(url, ['keyword', 'place'])).toStrictEqual({ keyword: 'physics' });
   });

--- a/app/frontend/src/search/ui/alert.test.js
+++ b/app/frontend/src/search/ui/alert.test.js
@@ -7,7 +7,7 @@ describe('getJobAlertLink', () => {
     <option value="50">50 miles</option>
 </select>`;
 
-    resultsUrl = 'jobs?utf8=✓&keyword=&location=harlow&commit=Search#vacancy-results';
+    resultsUrl = 'jobs?utf8=✓&keyword=&location=harlow&commit=Search#job-count';
 
     expect(getJobAlertLink(resultsUrl))
       .toBe('/subscriptions/new?search_criteria%5Blocation%5D=harlow&search_criteria%5Bradius%5D=10&');
@@ -19,7 +19,7 @@ describe('getJobAlertLink', () => {
     document.body.innerHTML = `<select name="radius" id="radius"><option value="10">10 mile</option>
       <option value="50">50 miles</option>
   </select>`;
-    resultsUrl = 'jobs?utf8=✓&keyword=teacher&location=london&commit=Search#vacancy-results';
+    resultsUrl = 'jobs?utf8=✓&keyword=teacher&location=london&commit=Search#job-count';
     expect(getJobAlertLink(resultsUrl))
       .toBe('/subscriptions/new?search_criteria%5Bkeyword%5D=teacher&search_criteria%5Blocation%5D=london&search_criteria%5Blocation_category%5D=london&');
 

--- a/app/views/pages/home/_search.html.haml
+++ b/app/views/pages/home/_search.html.haml
@@ -1,6 +1,6 @@
 %h1.govuk-heading-m= t('jobs.heading')
 
-= form_for VacancyAlgoliaSearchBuilder.new({}), as: '', url: jobs_path(anchor: 'vacancy-results'), method: :get do |f|
+= form_for VacancyAlgoliaSearchBuilder.new({}), as: '', url: jobs_path(anchor: 'job-count'), method: :get do |f|
 
   = f.govuk_text_field :keyword,
     label: { text: t('jobs.filters.keyword'), size: 's' },

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -2,7 +2,7 @@
   %h2.govuk-heading-m
     =t('jobs.filters.title')
 
-  = form_tag jobs_path(anchor: 'vacancy-results'), class: 'filters-form', role: 'search', method: :get do
+  = form_tag jobs_path(anchor: 'job-count'), class: 'filters-form', role: 'search', method: :get do
     .govuk-form-group#keyword-search
       = label_tag 'keyword', t('jobs.filters.keyword'), class: 'govuk-label'
       = search_field_tag :keyword, @vacancies_search.keyword, class: 'govuk-input', placeholder: t('jobs.filters.keyword_hint')


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-810

## Changes in this PR:

This is to ensure that on committing a search, the page is anchored to the h1 with id=job-count. This helps improve the experience for users reading the site with a screenreader/voiceover (see ticket).

Is there another way to fix the accessibility issue which doesn't require the page to be anchored?