### PR TITLE
Rename 'save and continue' to 'continue'

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -56,8 +56,8 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
                 success: I18n.t('messages.jobs.draft_saved_html', job_title: job_title)
   end
 
-  def redirect_to_next_step_if_save_and_continue(vacancy_id, job_title = nil)
-    if params[:commit] == I18n.t('buttons.save_and_continue')
+  def redirect_to_next_step_if_continue(vacancy_id, job_title = nil)
+    if params[:commit] == I18n.t('buttons.continue')
       redirect_to_next_step(vacancy_id)
     elsif params[:commit] == I18n.t('buttons.update_job')
       redirect_to edit_school_job_path(vacancy_id), success: {

--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -14,7 +14,7 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
     if @application_details_form.valid?
       update_vacancy(application_details_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue(@vacancy.id, @vacancy.job_title)
+      return redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
     end
 
     render :show

--- a/app/controllers/hiring_staff/vacancies/documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/documents_controller.rb
@@ -14,7 +14,7 @@ class HiringStaff::Vacancies::DocumentsController < HiringStaff::Vacancies::Appl
   before_action :redirect_unless_supporting_documents
   before_action only: %i[create] do
     save_vacancy_as_draft_if_save_and_return_later({}, @vacancy)
-    redirect_to_next_step_if_save_and_continue(@vacancy.id, @vacancy.job_title)
+    redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
   end
 
   before_action :set_documents_form, only: %i[show create]

--- a/app/controllers/hiring_staff/vacancies/important_dates_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/important_dates_controller.rb
@@ -16,7 +16,7 @@ class HiringStaff::Vacancies::ImportantDatesController < HiringStaff::Vacancies:
     if @important_dates_form.complete_and_valid?
       update_vacancy(@important_dates_form.params_to_save, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue(@vacancy.id, @vacancy.job_title)
+      return redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
     end
 
     render :show

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -28,7 +28,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
     elsif @job_specification_form.complete_and_valid?
       session_vacancy_id ? update_vacancy(job_specification_form_params) : save_vacancy_without_validation
       store_vacancy_attributes(@job_specification_form.vacancy.attributes)
-      return redirect_to_next_step_if_save_and_continue(@vacancy&.id.present? ? @vacancy.id : session_vacancy_id)
+      return redirect_to_next_step_if_continue(@vacancy&.id.present? ? @vacancy.id : session_vacancy_id)
     end
 
     render :show
@@ -39,7 +39,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
       remove_subject_fields(@vacancy) unless @vacancy.subjects.nil?
       update_vacancy(job_specification_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue(@vacancy.id, @vacancy.job_title)
+      return redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
     end
 
     render :show

--- a/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
@@ -14,7 +14,7 @@ class HiringStaff::Vacancies::JobSummaryController < HiringStaff::Vacancies::App
     if @job_summary_form.valid?
       update_vacancy(job_summary_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue(@vacancy.id, @vacancy.job_title)
+      return redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
     end
 
     render :show

--- a/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/pay_package_controller.rb
@@ -14,7 +14,7 @@ class HiringStaff::Vacancies::PayPackageController < HiringStaff::Vacancies::App
     if @pay_package_form.valid?
       update_vacancy(pay_package_form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_save_and_continue(@vacancy.id, @vacancy.job_title)
+      return redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
     end
 
     render :show

--- a/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/supporting_documents_controller.rb
@@ -38,7 +38,7 @@ class HiringStaff::Vacancies::SupportingDocumentsController < HiringStaff::Vacan
     if session[:current_step].eql?(:review) && @supporting_documents_form.supporting_documents == 'yes'
       redirect_to school_job_documents_path(@vacancy.id)
     else
-      redirect_to_next_step_if_save_and_continue(@vacancy.id, @vacancy.job_title)
+      redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -663,7 +663,7 @@ en:
     delete: 'Delete'
     dismiss: 'Dismiss'
     find: 'Find'
-    save_and_continue: 'Continue'
+    continue: 'Continue'
     save_and_return_later: 'Save and return later'
     submit: 'Submit'
     update_job: 'Update listing'

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature 'Copying a vacancy' do
     end
 
     fill_in_copy_vacancy_form_fields(new_vacancy)
-    click_on I18n.t('buttons.save_and_continue')
+    click_on I18n.t('buttons.continue')
 
     within('h2.govuk-heading-l') do
       expect(page).to have_content(I18n.t('jobs.copy_review_heading'))
@@ -120,7 +120,7 @@ RSpec.feature 'Copying a vacancy' do
         expect(page).to have_content(I18n.t('jobs.copy_job_title', job_title: original_vacancy.job_title))
       end
 
-      click_on I18n.t('buttons.save_and_continue')
+      click_on I18n.t('buttons.continue')
 
       within('h2.govuk-heading-l') do
         expect(page).to have_content(I18n.t('jobs.copy_review_heading'))
@@ -150,7 +150,7 @@ RSpec.feature 'Copying a vacancy' do
       end
 
       fill_in_copy_vacancy_form_fields(new_vacancy)
-      click_on I18n.t('buttons.save_and_continue')
+      click_on I18n.t('buttons.continue')
 
       within('h2.govuk-heading-l') do
         expect(page).to have_content(I18n.t('jobs.copy_review_heading'))
@@ -181,7 +181,7 @@ RSpec.feature 'Copying a vacancy' do
       fill_in_copy_vacancy_form_fields(new_vacancy)
       fill_in 'copy_vacancy_form[expires_on(2i)]', with: '090'
 
-      click_on I18n.t('buttons.save_and_continue')
+      click_on I18n.t('buttons.continue')
       expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.invalid'))
     end
   end
@@ -241,7 +241,7 @@ RSpec.feature 'Copying a vacancy' do
       expect(page).to have_content(I18n.t('jobs.copy_job_title', job_title: original_vacancy.job_title))
 
       fill_in_copy_vacancy_form_fields(new_vacancy)
-      click_on I18n.t('buttons.save_and_continue')
+      click_on I18n.t('buttons.continue')
     end
 
     context 'when publish on is blank' do

--- a/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_draft_vacancy_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
     before do
       visit new_school_job_path
       fill_in_job_specification_form_fields(vacancy)
-      click_on I18n.t('buttons.save_and_continue')
+      click_on I18n.t('buttons.continue')
     end
 
     context '#redirects_to' do
@@ -37,7 +37,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.benefits = 'Gym, health insurance'
 
         fill_in_pay_package_form_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 7))
         within('h2.govuk-heading-l') do
@@ -52,7 +52,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.benefits = 'Gym, health insurance'
 
         fill_in_pay_package_form_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         draft_vacancy.starts_on = DateTime.now + 1.year
         draft_vacancy.expires_on = draft_vacancy.starts_on - 1.day
@@ -60,7 +60,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.publish_on = DateTime.now + 1.day
 
         fill_in_important_dates_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 7))
         within('h2.govuk-heading-l') do
@@ -75,7 +75,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.benefits = 'Gym, health insurance'
 
         fill_in_pay_package_form_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         draft_vacancy.starts_on = DateTime.now + 1.year
         draft_vacancy.expires_on = draft_vacancy.starts_on - 1.day
@@ -83,10 +83,10 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.publish_on = DateTime.now + 1.day
 
         fill_in_important_dates_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_supporting_documents_form_fields
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 7))
         within('h2.govuk-heading-l') do
