### PR TITLE
allow algolia api keys to come from .env value using erb template

### DIFF
--- a/app/frontend/packs/search.js
+++ b/app/frontend/packs/search.js
@@ -1,2 +1,1 @@
 import 'src/search';
-

--- a/app/frontend/src/search/algolia_instant_search.erb
+++ b/app/frontend/src/search/algolia_instant_search.erb
@@ -1,0 +1,3 @@
+import algoliasearch from 'algoliasearch';
+const search = algoliasearch('<%= ENV["ALGOLIA_APP_ID"] %>', '<%= ENV["ALGOLIA_SEARCH_API_KEY"] %>');
+export default search;

--- a/app/frontend/src/search/client.js
+++ b/app/frontend/src/search/client.js
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch';
+
 import instantsearch from 'instantsearch.js';
 
 import { getFilters, getQuery } from './query';
@@ -8,11 +8,10 @@ import { getRadius } from './ui/input/radius';
 
 // This is the public API key which can be safely used in your frontend code.
 // This key is usable for search queries and list the indices you've got access to.
-export const search = algoliasearch('QM2YE0HRBW', '4082ba44346a92023eac1f794d739dd1');
 
-export const searchClient = (indexName) => instantsearch({
+export const searchClient = (indexName, Client) => instantsearch({
   indexName,
-  searchClient: search,
+  searchClient: Client,
   searchFunction(helper) {
     onSearch(helper);
   },
@@ -44,5 +43,3 @@ export const onSearch = (helper) => {
 
   return helper.search();
 };
-
-export const index = (indexName) => search.initIndex(indexName);

--- a/app/frontend/src/search/index.js
+++ b/app/frontend/src/search/index.js
@@ -8,6 +8,7 @@ import {
 import { hits, configure } from 'instantsearch.js/es/widgets';
 
 import { searchClient } from './client';
+import Client from './algolia_instant_search'; // eslint-disable-line
 
 import { renderSearchBox } from './ui/input';
 import { templates, renderContent } from './ui/hits';
@@ -26,7 +27,7 @@ import { enableSubmitButton } from './ui/form';
 const ALGOLIA_INDEX = 'Vacancy';
 const SEARCH_THRESHOLD = 2;
 
-const searchClientInstance = searchClient(ALGOLIA_INDEX);
+const searchClientInstance = searchClient(ALGOLIA_INDEX, Client);
 
 const searchBox = connectSearchBox(renderSearchBox);
 const heading = connectHits(renderContent);

--- a/app/frontend/src/search/ui/hits.js
+++ b/app/frontend/src/search/ui/hits.js
@@ -23,6 +23,10 @@ export const hideServerMarkup = () => {
     document.querySelector('ul.vacancies').style.display = 'none';
   }
 
+  if (document.querySelector('#server-no-results')) {
+    document.querySelector('#server-no-results').style.display = 'none';
+  }
+
   if (document.querySelector('ul.pagination-server')) {
     document.querySelector('ul.pagination-server').style.display = 'none';
   }
@@ -57,7 +61,8 @@ export const templates = {
 </dl>
 </article>
 `,
-  empty: `<div class="divider-bottom">
+  empty: `<div id="client-no-results">
+<div class="divider-bottom">
 <p class="govuk-heading-m">Try another search</p>
 <ul class="govuk-list govuk-list--bullet">
 <li>with different keywords</li>
@@ -72,5 +77,6 @@ Or <a href="/subscriptions/new?search_criteria%5Blocation%5D=&amp;search_criteri
 <li>get an email when new jobs match their search</li>
 <li>can unsubscribe at any time</li>
 <li>receive no more than 1 email a day</li>
-</ul>`,
+</ul>
+</div>`,
 };

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -23,19 +23,20 @@
             = render partial: 'vacancy', locals: { vacancy: vacancy }
 
       - elsif @vacancies.user_search?
-        .divider-bottom
-          %p.govuk-heading-m
-            = t('jobs.no_jobs.intro')
+        #server-no-results
+          .divider-bottom
+            %p.govuk-heading-m
+              = t('jobs.no_jobs.intro')
+              %ul.govuk-list.govuk-list--bullet
+                - t('jobs.no_jobs.suggestions').each do |list_item|
+                  %li= list_item
+          %span.govuk-heading-m
+            = t('subscriptions.link.no_search_results_html', link_href: new_subscription_path(search_criteria: @vacancies_search.only_active_to_hash), class: 'govuk-link', id: 'job-alert-link-search')
+          %p{ class: 'govuk-!-margin-1' }
+            = t('subscriptions.benefits.title')
             %ul.govuk-list.govuk-list--bullet
-              - t('jobs.no_jobs.suggestions').each do |list_item|
+              - t('subscriptions.benefits.list').each do |list_item|
                 %li= list_item
-        %span.govuk-heading-m
-          = t('subscriptions.link.no_search_results_html', link_href: new_subscription_path(search_criteria: @vacancies_search.only_active_to_hash), class: 'govuk-link', id: 'job-alert-link-search')
-        %p{ class: 'govuk-!-margin-1' }
-          = t('subscriptions.benefits.title')
-          %ul.govuk-list.govuk-list--bullet
-            - t('subscriptions.benefits.list').each do |list_item|
-              %li= list_item
 
       - else
         %div.empty

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,4 +1,5 @@
 const { environment } = require('@rails/webpacker')
+const erb = require('./loaders/erb')
 const webpack = require('webpack')
 
 module.exports = environment
@@ -11,3 +12,5 @@ environment.plugins.prepend(
     jquery: 'jquery'
   })
 )
+
+environment.loaders.prepend('erb', erb)

--- a/config/webpack/loaders/erb.js
+++ b/config/webpack/loaders/erb.js
@@ -1,0 +1,11 @@
+module.exports = {
+  test: /\.erb$/,
+  enforce: 'pre',
+  exclude: /node_modules/,
+  use: [{
+    loader: 'rails-erb-loader',
+    options: {
+      runner: (/^win/.test(process.platform) ? 'ruby ' : '') + 'bin/rails runner'
+    }
+  }]
+}

--- a/config/webpack/loaders/erb.js
+++ b/config/webpack/loaders/erb.js
@@ -5,7 +5,11 @@ module.exports = {
   use: [{
     loader: 'rails-erb-loader',
     options: {
-      runner: (/^win/.test(process.platform) ? 'ruby ' : '') + 'bin/rails runner'
+      runner: (/^win/.test(process.platform) ? 'ruby ' : '') + 'bin/rails runner',
+      env: {
+        ...process.env,
+        DISABLE_SPRING: 1,
+      }
     }
   }]
 }

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -34,6 +34,7 @@ default: &default
     - .woff2
 
   extensions:
+    - .erb
     - .mjs
     - .js
     - .sass

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "govuk-frontend": "3.4.0",
     "instantsearch.js": "^4.4.1",
     "jquery": "^3.5.0",
+    "rails-erb-loader": "^5.5.2",
     "rails-ujs": "^5.2.3",
     "regenerator-runtime": "^0.13.5",
     "rollbar": "^2.17.0"
@@ -23,6 +24,7 @@
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.21.2",
     "jest": "^25.4.0",
+    "jest-erb-transformer": "^1.0.2",
     "jsdom": "^16.2.2",
     "stylelint": "^13.5.0",
     "stylelint-config-sass-guidelines": "^7.0.0",
@@ -43,6 +45,15 @@
     "sass:lint": "yarn stylelint app/frontend/**/*.scss -q"
   },
   "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "jsx",
+      "ts",
+      "tsx",
+      "node",
+      "erb"
+    ],
     "testMatch": [
       "<rootDir>/app/frontend/src/**/*.test.js"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5817,6 +5817,11 @@ jest-environment-node@^25.5.0:
     jest-util "^25.5.0"
     semver "^6.3.0"
 
+jest-erb-transformer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/jest-erb-transformer/-/jest-erb-transformer-1.0.2.tgz#1cf06f3fcd5b65601dee8f05cccce488d57fa46d"
+  integrity sha512-UPRBu7SF+LCXHwW8JbEphrtQ56NnpHQTIVPeneDZPPXKPIwokU8yPLwd7mF9NuWjks3VJZ11towgUlEu/b0MEg==
+
 jest-get-type@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
@@ -6390,6 +6395,11 @@ lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
+
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
 
 lodash.get@^4.0:
   version "4.4.2"
@@ -8604,6 +8614,14 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+rails-erb-loader@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/rails-erb-loader/-/rails-erb-loader-5.5.2.tgz#db3fa8ac89600f09d179a1a70a2ca18c592576ea"
+  integrity sha512-cjQH9SuSvRPhnWkvjmmAW/S4AFVDfAtYnQO4XpKJ8xpRdZayT73iXoE+IPc3VzN03noZXhVmyvsCvKvHj4LY6w==
+  dependencies:
+    loader-utils "^1.1.0"
+    lodash.defaults "^4.2.0"
 
 rails-ujs@^5.2.3:
   version "5.2.4"


### PR DESCRIPTION
Allow the api keys for algolia to be dynamically inserted into an .erb template (so they match with current environment). the client to be initialised can then be imported from front end javascript.

So this backend and frontend are both using the correct and consistent algolia api key env vars so client side search can be used in any (staging/dev/prod) environment

https://dfedigital.atlassian.net/browse/TEVA-981

## Changes in this PR:

- was a minor bug i noticed and fixed around job alerts markup mixed in this pr
