### PR TITLE
Allow SchoolGroup users to sign in

### DIFF
--- a/app/controllers/concerns/authentication_concerns.rb
+++ b/app/controllers/concerns/authentication_concerns.rb
@@ -21,10 +21,10 @@ module AuthenticationConcerns
   end
 
   def current_school
-    @current_school ||= School.find_by!(urn: session[:urn])
+    @current_school ||= School.find_by!(urn: session[:urn]) if session[:urn].present?
   end
 
   def current_school_group
-    @current_school_group ||= SchoolGroup.find_by!(uid: session[:uid])
+    @current_school_group ||= SchoolGroup.find_by!(uid: session[:uid]) if session[:uid].present?
   end
 end

--- a/app/controllers/concerns/authentication_concerns.rb
+++ b/app/controllers/concerns/authentication_concerns.rb
@@ -13,11 +13,7 @@ module AuthenticationConcerns
   end
 
   def current_organisation
-    if SchoolGroupJobsFeature.enabled?
-      current_school_group || current_school
-    else
-      current_school
-    end
+    current_school || current_school_group
   end
 
   def current_school
@@ -25,6 +21,8 @@ module AuthenticationConcerns
   end
 
   def current_school_group
-    @current_school_group ||= SchoolGroup.find_by!(uid: session[:uid]) if session[:uid].present?
+    if SchoolGroupJobsFeature.enabled?
+      @current_school_group ||= SchoolGroup.find_by!(uid: session[:uid]) if session[:uid].present?
+    end
   end
 end

--- a/app/controllers/concerns/authentication_concerns.rb
+++ b/app/controllers/concerns/authentication_concerns.rb
@@ -3,14 +3,28 @@ module AuthenticationConcerns
 
   included do
     helper_method :authenticated?
+    helper_method :current_organisation
     helper_method :current_school
+    helper_method :current_school_group
   end
 
   def authenticated?
     session[:session_id].present?
   end
 
+  def current_organisation
+    if SchoolGroupJobsFeature.enabled?
+      current_school_group || current_school
+    else
+      current_school
+    end
+  end
+
   def current_school
-    School.find_by!(urn: session[:urn])
+    @current_school ||= School.find_by!(urn: session[:urn])
+  end
+
+  def current_school_group
+    @current_school_group ||= SchoolGroup.find_by!(uid: session[:uid])
   end
 end

--- a/app/controllers/concerns/sign_in_audit_concerns.rb
+++ b/app/controllers/concerns/sign_in_audit_concerns.rb
@@ -17,7 +17,7 @@ module SignInAuditConcerns
   end
 
   def audit_successful_authorisation
-    Auditor::Audit.new(current_school, 'dfe-sign-in.authorisation.success', current_session_id).log
+    Auditor::Audit.new(current_organisation, 'dfe-sign-in.authorisation.success', current_session_id).log
   end
 
   def audit_failed_authorisation

--- a/app/controllers/hiring_staff/base_controller.rb
+++ b/app/controllers/hiring_staff/base_controller.rb
@@ -49,6 +49,9 @@ class HiringStaff::BaseController < ApplicationController
   end
 
   def redirect_signed_in_users
+    if SchoolGroupJobsFeature.enabled?
+      return redirect_to school_group_temporary_path if session.key?(:uid)
+    end
     return redirect_to school_path if session.key?(:urn)
   end
 

--- a/app/controllers/hiring_staff/base_controller.rb
+++ b/app/controllers/hiring_staff/base_controller.rb
@@ -7,8 +7,6 @@ class HiringStaff::BaseController < ApplicationController
     :check_session,
     :check_terms_and_conditions
 
-  helper_method :current_school
-
   include AuthenticationConcerns
   include ActionView::Helpers::DateHelper
 
@@ -22,10 +20,6 @@ class HiringStaff::BaseController < ApplicationController
 
   def check_terms_and_conditions
     redirect_to terms_and_conditions_path unless current_user&.accepted_terms_and_conditions?
