### PR TITLE
Optional job role

### DIFF
--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -28,10 +28,8 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
   end
 
   def copy_form_params
-    strip_empty_checkboxes(:copy_vacancy_form, [:job_roles])
     params.require(:copy_vacancy_form).permit(:state, :job_title, :about_school,
                                               :publish_on, :expires_on, :starts_on,
-                                              :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem,
-                                              job_roles: [])
+                                              :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem)
   end
 end

--- a/app/form_models/copy_vacancy_form.rb
+++ b/app/form_models/copy_vacancy_form.rb
@@ -20,7 +20,6 @@ class CopyVacancyForm < VacancyForm
     self.vacancy.status = 'draft'
 
     self.job_title = vacancy.job_title
-    self.job_roles = vacancy.job_roles
     self.about_school = vacancy.about_school
     self.publish_on = nil if vacancy.publish_on.past?
 

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -45,7 +45,7 @@ module VacanciesHelper
 
   def new_sections(vacancy)
     sections = []
-    sections << 'job_details' unless vacancy.job_roles&.any? && !missing_subjects?(vacancy)
+    sections << 'job_details' if missing_subjects?(vacancy)
     sections << 'supporting_documents' unless vacancy.supporting_documents
     sections
   end

--- a/app/models/concerns/vacancy_copy_validations.rb
+++ b/app/models/concerns/vacancy_copy_validations.rb
@@ -7,8 +7,6 @@ module VacancyCopyValidations
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
     validate :job_title_has_no_tags?, if: :job_title?
 
-    validates :job_roles, presence: true
-
     validates :about_school, presence: true
 
     validate :publish_on_must_not_be_before_today

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -7,8 +7,6 @@ module VacancyJobSpecificationValidations
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
     validate :job_title_has_no_tags?, if: :job_title?
 
-    validates :job_roles, presence: true
-
     validates :working_patterns, presence: true
   end
 

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -24,14 +24,6 @@
         %span#copy_form_job_title-info.govuk-hint.govuk-character-count__message{ "aria-live": "polite" }
           You can enter up to 100 characters
 
-      - unless @vacancy.job_roles.present?
-        = f.govuk_collection_check_boxes :job_roles,
-          job_role_options,
-          :itself,
-          :itself,
-          legend: { text: t('helpers.fieldset.job_specification_form.job_roles_html') },
-          hint_text: t('helpers.hint.job_specification_form.job_roles')
-
       - unless @vacancy.about_school.present?
         = f.govuk_text_area :about_school,
           label: { text: t('helpers.fieldset.job_summary_form.about_school_html', school: current_school.name), size: 's' },

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -15,7 +15,7 @@
   .app-check-your-answers__contents
     %dt.app-check-your-answers__question#job_roles
       %h4.govuk-heading-s= t('jobs.job_roles')
-    %dd.app-check-your-answers__answer= @vacancy.show_job_roles
+    %dd.app-check-your-answers__answer= @vacancy.show_job_roles.presence || t('jobs.not_defined')
 
   .app-check-your-answers__contents
     %dt.app-check-your-answers__question#subjects

--- a/app/views/hiring_staff/vacancies/job_specification/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/show.html.haml
@@ -32,7 +32,7 @@
         job_role_options,
         :itself,
         :itself,
-        legend: { text: t('helpers.fieldset.job_specification_form.job_roles_html') },
+        legend: { text: t('helpers.fieldset.job_specification_form.job_roles') },
         hint_text: t('helpers.hint.job_specification_form.job_roles')
 
       = f.govuk_fieldset legend: { text: t('helpers.fieldset.job_specification_form.subjects') } do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,7 +118,7 @@ en:
         starts_on: "Date job starts"
       job_specification_form:
         job_title_html: "Job title (<span class='text-red'>Required</span>)"
-        job_roles_html: "Job role (<span class='text-red'>Required</span>)"
+        job_roles: Job role
         subjects: Subject(s)
         working_pattern_html: "Working patterns (<span class='text-red'>Required</span>)"
       pay_package_form:

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+
 RSpec.feature 'Copying a vacancy' do
   let(:school) { create(:school) }
 
