### PR TITLE
Restore CSRF protection for job alert form

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -2,7 +2,6 @@ class SubscriptionsController < ApplicationController
   include ParameterSanitiser
 
   before_action :check_email_alerts_feature_flag, except: :unsubscribe
-  skip_before_action :verify_authenticity_token, only: :create
 
   def new
     subscription = Subscription.new(search_criteria: search_criteria_params.to_json)


### PR DESCRIPTION
This introduces an attack vector that is riskier than running with the current bug (TEVA-881). I am overriding this release and will investigate the cause in more detail. A quick glance at Stack Overflow suggests a few different ways this might be dealt with without disabling CSRF protection on our busiest form.

Details of CSRF are available: [here](https://guides.rubyonrails.org/security.html#cross-site-request-forgery-csrf), [here](https://owasp.org/www-community/attacks/csrf), and [here](https://owasp.org/www-community/attacks/csrf)