-  end
-
-  def current_school
-    @current_school ||= School.find_by!(urn: session[:urn])
   end
 
   def current_user

--- a/app/controllers/hiring_staff/base_controller.rb
+++ b/app/controllers/hiring_staff/base_controller.rb
@@ -49,9 +49,7 @@ class HiringStaff::BaseController < ApplicationController
   end
 
   def redirect_signed_in_users
-    if SchoolGroupJobsFeature.enabled?
-      return redirect_to school_group_temporary_path if session[:uid].present?
-    end
+    return redirect_to school_group_temporary_path if session[:uid].present?
     return redirect_to school_path if session[:urn].present?
   end
 

--- a/app/controllers/hiring_staff/base_controller.rb
+++ b/app/controllers/hiring_staff/base_controller.rb
@@ -15,7 +15,7 @@ class HiringStaff::BaseController < ApplicationController
   end
 
   def check_session
-    redirect_to new_identifications_path unless session.key?(:urn)
+    redirect_to new_identifications_path unless session[:urn].present? || session[:uid].present?
   end
 
   def check_terms_and_conditions
@@ -50,9 +50,9 @@ class HiringStaff::BaseController < ApplicationController
 
   def redirect_signed_in_users
     if SchoolGroupJobsFeature.enabled?
-      return redirect_to school_group_temporary_path if session.key?(:uid)
+      return redirect_to school_group_temporary_path if session[:uid].present?
     end
-    return redirect_to school_path if session.key?(:urn)
+    return redirect_to school_path if session[:urn].present?
   end
 
   def timeout_period_as_string

--- a/app/controllers/hiring_staff/schools_controller.rb
+++ b/app/controllers/hiring_staff/schools_controller.rb
@@ -1,4 +1,6 @@
 class HiringStaff::SchoolsController < HiringStaff::BaseController
+  def placeholder; end
+
   def show
     @multiple_schools = session_has_multiple_schools?
     @school = SchoolPresenter.new(current_school)

--- a/app/controllers/hiring_staff/sign_in/base_sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/base_sessions_controller.rb
@@ -12,4 +12,12 @@ class HiringStaff::SignIn::BaseSessionsController < HiringStaff::BaseController
     session.destroy
     redirect_to new_identifications_path, flash_message
   end
+
+  def redirect_to_organisation_path
+    if current_organisation.is_a?(School)
+      redirect_to school_path
+    else
+      redirect_to school_group_temporary_path
+    end
+  end
 end

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -36,10 +36,11 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::SignIn::BaseSe
     session.update(
       session_id: user_id,
       urn: school_urn,
+      uid: school_group_uid,
       multiple_schools: authorisation_permissions.many_schools?,
       id_token: id_token
     )
-    Rails.logger.info("Updated session with URN #{session[:urn]}")
+    Rails.logger.info("Updated session with URN #{session[:urn]} or UID #{session[:uid]}")
     audit_successful_authorisation
   end
 
@@ -57,6 +58,10 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::SignIn::BaseSe
 
   def school_urn
     auth_hash.dig('extra', 'raw_info', 'organisation', 'urn') || ''
+  end
+
+  def school_group_uid
+    auth_hash.dig('extra', 'raw_info', 'organisation', 'uid') || ''
   end
 
   def organisation_id
@@ -77,7 +82,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::SignIn::BaseSe
     if authorisation_permissions.authorised?
       update_session(authorisation_permissions)
       update_user_last_activity_at
-      redirect_to school_path
+      redirect_to_organisation_path
     else
       not_authorised
     end

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -61,7 +61,9 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::SignIn::BaseSe
   end
 
   def school_group_uid
-    auth_hash.dig('extra', 'raw_info', 'organisation', 'uid') || ''
+    if SchoolGroupJobsFeature.enabled?
+      auth_hash.dig('extra', 'raw_info', 'organisation', 'uid') || ''
+    end
   end
 
   def organisation_id
