### PR TITLE
replace env.GITHUB_SHA with github.sha in docker push step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
- DOCKERHUB_REPOSITORY: 'dfedigital/teaching-vacancies'
+ DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
 
 jobs:
   build_image:
@@ -28,7 +28,7 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ env.DOCKERHUB_REPOSITORY }}
-        tags: ${{ env.GITHUB_SHA }}
+        tags: ${{ github.sha }}
         target: production
 
   deploy_production:
@@ -48,6 +48,7 @@ jobs:
         sudo cp /tmp/cf7 /usr/local/bin/cf7
 
     - name: Deploy to production
+      if: github.ref == 'refs/heads/master'
       env:
         CF_USERNAME: ${{ secrets.CF_USERNAME }}
         CF_PASSWORD: ${{ secrets.CF_PASSWORD }}


### PR DESCRIPTION
${{ env.GITHUB_SHA }} is not populated, will have to use ${{ github.sha}}

Also keeping ```if: github.ref == 'refs/heads/master'``` in 
`Deploy to production task` to avoid adding it every time pipeline changes are tested.