### PR TITLE
Run app without algolia env variables

### DIFF
--- a/config/initializers/algoliasearch.rb
+++ b/config/initializers/algoliasearch.rb
@@ -10,12 +10,14 @@ See main README.md for instructions how to create new dev indexes.
   end
 end
 
-if !Rails.env.production? && ENV.fetch('ALGOLIA_APP_ID') == ALGOLIA_PRODUCTION_APP_ID
+if !Rails.env.production? && ENV['ALGOLIA_APP_ID'] == ALGOLIA_PRODUCTION_APP_ID
   raise AlgoliaEnvironmentError.new
 end
 
-AlgoliaSearch.configuration = {
-  application_id: ENV.fetch('ALGOLIA_APP_ID'),
-  api_key: ENV.fetch('ALGOLIA_WRITE_API_KEY'),
-  pagination_backend: :kaminari
-}
+if ENV['ALGOLIA_APP_ID']
+  AlgoliaSearch.configuration = {
+    application_id: ENV['ALGOLIA_APP_ID'],
+    api_key: ENV['ALGOLIA_WRITE_API_KEY'],
+    pagination_backend: :kaminari
+  }
+end


### PR DESCRIPTION

## Changes in this PR:
Rake tasks may not require access to algolia so make the environment variables optional

## How to review
Run docker build