@@ -79,7 +81,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::SignIn::BaseSe
   end
 
   def check_authorisation(authorisation_permissions)
-    if authorisation_permissions.authorised?
+    if authorisation_permissions.authorised? && organisation_id_present
       update_session(authorisation_permissions)
       update_user_last_activity_at
       redirect_to_organisation_path
@@ -90,5 +92,9 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::SignIn::BaseSe
 
   def redirect_for_fallback_authentication
     redirect_to new_auth_email_path if AuthenticationFallback.enabled?
+  end
+
+  def organisation_id_present
+    school_urn.present? || school_group_uid.present?
   end
 end

--- a/app/controllers/hiring_staff/sign_in/email/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/email/sessions_controller.rb
@@ -39,8 +39,6 @@ class HiringStaff::SignIn::Email::SessionsController < HiringStaff::SignIn::Base
     @reason_for_failing_sign_in = information.reason_for_failing_sign_in
     @schools, @school_groups = information.schools, information.school_groups
     update_session_without_urn_or_uid(information.details_to_update_in_session)
-    # .to_i used to convert nil to 0
-    only_one_organisation? = @schools&.count.to_i + @school_groups&.count.to_i == 1
     redirect_to auth_email_create_session_path(urn: @schools&.first&.urn, uid: @school_groups&.first&.uid) if
       only_one_organisation?
   end
@@ -91,5 +89,10 @@ class HiringStaff::SignIn::Email::SessionsController < HiringStaff::SignIn::Base
   def user_authorised?
     user = User.find_by(oid: session[:session_id]) rescue nil
     user&.dsi_data&.dig('school_group_uids')&.include?(get_uid) || user&.dsi_data&.dig('school_urns')&.include?(get_urn)
+  end
+
+  def only_one_organisation?
+    # .to_i used to convert nil to 0
+    @schools&.count.to_i + @school_groups&.count.to_i == 1
   end
 end

--- a/app/controllers/hiring_staff/sign_in/email/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/email/sessions_controller.rb
@@ -13,9 +13,9 @@ class HiringStaff::SignIn::Email::SessionsController < HiringStaff::SignIn::Base
   def new; end
 
   def create
-    session.update(urn: get_urn)
-    Rails.logger.info("Updated session with URN #{session[:urn]}")
-    redirect_to school_path
+    session.update(urn: get_urn, uid: get_uid)
+    Rails.logger.info("Updated session with URN #{session[:urn]} or UID #{session[:uid]}")
+    redirect_to_organisation_path
   end
 
   def destroy
@@ -35,23 +35,29 @@ class HiringStaff::SignIn::Email::SessionsController < HiringStaff::SignIn::Base
   end
 
   def choose_organisation
-    # This flow needs to be adapted when we have implemented school groups/trusts/LAs
-    # It is likely that we will not sign in Trust users as a school.
     information = GetInformationFromLoginKey.new(get_key)
-    @reason_for_failing_sign_in, @schools = information.reason_for_failing_sign_in, information.schools
-    update_session_without_urn(information.details_to_update_in_session)
-    redirect_to auth_email_create_session_path(urn: @schools.first.urn) if @schools&.one?
+    @reason_for_failing_sign_in = information.reason_for_failing_sign_in
+    @schools, @school_groups = information.schools, information.school_groups
+    update_session_without_urn_or_uid(information.details_to_update_in_session)
+    # .to_i used to convert nil to 0
+    only_one_organisation? = @schools&.count.to_i + @school_groups&.count.to_i == 1
+    redirect_to auth_email_create_session_path(urn: @schools&.first&.urn, uid: @school_groups&.first&.uid) if
+      only_one_organisation?
   end
 
   private
 
