### PR TITLE
[TEVA-903] enable radius select when input contains a number

### DIFF
--- a/app/frontend/src/lib/utils.js
+++ b/app/frontend/src/lib/utils.js
@@ -28,6 +28,8 @@ export const stringMatchesPostcode = (postcode) => {
   return regex.test(postcode);
 };
 
+export const stringContainsNumber = string => /\d/.test(string)
+
 export const convertMilesToMetres = (miles) => Math.ceil(parseInt(miles, 10) * 1609.34);
 
 export const convertEpochToUnixTimestamp = (timestamp) => Math.round(timestamp / 1000);

--- a/app/frontend/src/lib/utils.test.js
+++ b/app/frontend/src/lib/utils.test.js
@@ -1,5 +1,5 @@
 import {
-  getUnixTimestampForDayStart, constructNewUrlWithParam, stringMatchesPostcode, convertMilesToMetres, convertEpochToUnixTimestamp, extractQueryParams,
+  getUnixTimestampForDayStart, constructNewUrlWithParam, stringMatchesPostcode, convertMilesToMetres, convertEpochToUnixTimestamp, extractQueryParams, stringContainsNumber
 } from './utils';
 
 describe('constructNewUrlWithParams', () => {
@@ -54,6 +54,16 @@ describe('stringMatchesPostcode', () => {
     invalidPostcodes.map((postcode) => expect(stringMatchesPostcode(postcode)).toBe(false));
   });
 });
