### PR TITLE
mobile Safari Current location fix

### DIFF
--- a/app/frontend/src/lib/currentLocation.js
+++ b/app/frontend/src/lib/currentLocation.js
@@ -36,7 +36,7 @@ export const showLocationLink = (container) => {
 };
 
 export const showErrorMessage = (link) => {
-  if (!document.getElementsByClassName('js-location-finder__link .govuk-error-message')[0]) {
+  if (!document.querySelector('.js-location-finder__link .govuk-error-message')) {
     const errorMessage = document.createElement('div');
     errorMessage.classList.add('govuk-error-message');
     errorMessage.classList.add('govuk-!-margin-top-2');
@@ -46,8 +46,8 @@ export const showErrorMessage = (link) => {
 };
 
 export const removeErrorMessage = () => {
-  if (document.getElementsByClassName('js-location-finder__link .govuk-error-message')[0]) {
-    document.getElementsByClassName('js-location-finder__link .govuk-error-message')[0].remove();
+  if (document.querySelector('.js-location-finder__link .govuk-error-message')) {
+    document.querySelector('.js-location-finder__link .govuk-error-message').remove();
   }
 };
 
@@ -82,7 +82,10 @@ export const init = () => {
 
     navigator.geolocation.getCurrentPosition((data) => {
       postcodeFromPosition(data, getPostcodeFromCoordinates);
-    }, stopLoading);
+    }, () => {
+      stopLoading(containerEl, inputEl);
+      showErrorMessage(document.getElementById('current-location'));
+    });
   });
 
   inputEl.addEventListener('focus', () => {

--- a/app/frontend/src/lib/currentLocation.js
+++ b/app/frontend/src/lib/currentLocation.js
@@ -8,6 +8,9 @@ import Rollbar from './logging';
 
 const loader = new GOVUK.Loader();
 
+const containerEl = document.getElementsByClassName('js-location-finder')[0];
+const inputEl = document.getElementsByClassName('js-location-finder__input')[0];
+
 export const ERROR_MESSAGE = 'Unable to find your location';
 export const LOGGING_MESSAGE = '[Module: currentLocation]: Unable to find user location';
 
@@ -33,7 +36,7 @@ export const showLocationLink = (container) => {
 };
 
 export const showErrorMessage = (link) => {
-  if (!document.querySelector('.js-location-finder__link .govuk-error-message')) {
+  if (!document.getElementsByClassName('js-location-finder__link .govuk-error-message')[0]) {
     const errorMessage = document.createElement('div');
     errorMessage.classList.add('govuk-error-message');
     errorMessage.classList.add('govuk-!-margin-top-2');
@@ -43,21 +46,21 @@ export const showErrorMessage = (link) => {
 };
 
 export const removeErrorMessage = () => {
-  if (document.querySelector('.js-location-finder__link .govuk-error-message')) {
-    document.querySelector('.js-location-finder__link .govuk-error-message').remove();
+  if (document.getElementsByClassName('js-location-finder__link .govuk-error-message')[0]) {
+    document.getElementsByClassName('js-location-finder__link .govuk-error-message')[0].remove();
   }
 };
 
 export const onSuccess = (postcode, element) => {
   element.value = postcode;
   enableRadiusSelect();
-  currentLocation.stopLoading(document.querySelector('.js-location-finder'), document.querySelector('.js-location-finder__input'));
+  currentLocation.stopLoading(containerEl, inputEl);
 };
 
 export const onFailiure = () => {
   currentLocation.showErrorMessage(document.getElementById('current-location'));
   disableRadiusSelect();
-  currentLocation.stopLoading(document.querySelector('.js-location-finder'), document.querySelector('.js-location-finder__input'));
+  currentLocation.stopLoading(containerEl, inputEl);
   Rollbar.log(LOGGING_MESSAGE);
 };
 
@@ -75,14 +78,14 @@ export const init = () => {
   document.getElementById('current-location').addEventListener('click', (event) => {
     event.stopPropagation();
 
-    startLoading(document.querySelector('.js-location-finder'), document.querySelector('.js-location-finder__input'));
+    startLoading(containerEl, inputEl);
 
     navigator.geolocation.getCurrentPosition((data) => {
       postcodeFromPosition(data, getPostcodeFromCoordinates);
     }, stopLoading);
   });
 
-  document.querySelector('.js-location-finder__input').addEventListener('focus', () => {
+  inputEl.addEventListener('focus', () => {
     removeErrorMessage();
   });
 };
@@ -97,8 +100,8 @@ const currentLocation = {
 export default currentLocation;
 
 window.addEventListener('DOMContentLoaded', () => {
-  if (navigator.geolocation && document.querySelector('.js-location-finder')) {
-      showLocationLink(document.querySelector('.js-location-finder'));
+  if (navigator.geolocation && containerEl) {
+      showLocationLink(containerEl);
       init();
   }
 });


### PR DESCRIPTION
mobile safari requires that a user manually enable geolocation before it will ask for permission for a particular website and the current error handler wouldnt have caught that scenario.

https://dfedigital.atlassian.net/browse/TEVA-962