-  def update_session_without_urn(options)
+  def update_session_without_urn_or_uid(options)
     return unless options[:oid]
     session.update(
       session_id: options[:oid],
       multiple_schools: options[:has_multiple_schools]
     )
     Rails.logger.warn("Hiring staff signed in via fallback authentication: #{options[:oid]}")
+  end
+
+  def get_uid
+    params.dig(:uid)
   end
 
   def get_urn
@@ -84,7 +90,6 @@ class HiringStaff::SignIn::Email::SessionsController < HiringStaff::SignIn::Base
 
   def user_authorised?
     user = User.find_by(oid: session[:session_id]) rescue nil
-    user&.dsi_data&.dig('school_urns')&.include? get_urn
-    # TODO: include school_groups here when we have implemented school groups/trusts/LAs
+    user&.dsi_data&.dig('school_group_uids')&.include?(get_uid) || user&.dsi_data&.dig('school_urns')&.include?(get_urn)
   end
 end

--- a/app/controllers/hiring_staff/sign_in/email/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/email/sessions_controller.rb
@@ -37,7 +37,8 @@ class HiringStaff::SignIn::Email::SessionsController < HiringStaff::SignIn::Base
   def choose_organisation
     information = GetInformationFromLoginKey.new(get_key)
     @reason_for_failing_sign_in = information.reason_for_failing_sign_in
-    @schools, @school_groups = information.schools, information.school_groups
+    @schools = information.schools
+    @school_groups = information.school_groups
     update_session_without_urn_or_uid(information.details_to_update_in_session)
     redirect_to auth_email_create_session_path(urn: @schools&.first&.urn, uid: @school_groups&.first&.uid) if
       only_one_organisation?

--- a/app/views/hiring_staff/schools/placeholder.html.haml
+++ b/app/views/hiring_staff/schools/placeholder.html.haml
@@ -1,0 +1,2 @@
+%h1.govuk-heading-l.mb0
+  = t('schools.jobs.index', organisation: current_organisation.name)

--- a/app/views/hiring_staff/schools/show.html.haml
+++ b/app/views/hiring_staff/schools/show.html.haml
@@ -3,7 +3,7 @@
 .school.govuk-grid-row
   .govuk-grid-column-full
     %h1.govuk-heading-l.mb0
-      = t('schools.jobs.index', school: @school.name)
+      = t('schools.jobs.index', organisation: @school.name)
     - if @multiple_schools
       - if AuthenticationFallback.enabled?
         = link_to t('sign_in.organisation.change'), auth_email_change_organisation_path, class: 'govuk-link'

--- a/app/views/hiring_staff/sign_in/email/sessions/choose_organisation.html.haml
+++ b/app/views/hiring_staff/sign_in/email/sessions/choose_organisation.html.haml
@@ -17,3 +17,7 @@
       - @schools.each do |school|
         = link_to(school.location, auth_email_create_session_path(urn: school.urn), class: 'govuk-link')
         %br
+
+      - @school_groups.each do |school_group|
+        = link_to(school_group.name, auth_email_create_session_path(uid: school_group.uid), class: 'govuk-link')
+        %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -540,7 +540,7 @@ en:
     no_information: 'No information available'
     map_aria_label: 'Interactive map showing school location'
     jobs:
-      index: 'Jobs at %{school}'
+      index: 'Jobs at %{organisation}'
     no_jobs:
       heading: You have no job listings to manage
       intro: 'To create a job listing for your school, you will need the following information:'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,8 @@ Rails.application.routes.draw do
 
   resource :terms_and_conditions, only: %i[show update], controller: 'hiring_staff/terms_and_conditions'
 
+  get 'school_group', to: 'hiring_staff/schools#placeholder', as: 'school_group_temporary'
+
   resource :school, only: %i[show edit update], controller: 'hiring_staff/schools' do
     scope constraints: { type: /(published|draft|pending|expired|awaiting_feedback)/ } do
       get 'jobs(/:type)', to: 'hiring_staff/schools#show', defaults: { type: :published }, as: :jobs_with_type

