### PR TITLE
Add workaround for rails console on docker

### DIFF
--- a/documentation/govuk-paas.md
+++ b/documentation/govuk-paas.md
@@ -101,6 +101,21 @@ cf7 ssh <app_name>
 cf7 ssh <app_name> -t -c "/tmp/lifecycle/launcher /home/vcap/app 'rails console' ''"
 ```
 
+**NOTE:** This didn't work as expected on the new docker containers.  If you get the following error: 
+
+```bash
+cf7 ssh <app_name> -t -c "/tmp/lifecycle/launcher /home/vcap/app 'rails console' ''"
+Invalid metadata - unexpected end of JSON input%
+```
+
+use this workaround:
+
+```bash
+cf7 ssh <app_name>
+cd /teacher-vacancy
+/usr/local/bin/bundle exec rails console
+```
+
 ## Run task
 ```bash
 cf7 run-task <app_name> -c "rails task:name"


### PR DESCRIPTION
I ran into this when I was trying to debug a failure to publish. This is the workaround I used.
