### PR TITLE
Extend session cookie to work around CSRF issue

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,2 +1,3 @@
 Rails.application.config.session_store :active_record_store,
-                                       key: '_teachingvacancies_session'
+                                       key: '_teachingvacancies_session',
+                                       expire_after: 2.weeks


### PR DESCRIPTION
Some browsers have a behaviour where although they will delete a session
cookie when the app is shutdown, they will still serve a cached version
of the page on relaunch. This causes issues with CSRF protection as it
relies on the token embedded in the page/form matching the token in the
session cookie. So a user that then submits the form will get a 422
error (`ActionController::InvalidAuthenticityToken`) because their is
nothing in the session. We get around this by giving the session cookie
a life beyond the browser session.

See https://github.com/DFE-Digital/claim-additional-payments-for-teaching/commit/613320f028b075b430315c364a9bc34431dabe35

and rails/rails#21948 for further details on
the issue.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-881