@@ -101,7 +101,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.benefits = 'Gym, health insurance'
 
         fill_in_pay_package_form_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         draft_vacancy.starts_on = DateTime.now + 1.year
         draft_vacancy.expires_on = draft_vacancy.starts_on - 1.day
@@ -109,10 +109,10 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.publish_on = DateTime.now + 1.day
 
         fill_in_important_dates_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         select_no_for_supporting_documents
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 7))
         within('h2.govuk-heading-l') do
@@ -127,7 +127,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.benefits = 'Gym, health insurance'
 
         fill_in_pay_package_form_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         draft_vacancy.starts_on = DateTime.now + 1.year
         draft_vacancy.expires_on = draft_vacancy.starts_on - 1.day
@@ -135,12 +135,12 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.publish_on = DateTime.now + 1.day
 
         fill_in_important_dates_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_supporting_documents_form_fields
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 7))
         within('h2.govuk-heading-l') do
@@ -155,7 +155,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.benefits = 'Gym, health insurance'
 
         fill_in_pay_package_form_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         draft_vacancy.starts_on = DateTime.now + 1.year
         draft_vacancy.expires_on = draft_vacancy.starts_on - 1.day
@@ -163,18 +163,18 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.publish_on = DateTime.now + 1.day
 
         fill_in_important_dates_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_supporting_documents_form_fields
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         draft_vacancy.contact_email = 'test@email.com'
         draft_vacancy.application_link = 'https://example.com'
 
         fill_in_application_details_form_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 6, total: 7))
         within('h2.govuk-heading-l') do
@@ -192,7 +192,7 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.benefits = 'Gym, health insurance'
 
         fill_in_pay_package_form_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         draft_vacancy.starts_on = DateTime.now + 1.year
         draft_vacancy.expires_on = draft_vacancy.starts_on - 1.day