--- a/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
+++ b/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe HiringStaff::Vacancies::JobSpecificationController, type: :controller do
+  let(:session) { double('session') }
   let(:vacancy) { double('vacancy') }
   let(:vacancy_id) { double('test_vacancy_id') }
   let(:school_id) { double('test_school_id') }
@@ -9,8 +10,10 @@ RSpec.describe HiringStaff::Vacancies::JobSpecificationController, type: :contro
   before do
     allow(job_specification_form).to receive(:new)
 
-    allow(controller).to receive(:session).and_return(double('session').as_null_object)
-    allow(controller).to receive_message_chain(:session, :key?).with(:urn).and_return(true)
+    allow(controller).to receive(:session).and_return(session)
+    allow(session).to receive(:[]).with(:urn).and_return('urn')
+    allow(session).to receive(:[]).with(:vacancy_attributes).and_return(nil)
+    allow(session).to receive(:id).and_return(nil)
     allow(controller).to receive_message_chain(:current_user, :accepted_terms_and_conditions?).and_return(true)
     allow(controller).to receive_message_chain(:current_user, :last_activity_at).and_return(Time.zone.now)
     allow(controller).to receive_message_chain(:current_user, :update)

--- a/spec/features/hiring_staff_can_manage_their_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_manage_their_vacancies_spec.rb
@@ -12,6 +12,6 @@ RSpec.feature 'Hiring staff can manage vacancies from a link on home page' do
       click_on(I18n.t('pages.home.signed_in.manage_link'))
     end
 
-    expect(find('h1')).to have_content(I18n.t('schools.jobs.index', school: school.name))
+    expect(find('h1')).to have_content(I18n.t('schools.jobs.index', organisation: school.name))
   end
 end

--- a/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_preview_a_vacancy_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Hiring staff can preview a vacancy' do
     scenario 'users can navigate back to manage jobs page' do
       click_on I18n.t('buttons.back_to_manage_jobs')
       expect(page).to have_current_path(jobs_with_type_school_path('draft', from_review: vacancy.id))
-      expect(page).to have_content(I18n.t('schools.jobs.index', school: school.name))
+      expect(page).to have_content(I18n.t('schools.jobs.index', organisation: school.name))
       expect(page).to have_content(I18n.t('buttons.create_job'))
     end
   end

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -125,23 +125,36 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
   context 'with valid credentials that match a SchoolGroup' do
     let(:organisation) { create(:school_group) }
 
-    before do
-      allow(SchoolGroupJobsFeature).to receive(:enabled?).and_return(true)
+    context 'SchoolGroupJobsFeature enabled' do
+      before do
+        allow(SchoolGroupJobsFeature).to receive(:enabled?).and_return(true)
 
-      stub_authentication_step(school_urn: nil, school_group_uid: organisation.uid, email: dsi_email_address)
-      stub_authorisation_step
-      stub_sign_in_with_multiple_organisations
+        stub_authentication_step(school_urn: nil, school_group_uid: organisation.uid, email: dsi_email_address)
+        stub_authorisation_step
+        stub_sign_in_with_multiple_organisations
 
-      visit root_path
-      sign_in_user
+        visit root_path
+        sign_in_user
+      end
+
+      it_behaves_like 'a successful sign in'
+
+      scenario 'it redirects the sign in page to the SchoolGroup page' do
+        visit new_identifications_path
+        expect(page).to have_content("Jobs at #{organisation.name}")
+        expect(current_path).to eql(school_group_temporary_path)
+      end
     end
 
-    it_behaves_like 'a successful sign in'
+    context 'SchoolGroupJobsFeature disabled' do
+      before do
+        stub_authentication_step(school_urn: nil, school_group_uid: organisation.uid, email: 'test@email.com')
+        stub_authorisation_step
+      end
 
