### PR TITLE
Alert channel actively on smoke test failure

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -50,5 +50,5 @@ jobs:
           SLACK_CHANNEL: twd_tv_dev
           SLACK_USERNAME: Smoke Test
           SLACK_TITLE: Smoke test failed
-          SLACK_MESSAGE: 'Production website smoke test has failed :cry:'
+          SLACK_MESSAGE: 'Production website smoke test has failed :cry: @channel'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
- Add `@channel` to smoke test failure message. I'm worried that if production is down it will take us a while to actually notice, because who honestly reads the `twd_tv_dev` channel?

Pros: we notice that production is down a lot sooner.

Cons: if production is down for 3 hours, we each get 3*(60/5) = 36 Slack notifications each. But if it comes to that, you can mute Slack channels.