@@ -200,10 +200,10 @@ RSpec.feature 'Hiring staff can edit a draft vacancy' do
         draft_vacancy.publish_on = DateTime.now + 1.day
 
         fill_in_important_dates_fields(draft_vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         select_no_for_supporting_documents
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         edit_a_published_vacancy
       end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'Creating a vacancy' do
       scenario 'is invalid unless all mandatory fields are submitted' do
         visit new_school_job_path
 
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         mandatory_fields = %w[job_title working_patterns]
 
@@ -66,7 +66,7 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 7))
         within('h2.govuk-heading-l') do
@@ -78,7 +78,7 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(Vacancy.last.state).to eql('create')
       end
@@ -87,7 +87,7 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         activity = Vacancy.last.activities.last
         expect(activity.session_id).to eq(session_id)
@@ -101,9 +101,9 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         within('.govuk-error-summary') do
           expect(page).to have_content(I18n.t('jobs.errors_present'))
@@ -118,10 +118,10 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 3, total: 7))
         within('h2.govuk-heading-l') do
@@ -135,12 +135,12 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         within('.govuk-error-summary') do
           expect(page).to have_content(I18n.t('jobs.errors_present'))
@@ -170,13 +170,13 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_important_dates_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 7))
         within('h2.govuk-heading-l') do
@@ -190,15 +190,15 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_important_dates_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
-        click_on I18n.t('buttons.save_and_continue') # submit empty form
+        click_on I18n.t('buttons.continue') # submit empty form
 
         expect(page)
           .to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.supporting_documents.inclusion'))
@@ -208,16 +208,16 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_important_dates_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         select_no_for_supporting_documents
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 5, total: 7))
         within('h2.govuk-heading-l') do
@@ -229,16 +229,16 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_important_dates_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         choose 'Yes'
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 4, total: 7))
         within('h2.govuk-heading-l') do
@@ -384,18 +384,18 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_important_dates_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         select_no_for_supporting_documents
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         within('.govuk-error-summary') do
           expect(page).to have_content(I18n.t('jobs.errors_present'))
@@ -411,19 +411,19 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_important_dates_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         select_no_for_supporting_documents
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_application_details_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 6, total: 7))
         within('h2.govuk-heading-l') do
@@ -437,21 +437,21 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_important_dates_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         select_no_for_supporting_documents
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_application_details_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         within('.govuk-error-summary') do
           expect(page).to have_content(I18n.t('jobs.errors_present'))
@@ -470,22 +470,22 @@ RSpec.feature 'Creating a vacancy' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_important_dates_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         select_no_for_supporting_documents
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_application_details_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_job_summary_form_fields(vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page).to have_content(I18n.t('jobs.current_step', step: 7, total: 7))
         within('h2.govuk-heading-l') do
@@ -501,7 +501,7 @@ RSpec.feature 'Creating a vacancy' do
           visit new_school_job_path
 
           fill_in_job_specification_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           v = Vacancy.find_by(job_title: vacancy.job_title)
           visit school_job_path(id: v.id)
@@ -516,16 +516,16 @@ RSpec.feature 'Creating a vacancy' do
           visit new_school_job_path
 
           fill_in_job_specification_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_pay_package_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_important_dates_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           select_no_for_supporting_documents
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           v = Vacancy.find_by(job_title: vacancy.job_title)
           visit school_job_path(id: v.id)
@@ -540,19 +540,19 @@ RSpec.feature 'Creating a vacancy' do
           visit new_school_job_path
 
           fill_in_job_specification_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_pay_package_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_important_dates_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           select_no_for_supporting_documents
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_application_details_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           v = Vacancy.find_by(job_title: vacancy.job_title)
           visit school_job_path(id: v.id)
@@ -567,22 +567,22 @@ RSpec.feature 'Creating a vacancy' do
           visit new_school_job_path
 
           fill_in_job_specification_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_pay_package_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_important_dates_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           select_no_for_supporting_documents
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_application_details_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_job_summary_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           expect(Vacancy.last.state).to eql('review')
           expect(page).to have_content(I18n.t('jobs.current_step', step: 7, total: 7))
@@ -595,22 +595,22 @@ RSpec.feature 'Creating a vacancy' do
           visit new_school_job_path
 
           fill_in_job_specification_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_pay_package_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_important_dates_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           select_no_for_supporting_documents
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_application_details_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_job_summary_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           expect(Vacancy.last.state).to eql('review')
           expect(page).to have_content(I18n.t('jobs.current_step', step: 7, total: 7))