@@ -182,43 +183,6 @@ RSpec.feature 'Copying a vacancy' do
 
       click_on I18n.t('buttons.save_and_continue')
       expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.invalid'))
-    end
-  end
-
-  context '#job_roles' do
-    context 'when a copied job has no job role set' do
-      scenario 'it shows the job role field' do
-        original_vacancy = build(:vacancy, :past_publish, job_roles: nil, school: school)
-        original_vacancy.save(validate: false)
-
-        visit school_path
-
-        within('table.vacancies') do
-          click_on I18n.t('jobs.copy_link')
-        end
-
-        within('h1.govuk-heading-m') do
-          expect(page).to have_content(I18n.t('jobs.copy_job_title', job_title: original_vacancy.job_title))
-        end
-        expect(page).to have_content(I18n.t('jobs.job_roles'))
-      end
-    end
-
-    context 'when a copied job has job role set' do
-      scenario 'it does not show the job role field' do
-        original_vacancy = create(:vacancy, school: school)
-
-        visit school_path
-
-        within('table.vacancies') do
-          click_on I18n.t('jobs.copy_link')
-        end
-
-        within('h1.govuk-heading-m') do
-          expect(page).to have_content(I18n.t('jobs.copy_job_title', job_title: original_vacancy.job_title))
-        end
-        expect(page).to_not have_content(I18n.t('jobs.job_roles'))
-      end
     end
   end
 

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -95,28 +95,6 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         expect(page).to have_content('Assistant Head Teacher')
       end
 
-      scenario 'can edit job role for a legacy vacancy' do
-        # rubocop:disable Rails/SkipsModelValidations
-        vacancy.update_columns(job_roles: [])
-        # rubocop:enable Rails/SkipsModelValidations
-
-        visit edit_school_job_path(vacancy.id)
-
-        expect(page).to have_content(I18n.t('jobs.job_details'))
-        expect(page).to have_content(I18n.t('messages.jobs.new_sections.message'))
-        expect(page).to have_selector('.new-job_details')
-
-        click_header_link(I18n.t('jobs.job_details'))
-
-        fill_in_job_specification_form_fields(vacancy)
-
-        click_on I18n.t('buttons.update_job')
-
-        expect(page).to have_content(I18n.t('jobs.job_details'))
-        expect(page).to_not have_selector('.new-job_details')
-        expect(page).to_not have_content(I18n.t('messages.jobs.new_sections.message'))
-      end
-
       scenario 'ensures the vacancy slug is updated when the title is saved' do
         vacancy = create(:vacancy, :published, slug: 'the-vacancy-slug', school: school)
         visit edit_school_job_path(vacancy.id)

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'Creating a vacancy' do
 
         click_on I18n.t('buttons.save_and_continue')
 
-        mandatory_fields = %w[job_title job_roles working_patterns]
+        mandatory_fields = %w[job_title working_patterns]
 
         within('.govuk-error-summary') do
           expect(page).to have_content(I18n.t('jobs.errors_present'))

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -36,11 +36,6 @@ RSpec.describe VacanciesHelper, type: :helper do
       expect(helper.new_sections(vacancy)).to include('supporting_documents')
     end
 
-    it 'includes job_details for legacy listings with job_roles as nil' do
-      allow(vacancy).to receive_message_chain(:job_roles, :any?).and_return(false)
-      expect(helper.new_sections(vacancy)).to include('job_details')
-    end
-
     it 'includes job_details for legacy listings with missing subjects' do
       allow(helper).to receive(:missing_subjects?).with(vacancy).and_return(true)
       expect(helper.new_sections(vacancy)).to include('job_details')

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe Vacancy, type: :model do
   describe 'validations' do
     context 'a new record' do
       it { should validate_presence_of(:job_title) }
-      it { should validate_presence_of(:job_roles) }
       it { should validate_presence_of(:job_summary) }
       it { should validate_presence_of(:working_patterns) }
       it { should validate_presence_of(:salary) }


### PR DESCRIPTION
This PR makes the job roles field optional. 

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-752

## Changes in this PR
- Job role is an optional field in the job details section
- Job role field is never shown when copying a vacancy
- New sections message is not displayed when jobs don't have a job role set