+
+describe('stringContainsNumber', () => {
+  test('is true when supplied string contains a number', () => {
+    expect(stringContainsNumber('alex8')).toBe(true);
+  });
+
+  test('is falsy when supplied string doesnt contain a number', () => {
+    expect(stringContainsNumber('alex')).toBe(false);
+  });
+})
 
 describe('convertMilesToMetres', () => {
   test('converts an integer of number of miles to the equivalent in metres', () => {

--- a/app/frontend/src/search/index.js
+++ b/app/frontend/src/search/index.js
@@ -12,7 +12,7 @@ import { searchClient } from './client';
 import { renderSearchBox } from './ui/input';
 import { templates, renderContent } from './ui/hits';
 import { updateNoResultsLink } from './ui/alert';
-import { onSubmit as locationSubmit, getCoords } from './ui/input/location';
+import { onSubmit as locationSubmit, onChange as locationChange, getCoords } from './ui/input/location';
 import { onSubmit as keywordSubmit } from './ui/input/keyword';
 import { renderAutocomplete } from '../lib/autocomplete';
 import { renderSortSelectInput } from './ui/sort';
@@ -24,7 +24,7 @@ import { updateUrlQueryParams, setDataAttribute } from '../lib/utils';
 import { enableSubmitButton } from './ui/form';
 
 const ALGOLIA_INDEX = 'Vacancy';
-const SEARCH_THRESHOLD = 3;
+const SEARCH_THRESHOLD = 2;
 
 const searchClientInstance = searchClient(ALGOLIA_INDEX);
 
@@ -127,4 +127,8 @@ renderAutocomplete({
   onSelection: (value) => {
     updateUrlQueryParams('location', value, window.location.href);
   },
+});
+
+document.getElementById('location').addEventListener('input', (e) => {
+  locationChange(e.target.value);
 });

--- a/app/frontend/src/search/ui/input.js
+++ b/app/frontend/src/search/ui/input.js
@@ -7,10 +7,18 @@ export const renderSearchBox = (renderOptions, isFirstRender) => {
   if (isFirstRender) {
     widgetParams.inputElement.addEventListener('input', () => {
       enableSubmitButton(widgetParams.container);
+
+      if (widgetParams.onChange) {
+        widgetParams.onChange(widgetParams.inputElement.value);
+      }
     });
 
     widgetParams.inputElement.addEventListener('change', () => {
       enableSubmitButton(widgetParams.container);
+
+      if (widgetParams.onChange) {
+        widgetParams.onChange(widgetParams.inputElement.value);
+      }
     });
 
     widgetParams.container.addEventListener('submit', (e) => {

--- a/app/frontend/src/search/ui/input/keyword.js
+++ b/app/frontend/src/search/ui/input/keyword.js
@@ -3,4 +3,4 @@ export const onSubmit = (client) => {
   client.refresh();
 };
 
-export const getKeyword = () => document.querySelector('#keyword-field').value;
+export const getKeyword = () => document.querySelector('#keyword').value;

--- a/app/frontend/src/search/ui/input/keyword.test.js
+++ b/app/frontend/src/search/ui/input/keyword.test.js
@@ -23,7 +23,7 @@ describe('keyword search box', () => {
 
   describe('getKeyword', () => {
     test('to return a string from input box', () => {
-      document.body.innerHTML = '<input id="keyword-field" />';
+      document.body.innerHTML = '<input id="keyword" />';
       expect(typeof getKeyword()).toBe('string');
     });
   });

--- a/app/frontend/src/search/ui/input/location.js
+++ b/app/frontend/src/search/ui/input/location.js
@@ -15,6 +15,14 @@ export const onSubmit = (query, locations, client) => {
   }
 };
 
+export const onChange = (value) => {
+  if (/\d/.test(value)) {
+    enableRadiusSelect();
+  } else {
+    disableRadiusSelect();
+  }
+};
+
 export const shouldNotGeocode = (query, locations) => query.length && locations.indexOf(query.toLowerCase()) > -1; // eslint-disable-line
 
 export const geocodeSuccess = (coords, client) => {

--- a/app/frontend/src/search/ui/input/location.test.js
+++ b/app/frontend/src/search/ui/input/location.test.js
@@ -1,4 +1,9 @@
-import { shouldNotGeocode, onSubmit, geocodeSuccess } from './location';
+import {
+  shouldNotGeocode,
+  onSubmit,
+  geocodeSuccess,
+  onChange,
+} from './location';
 import { locations } from '../../data/locations';
 
 import { getGeolocatedCoordinates } from '../../../lib/api';
@@ -57,6 +62,18 @@ describe('location search box', () => {
       expect(setPage).toHaveBeenNthCalledWith(1, 0);
       expect(disableRadiusSelect).toHaveBeenCalledTimes(1);
       expect(getGeolocatedCoordinates).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onChange (input)', () => {
+    test('disables the radius input if the input value does not contain a number', () => {
+      onChange('london');
+      expect(disableRadiusSelect).toHaveBeenCalledTimes(1);
+    });
+
+    test('enables the radius input if the input value does contain a number', () => {
+      onChange('w1');
+      expect(enableRadiusSelect).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -6,7 +6,8 @@
     = f.govuk_text_field :keyword,
       label: { text: t('jobs.filters.keyword') },
       placeholder: t('jobs.filters.keyword_hint'),
-      value: @vacancies_search.keyword
+      value: @vacancies_search.keyword,
+      id: 'keyword'
 
     // This partial does not yet use GDS Formbuilder.
     = render 'shared/location_search_tag', extra_label_class: nil

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
 
           click_on 'Return to your search results'
 
-          expect(page.find_field('keyword-field').value).to eq('teacher')
+          expect(page.find_field('keyword').value).to eq('teacher')
         end
       end
     end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-903

By default, the dropdown 'Within radius of' is hidden when the location box is empty or when it only contains letters.

'Within radius of' appears INSTANTLY when user inputs a number in the location field.

'Within radius of' appears INSTANTLY if user clicks on 'Use my current location'

'Within radius of' disappears INSTANTLY if user deletes the number from the location box.

## Changes in this PR:

- add custom event handler to index of search bundle (I do think the handle is better in a seperate file to bundle differently as it shouldnt just be bundles just with the search functionality but i have an idea of what to do that warrant another PR. the acceptance criteria for this immediate ticket are met however

- add utility function to detect for number and use this to decide if radius is shown when event is fired

- associated JS unit tests

- over rode the `keyword-field` and reverted to keyword for consistency