### PR TITLE
Decouple Vacancy and School models in en.yml - use organisation

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -53,15 +53,15 @@ module VacanciesHelper
   def page_title_prefix(vacancy, form_object, page_heading)
     if %w(create review).include?(vacancy.state)
       "#{form_object.errors.present? ?
-        'Error: ' : ''}#{page_heading} — #{t('jobs.create_a_job_title', school: current_school.name)}"
+        'Error: ' : ''}#{page_heading} — #{t('jobs.create_a_job_title', organisation: current_organisation.name)}"
     else
       "#{form_object.errors.present? ?
         'Error: ' : ''}Edit the #{page_heading}"
     end
   end
 
-  def review_page_title_prefix(vacancy, school = current_school)
-    page_title = I18n.t('jobs.review_page_title', school: school.name)
+  def review_page_title_prefix(vacancy, organisation = current_organisation)
+    page_title = I18n.t('jobs.review_page_title', organisation: organisation.name)
     "#{vacancy.errors.present? ? 'Error: ' : ''}#{page_title}"
   end
 
@@ -70,11 +70,14 @@ module VacanciesHelper
     I18n.t('jobs.review_heading')
   end
 
-  def page_title(vacancy, school = current_school)
-    return I18n.t('jobs.copy_job_title',
-                  job_title: vacancy.job_title.downcase) if vacancy.state == 'copy'
-    return I18n.t('jobs.create_a_job_title', school: school.name) if %w(create review).include?(vacancy.state)
-    I18n.t('jobs.edit_job_title', job_title: vacancy.job_title)
+  def page_title(vacancy, organisation = current_organisation)
+    if vacancy.state == 'copy'
+      I18n.t('jobs.copy_job_title', job_title: vacancy.job_title.downcase)
+    elsif %w(create review).include?(vacancy.state)
+      I18n.t('jobs.create_a_job_title', organisation: organisation.name)
+    else
+      I18n.t('jobs.edit_job_title', job_title: vacancy.job_title)
+    end
   end
 
   def missing_subjects?(vacancy)

--- a/app/views/hiring_staff/vacancies/job_specification/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/show.html.haml
@@ -1,7 +1,7 @@
 - if @vacancy.present?
   - content_for :page_title_prefix, page_title_prefix(@vacancy, @job_specification_form, t('jobs.job_details'))
 - else
-  - content_for :page_title_prefix, "#{@job_specification_form.errors.present? ? 'Error: ' : ''}#{t('jobs.job_details')} — #{t('jobs.create_a_job_title', school: current_school.name)}"
+  - content_for :page_title_prefix, "#{@job_specification_form.errors.present? ? 'Error: ' : ''}#{t('jobs.job_details')} — #{t('jobs.create_a_job_title', organisation: current_organisation.name)}"
 
 = render 'hiring_staff/vacancies/vacancy_form_partials/title'
 

--- a/app/views/hiring_staff/vacancies/preview.html.haml
+++ b/app/views/hiring_staff/vacancies/preview.html.haml
@@ -1,4 +1,4 @@
--content_for :page_title_prefix, t('jobs.preview_listing.page_title', school: current_school.name)
+-content_for :page_title_prefix, t('jobs.preview_listing.page_title', organisation: current_organisation.name)
 
 .vacancy
   = render '/hiring_staff/vacancies/preview_banner'

--- a/app/views/hiring_staff/vacancies/summary.html.haml
+++ b/app/views/hiring_staff/vacancies/summary.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t('jobs.confirmation_page.page_title', school: current_school.name)
+- content_for :page_title_prefix, t('jobs.confirmation_page.page_title', organisation: current_organisation.name)
 
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/hiring_staff/vacancies/vacancy_form_partials/_title.html.haml
+++ b/app/views/hiring_staff/vacancies/vacancy_form_partials/_title.html.haml
@@ -1,5 +1,5 @@
 %h1.govuk-heading-m
-  = @vacancy.present? ? page_title(@vacancy) : t('jobs.create_a_job_title', school: current_school.name)
+  = @vacancy.present? ? page_title(@vacancy) : t('jobs.create_a_job_title', organisation: current_organisation.name)
   - unless %w(copy edit edit_published).include?(@vacancy&.state)
     %span.govuk-caption-m
       = t('jobs.current_step', step: current_step,  total: total_steps)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -288,10 +288,10 @@ en:
     per_year: 'per year'
     per_year_pro_rata: 'per year pro rata'
     per_year_fte: 'per year (full-time equivalent)'
