### PR TITLE
correct autocomplete a11y as options should not be tabbable

### DIFF
--- a/app/frontend/src/lib/autocomplete.view.js
+++ b/app/frontend/src/lib/autocomplete.view.js
@@ -5,7 +5,7 @@ export const create = (container, input, onSelect) => {
     const ul = document.createElement('ul');
     ul.setAttribute('id', 'location__listbox');
     ul.setAttribute('role', 'listbox');
-    ul.setAttribute('tabindex', 0);
+    ul.setAttribute('tabindex', -1);
 
     ul.classList.add('autocomplete__menu');
     ul.classList.add('autocomplete__menu--overlay');
@@ -88,7 +88,7 @@ export const getOptionIndex = (el) => parseInt(el.getAttribute('aria-posinset'),
 
 export const getFocusedOption = (container) => container.getElementsByClassName('autocomplete__option--focused')[0];
 
-export const getOptionHtml = (refinement) => (hit, index, options) => `<li class="autocomplete__option" id="autocomplete__input__option--${index}" role="option" tabindex="0" aria-setsize="${options.length + 1}" aria-posinset=${index} data-location="${hit.toLowerCase()}">${highlightRefinement(hit, refinement)}</li>`;
+export const getOptionHtml = (refinement) => (hit, index, options) => `<li class="autocomplete__option" id="autocomplete__input__option--${index}" role="option" tabindex="-1" aria-setsize="${options.length + 1}" aria-posinset=${index} data-location="${hit.toLowerCase()}">${highlightRefinement(hit, refinement)}</li>`;
 
 export const highlightRefinement = (text, refinement) => {
   const index = text.toLowerCase().indexOf(refinement.toLowerCase());


### PR DESCRIPTION
part of https://dfedigital.atlassian.net/browse/TEVA-926

a separate PR for unit tests will be issued separately

as discussed with other DFE frontend developers the options in autocomplete should only be traversed with keyboard using up/down arrow. the tabbing order from the input element should not tab through options.
