### PR TITLE
Use GDS Formbuilder in search filters form

### DIFF
--- a/app/frontend/src/lib/currentLocation.js
+++ b/app/frontend/src/lib/currentLocation.js
@@ -57,7 +57,7 @@ export const onSuccess = (postcode, element) => {
   currentLocation.stopLoading(containerEl, inputEl);
 };
 
-export const onFailiure = () => {
+export const onFailure = () => {
   currentLocation.showErrorMessage(document.getElementById('current-location'));
   disableRadiusSelect();
   currentLocation.stopLoading(containerEl, inputEl);
@@ -68,10 +68,10 @@ export const postcodeFromPosition = (position, apiPromise) => apiPromise(positio
   if (response && response.result) {
     onSuccess(response.result[0].postcode, document.getElementById('location'));
   } else {
-    onFailiure();
+    onFailure();
   }
 }).catch(() => {
-  onFailiure();
+  onFailure();
 });
 
 export const init = () => {

--- a/app/frontend/src/lib/currentLocation.test.js
+++ b/app/frontend/src/lib/currentLocation.test.js
@@ -1,5 +1,5 @@
 import currentLocation, {
-  onSuccess, onFailiure, showErrorMessage, ERROR_MESSAGE, postcodeFromPosition,
+  onSuccess, onFailure, showErrorMessage, ERROR_MESSAGE, postcodeFromPosition,
 } from './currentLocation';
 import radius from '../search/ui/input/radius';
 
@@ -8,7 +8,7 @@ jest.mock('../search/ui/input/radius');
 describe('location search box', () => {
   let showErrorMessageMock = null; let stopLoadingMock = null; let enableRadiusMock = null; let
     disableRadiusMock = null; let onSuccessMock = null; let
-    onFailiureMock = null;
+    onFailureMock = null;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -27,7 +27,7 @@ describe('location search box', () => {
 
   describe('onFaliure', () => {
     test('updates the UI correctly and adds error message', () => {
-      onFailiure();
+      onFailure();
       expect(document.getElementById('location').value).toBe('');
       expect(disableRadiusMock).toHaveBeenCalled();
       expect(stopLoadingMock).toHaveBeenCalled();
@@ -63,8 +63,8 @@ describe('location search box', () => {
       currentLocation.onSuccess = jest.fn();
       onSuccessMock = jest.spyOn(currentLocation, 'onSuccess');
 
-      currentLocation.onFailiure = jest.fn();
-      onFailiureMock = jest.spyOn(currentLocation, 'onFailiure');
+      currentLocation.onFailure = jest.fn();
+      onFailureMock = jest.spyOn(currentLocation, 'onFailure');
     });
 
     test('calls onSuccess handler when API returns postcode', () => {
@@ -80,7 +80,7 @@ describe('location search box', () => {
         });
     });
 
-    test('calls onFailiure handler when API returns falsy value', () => {
+    test('calls onFailure handler when API returns falsy value', () => {
       postcodeFromPosition({
         coords: {
           latitude: 10,

--- a/app/frontend/src/search/ui/input/keyword.js
+++ b/app/frontend/src/search/ui/input/keyword.js
@@ -3,4 +3,4 @@ export const onSubmit = (client) => {
   client.refresh();
 };
 
-export const getKeyword = () => document.querySelector('#keyword').value;
+export const getKeyword = () => document.querySelector('#keyword-field').value;

--- a/app/frontend/src/search/ui/input/keyword.test.js
+++ b/app/frontend/src/search/ui/input/keyword.test.js
@@ -23,7 +23,7 @@ describe('keyword search box', () => {
 
   describe('getKeyword', () => {
     test('to return a string from input box', () => {
-      document.body.innerHTML = '<input id="keyword" />';
+      document.body.innerHTML = '<input id="keyword-field" />';
       expect(typeof getKeyword()).toBe('string');
     });
   });

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -2,17 +2,24 @@
   %h2.govuk-heading-m
     =t('jobs.filters.title')
 
-  = form_tag jobs_path(anchor: 'vacancy-results'), class: 'filters-form', role: 'search', method: :get do
-    .govuk-form-group#keyword-search
-      = label_tag 'keyword', t('jobs.filters.keyword'), class: 'govuk-label'
-      = search_field_tag :keyword, @vacancies_search.keyword, class: 'govuk-input', placeholder: t('jobs.filters.keyword_hint')
+  = form_for VacancyAlgoliaSearchBuilder.new({}), as: '', url: jobs_path, method: :get, html: { class: 'filters-form', role: 'search' } do |f|
+    = f.govuk_text_field :keyword,
+      label: { text: t('jobs.filters.keyword') },
+      placeholder: t('jobs.filters.keyword_hint'),
+      value: @vacancies_search.keyword
 
+    // This partial does not yet use GDS Formbuilder.
     = render 'shared/location_search_tag', extra_label_class: nil
 
+    // This select does not yet use GDS Formbuilder.
+    // We are currently unable to apply attributes (such as class
+    // and disabled) directly to GovUK Design Formbuilder select elements.
+    // Issue: https://github.com/DFE-Digital/govuk_design_system_formbuilder/issues/153
+    // I have added a draft of the eventual code to this issue.
     .govuk-form-group.govuk-inset-text#location-radius-select
       = label_tag 'radius', t('jobs.filters.within_radius'), class: 'govuk-label'
       = select_tag 'radius', options_for_select(radius_filter_options, @vacancies_search.radius), disabled: @vacancies_search.disable_radius?, class: 'govuk-select govuk-!-width-full'
 
-    = hidden_field_tag :jobs_sort, @vacancies_search.sort_by
+    = f.hidden_field :jobs_sort, value: @vacancies_search.sort_by
 
-    = submit_tag t('buttons.search'), class: 'govuk-button mb0 govuk-!-width-full'
+    = f.govuk_submit t('buttons.search'), classes: 'govuk-button mb0 govuk-!-width-full'

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
 
           click_on 'Return to your search results'
 
-          expect(page.find('#keyword').value).to eq('teacher')
+          expect(page.find_field('keyword-field').value).to eq('teacher')
         end
       end
     end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-960

## Changes in this PR:

- Use GDS Formbuilder where possible on the search filters form, in order to make use of the prevent_double_click option.