@@ -761,22 +761,22 @@ RSpec.feature 'Creating a vacancy' do
           visit new_school_job_path
 
           fill_in_job_specification_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_pay_package_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_important_dates_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           select_no_for_supporting_documents
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_application_details_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           fill_in_job_summary_form_fields(vacancy)
-          click_on I18n.t('buttons.save_and_continue')
+          click_on I18n.t('buttons.continue')
 
           expect(page).to have_content(I18n.t('jobs.review_heading'))
 
@@ -954,7 +954,7 @@ RSpec.feature 'Creating a vacancy' do
         expect(find_field('important_dates_form[expires_on(2i)]').value).to eql(yesterday_date.month.to_s)
         expect(find_field('important_dates_form[expires_on(1i)]').value).to eql(yesterday_date.year.to_s)
 
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         within('.govuk-error-summary') do
           expect(page).to have_content(I18n.t('jobs.errors_present'))
@@ -972,7 +972,7 @@ RSpec.feature 'Creating a vacancy' do
         fill_in 'important_dates_form[expires_on(3i)]', with: expiry_date.day
         fill_in 'important_dates_form[expires_on(2i)]', with: expiry_date.month
         fill_in 'important_dates_form[expires_on(1i)]', with: expiry_date.year
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         click_on I18n.t('jobs.submit_listing.button')
         expect(page).to have_content(I18n.t('jobs.confirmation_page.submitted'))

--- a/spec/features/hiring_staff_can_save_and_return_later_spec.rb
+++ b/spec/features/hiring_staff_can_save_and_return_later_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Hiring staff can save and return later' do
         click_on I18n.t('buttons.create_job')
 
         fill_in_job_specification_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
         created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
 
         expect(page.current_path).to eql(school_job_pay_package_path(created_vacancy.id))
@@ -67,11 +67,11 @@ RSpec.feature 'Hiring staff can save and return later' do
         click_on I18n.t('buttons.create_job')
 
         fill_in_job_specification_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
         created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
 
         fill_in_pay_package_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page.current_path).to eql(school_job_important_dates_path(created_vacancy.id))
 
@@ -96,11 +96,11 @@ RSpec.feature 'Hiring staff can save and return later' do
         click_on I18n.t('buttons.create_job')
 
         fill_in_job_specification_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
         created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
 
         fill_in_pay_package_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page.current_path).to eql(school_job_important_dates_path(created_vacancy.id))
 
@@ -128,14 +128,14 @@ RSpec.feature 'Hiring staff can save and return later' do
         click_on I18n.t('buttons.create_job')
 
         fill_in_job_specification_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
         created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
 
         fill_in_pay_package_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_important_dates_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page.current_path).to eql(school_job_supporting_documents_path(created_vacancy.id))
 
@@ -158,17 +158,17 @@ RSpec.feature 'Hiring staff can save and return later' do
         click_on I18n.t('buttons.create_job')
 
         fill_in_job_specification_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
         created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
 
         fill_in_pay_package_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_important_dates_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         select_no_for_supporting_documents
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page.current_path).to eql(school_job_application_details_path(created_vacancy.id))
 
@@ -191,20 +191,20 @@ RSpec.feature 'Hiring staff can save and return later' do
         click_on I18n.t('buttons.create_job')
 
         fill_in_job_specification_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
         created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
 
         fill_in_pay_package_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_important_dates_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         select_no_for_supporting_documents
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         fill_in_application_details_form_fields(@vacancy)
-        click_on I18n.t('buttons.save_and_continue')
+        click_on I18n.t('buttons.continue')
 
         expect(page.current_path).to eql(school_job_job_summary_path(created_vacancy.id))
 

--- a/spec/features/hiring_staff_session_timeout_spec.rb
+++ b/spec/features/hiring_staff_session_timeout_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Hiring staff session' do
     visit new_school_job_path
 
     travel (HiringStaff::BaseController::TIMEOUT_PERIOD + 1.minute) do
-      click_on I18n.t('buttons.save_and_continue')
+      click_on I18n.t('buttons.continue')
 
       # A request to logout is sent to DfE Sign-in system. On success DSI comes back at auth_dfe_signout_path
       expect(page.current_url).to include "#{ENV['DFE_SIGN_IN_ISSUER']}/session/end"
@@ -33,7 +33,7 @@ RSpec.feature 'Hiring staff session' do
     visit new_school_job_path
 
     travel (HiringStaff::BaseController::TIMEOUT_PERIOD - 1.minute) do
-      click_on I18n.t('buttons.save_and_continue')
+      click_on I18n.t('buttons.continue')
 
       expect(page.current_path).to eq job_specification_school_job_path
     end


### PR DESCRIPTION
Replaces 137 occurrences of this translation.

This makes for shorter method names, and less confusing ones too given that the button text only says 'Continue'.