-    scenario 'it redirects the sign in page to the SchoolGroup page' do
-      visit new_identifications_path
-      expect(page).to have_content("Jobs at #{organisation.name}")
-      expect(current_path).to eql(school_group_temporary_path)
+      it_behaves_like 'a failed sign in', user_id: '161d1f6a-44f1-4a1a-940d-d1088c439da7',
+                                          school_group_uid: '4505',
+                                          email: 'test@email.com'
     end
   end
 

--- a/spec/features/hiring_staff_can_view_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_view_vacancies_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'School viewing vacancies' do
   scenario 'A school should see advisory text when there are no vacancies' do
     visit school_path
 
-    expect(page).to have_content(I18n.t('schools.jobs.index', school: school.name))
+    expect(page).to have_content(I18n.t('schools.jobs.index', organisation: school.name))
     expect(page).not_to have_css('table.vacancies')
     expect(page).to have_content(I18n.t('schools.no_jobs.heading'))
   end
@@ -20,7 +20,7 @@ RSpec.feature 'School viewing vacancies' do
 
     visit school_path
 
-    expect(page).to have_content(I18n.t('schools.jobs.index', school: school.name))
+    expect(page).to have_content(I18n.t('schools.jobs.index', organisation: school.name))
     expect(page).to have_content(vacancy1.job_title)
     expect(page).to have_content(vacancy2.job_title)
   end

--- a/spec/features/hiring_staff_have_to_accept_terms_spec.rb
+++ b/spec/features/hiring_staff_have_to_accept_terms_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Hiring staff accepts terms and conditions' do
       click_on I18n.t('buttons.accept_and_continue')
 
       current_user.reload
-      expect(page).to have_content(I18n.t('schools.jobs.index', school: school.name))
+      expect(page).to have_content(I18n.t('schools.jobs.index', organisation: school.name))
       expect(current_user).to be_accepted_terms_and_conditions
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,7 +31,8 @@ RSpec.configure do |config|
     default_url_options[:host] = DOMAIN.to_s
   end
 
-  config.before(:each) do
+  config.before do
+    allow(SchoolGroupJobsFeature).to receive(:enabled?).and_return(false)
     Algolia::WebMock.mock!
   end
 

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -15,14 +15,15 @@ module AuthHelpers
     allow(fake_env).to receive(env_field_for_password.to_sym).and_return(env_value_for_password)
   end
 
-  def stub_hiring_staff_auth(urn:, session_id: 'session_id', email: nil)
-    page.set_rack_session(urn: urn)
+  def stub_hiring_staff_auth(urn: nil, uid: nil, session_id: 'session_id', email: nil)
+    page.set_rack_session(urn: urn) if urn.present?
+    page.set_rack_session(uid: uid) if uid.present?
     page.set_rack_session(session_id: session_id)
     create(:user, oid: session_id, email: email, last_activity_at: Time.zone.now)
   end
 
   def stub_authentication_step(organisation_id: '939eac36-0777-48c2-9c2c-b87c948a9ee0',
-                               school_urn: '110627',
+                               school_urn: '110627', school_group_uid: nil,
                                email: 'an-email@example.com')
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
       provider: 'dfe',
@@ -34,7 +35,8 @@ module AuthHelpers
         raw_info: {
           organisation: {
             id: organisation_id,
-            urn: school_urn
+            urn: school_urn,
+            uid: school_group_uid
           }
         }
       }


### PR DESCRIPTION
This PR allows SchoolGroup users to sign in with DfE sign in, as well as the AuthenticationFallback. Unless the SchoolGroupJobsFeature is enabled, this will have no effect on the application. If the feature is enabled, a SchoolGroup user can sign in and is redirected to a placeholder page - but no other functionality will work yet.

This PR is part of the work required to complete #1733.

## Changes in this PR
- Allow SchoolGroup users to sign in with DfE sign in
- Allow SchoolGroup users to sign in with Authentication fallback

## Next steps
- Incrementally remove the dependency on vacancies and users being associated to a School, so that the feature can be enabled