-    create_a_job_title: 'Create a job listing for %{school}'
+    create_a_job_title: 'Create a job listing for %{organisation}'
     copy_job_title: 'Copy %{job_title}'
     new_job_listing_details: New job listing details
-    review_page_title: 'Review the job listing — Create a job listing for %{school}'
+    review_page_title: 'Review the job listing — Create a job listing for %{organisation}'
     review_heading: 'Review the job listing'
     copy_review_heading: Review the new job listing
     edit_job_title: 'Edit %{job_title}'
@@ -349,7 +349,7 @@ en:
       heading: 'Preview this job listing'
       message: 'See how this job listing will appear to jobseekers on Teaching Vacancies'
       button: 'Preview job listing'
-      page_title: 'Preview job listing for %{school}'
+      page_title: 'Preview job listing for %{organisation}'
       summary:
         heading_html: 'Preview of &#8216;%{title}&#8217;'
         body_html:
@@ -418,7 +418,7 @@ en:
       time_updated: Date last updated
     confirmation_page:
       submitted: 'The job listing has been completed'
-      page_title: 'The job listing for %{school} has been completed'
+      page_title: 'The job listing for %{organisation} has been completed'
       view_posted_job: 'View your job listing'
       dashboard_link: 'You can also view, amend or delete it on %{link}'
       next_step: 'What happens next'

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Creating a vacancy' do
       visit new_organisation_job_path
 
       expect(page.current_path).to eq(job_specification_organisation_job_path)
-      expect(page).to have_content(I18n.t('jobs.create_a_job_title', school: school.name))
+      expect(page).to have_content(I18n.t('jobs.create_a_job_title', organisation: school.name))
       expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 7))
     end
 

--- a/spec/features/hiring_staff_can_save_and_return_later_spec.rb
+++ b/spec/features/hiring_staff_can_save_and_return_later_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Hiring staff can save and return later' do
         click_on I18n.t('buttons.create_job')
 
         expect(page.current_path).to eql(job_specification_organisation_job_path)
-        expect(page).to have_content(I18n.t('jobs.create_a_job_title', school: school.name))
+        expect(page).to have_content(I18n.t('jobs.create_a_job_title', organisation: school.name))
         expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 7))
         within('h2.govuk-heading-l') do
           expect(page).to have_content(I18n.t('jobs.job_details'))

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -76,14 +76,14 @@ RSpec.describe VacanciesHelper, type: :helper do
       allow(vacancy).to receive(:published?).and_return(false)
       allow(vacancy).to receive(:state).and_return('create')
 
-      expect(page_title(vacancy, school)).to eql(I18n.t('jobs.create_a_job_title', school: school.name))
+      expect(page_title(vacancy, school)).to eql(I18n.t('jobs.create_a_job_title', organisation: school.name))
     end
 
     it 'returns create a job title if vacancy state is review' do
       allow(vacancy).to receive(:published?).and_return(false)
       allow(vacancy).to receive(:state).and_return('review')
 
-      expect(page_title(vacancy, school)).to eql(I18n.t('jobs.create_a_job_title', school: school.name))
+      expect(page_title(vacancy, school)).to eql(I18n.t('jobs.create_a_job_title', organisation: school.name))
     end
 
     it 'returns edit job title' do

--- a/spec/views/hiring_staff/vacancies/job_specification/show.html.haml_spec.rb
+++ b/spec/views/hiring_staff/vacancies/job_specification/show.html.haml_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'hiring_staff/vacancies/job_specification/show' do
   end
 
   before do
-    allow(view).to receive(:current_school).and_return(instance_double(School).as_null_object)
+    allow(view).to receive(:current_organisation).and_return(instance_double(School).as_null_object)
     # Configured via the params set on the routes, as shown above. Exposed using a helper method, but that isn't
     # important for *this* test.
     allow(view).to receive(:params).and_return({ create_step: 1 })


### PR DESCRIPTION
This PR continues refactoring references to School to Organisation, since this is a better description and will make the code clearer. This PR continues the dis-entanglement in the application between vacancies and schools and is part of the work needed for #1723.

## Changes in this PR:

- Change references to school to references to organisation in relevant translations