### PR TITLE
Sign up to NQT job alerts

### DIFF
--- a/app/controllers/nqt_job_alerts_controller.rb
+++ b/app/controllers/nqt_job_alerts_controller.rb
@@ -1,0 +1,31 @@
+class NqtJobAlertsController < ApplicationController
+  include ParameterSanitiser
+
+  def new
+    @nqt_job_alerts_form = NqtJobAlertsForm.new(nqt_job_alerts_params)
+  end
+
+  def create
+    @nqt_job_alerts_form = NqtJobAlertsForm.new(nqt_job_alerts_params)
+    subscription = Subscription.new(@nqt_job_alerts_form.job_alert_params)
+    @subscription = SubscriptionPresenter.new(subscription)
+
+    recaptcha_valid = verify_recaptcha(model: subscription, action: 'subscription')
+    subscription.recaptcha_score = recaptcha_reply['score'] if recaptcha_valid && recaptcha_reply
+
+    if @nqt_job_alerts_form.valid?
+      subscription.save
+      AuditSubscriptionCreationJob.perform_later(@subscription.to_row)
+      SubscriptionMailer.confirmation(subscription.id).deliver_later
+      return render :confirm
+    end
+
+    render :new
+  end
+
+  private
+
+  def nqt_job_alerts_params
+    ParameterSanitiser.call(params[:nqt_job_alerts_form] || params).permit(:keywords, :location, :email)
+  end
+end

--- a/app/controllers/nqt_job_alerts_controller.rb
+++ b/app/controllers/nqt_job_alerts_controller.rb
@@ -17,10 +17,10 @@ class NqtJobAlertsController < ApplicationController
       subscription.save
       AuditSubscriptionCreationJob.perform_later(@subscription.to_row)
       SubscriptionMailer.confirmation(subscription.id).deliver_later
-      return render :confirm
+      render :confirm
+    else
+      render :new
     end
-
-    render :new
   end
 
   private

--- a/app/form_models/nqt_job_alerts_form.rb
+++ b/app/form_models/nqt_job_alerts_form.rb
@@ -48,6 +48,7 @@ class NqtJobAlertsForm
   end
 
   def unique_job_alert
-    errors.add(:base, 'Job alert already exists') if SubscriptionFinder.new(job_alert_params).exists?
+    errors.add(:base, I18n.t('nqt_job_alerts.form.errors.duplicate_alert')) if
+      SubscriptionFinder.new(job_alert_params).exists?
   end
 end

--- a/app/form_models/nqt_job_alerts_form.rb
+++ b/app/form_models/nqt_job_alerts_form.rb
@@ -1,0 +1,53 @@
+class NqtJobAlertsForm
+  include ActiveModel::Model
+
+  attr_accessor :keywords, :location, :email, :location_reference
+
+  validates :keywords, presence: true
+  validates :location, presence: true
+  validates :email, email_address: { presence: true }
+
+  validate :unique_job_alert
+
+  def initialize(params = {})
+    @keywords = params[:keywords]
+    @location = params[:location]
+    @email = params[:email]
+    @location_reference = location_reference
+  end
+
+  def job_alert_params
+    {
+      email: email,
+      frequency: :daily,
+      search_criteria: nqt_job_alert_hash.to_json
+    }
+  end
+
+  def location_reference
+    if location.present? && location_category
+      I18n.t('subscriptions.location_category_text', location: location_category)
+    else
+      I18n.t('subscriptions.location_radius_text', location: location, radius: 10)
+    end
+  end
+
+  private
+
+  def nqt_job_alert_hash
+    {
+      keyword: "nqt #{keywords}",
+      location: location,
+      radius: 10,
+      location_category: (location_category if location_category)
+    }.compact
+  end
+
+  def location_category
+    LocationCategory.include?(location) ? location : false
+  end
+
+  def unique_job_alert
+    errors.add(:base, 'Job alert already exists') if SubscriptionFinder.new(job_alert_params).exists?
+  end
+end

--- a/app/frontend/styles/components/flashes.scss
+++ b/app/frontend/styles/components/flashes.scss
@@ -42,6 +42,10 @@
   border-color: govuk-colour('blue');
 }
 
+.govuk-notification--notice__background {
+  background-color: rgba($color: govuk-colour('blue'), $alpha: 0.1);
+}
+
 .govuk-notification--success {
   background-image: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" fill="%2300703c" width="25" height="25" viewBox="0 0 25 25"><path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" ></path></svg>');
   background-position: top 20px left 15px;
@@ -62,4 +66,12 @@
   .govuk-notification__list a {
     color: govuk-colour('red');
   }
+}
+
+.alert {
+  background-image: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="21" height="20" viewBox="0 0 21 20"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.3423 9.85217C20.3423 15.2057 15.9389 19.5493 10.5114 19.5493C5.08403 19.5493 0.680542 15.2057 0.680542 9.85217C0.680542 4.4986 5.08403 0.155029 10.5114 0.155029C15.9389 0.155029 20.3423 4.4986 20.3423 9.85217ZM9.1855 3.47218L9.4223 11.6886H11.6164L11.8445 3.47218H9.1855ZM8.97469 15.0479C8.88707 14.8457 8.8429 14.6293 8.8429 14.3986C8.8429 14.1736 8.88707 13.9607 8.97469 13.7622C9.06231 13.5636 9.18397 13.3886 9.33893 13.2386C9.4939 13.0886 9.67348 12.97 9.87841 12.8836C10.0833 12.7972 10.3028 12.7536 10.5367 12.7536C10.7648 12.7536 10.9806 12.7972 11.1819 12.8836C11.3832 12.97 11.5606 13.0886 11.7127 13.2386C11.8647 13.3886 11.9849 13.5629 12.0726 13.7622C12.1602 13.9615 12.2043 14.1736 12.2043 14.3986C12.2043 14.6293 12.1602 14.8465 12.0726 15.0479C11.9849 15.2493 11.8647 15.4257 11.7127 15.5757C11.5606 15.7257 11.3839 15.8443 11.1819 15.9307C10.9798 16.0172 10.7648 16.0607 10.5367 16.0607C10.3028 16.0607 10.0826 16.0172 9.87841 15.9307C9.67421 15.8443 9.4939 15.7257 9.33893 15.5757C9.18397 15.4257 9.06231 15.25 8.97469 15.0479Z" ></path></svg>');
+  background-position: top 20px left 15px;
+  background-repeat: no-repeat;
+  background-size: 25px 25px;
+  padding-left: govuk-spacing(8);
 }

--- a/app/views/nqt_job_alerts/confirm.html.haml
+++ b/app/views/nqt_job_alerts/confirm.html.haml
@@ -1,0 +1,29 @@
+- content_for :page_title_prefix, t('nqt_job_alerts.page_title')
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    .govuk-panel.govuk-panel--confirmation.nqt-job-alert-success-gtm
+      %span.hod-checkmark
+        %svg{ xmlns: "http://www.w3.org/2000/svg", role: "presentation", focusable: "false", viewBox: "0 0 25 25", height: "40", width: "40" }
+          %path{ fill: "currentColor", d: "M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" }
+
+      %h1.govuk-panel__title= t('nqt_job_alerts.confirm.splash.heading')
+
+      .govuk-panel__body
+        %p= t('nqt_job_alerts.confirm.splash.message', email: @nqt_job_alerts_form.email)
+
+    %h2.govuk-heading-l= t('nqt_job_alerts.confirm.heading')
+    %p.govuk-body= t('nqt_job_alerts.confirm.intro')
+
+    .govuk-inset-text
+      %ul.govuk-list
+        %li
+          %span{ class: 'govuk-!-font-weight-bold'}= t('nqt_job_alerts.confirm.keywords')
+          = @nqt_job_alerts_form.keywords
+        %li
+          %span{ class: 'govuk-!-font-weight-bold'}= t('nqt_job_alerts.confirm.location')
+          = @nqt_job_alerts_form.location_reference
+
+    %p.govuk-body= t('nqt_job_alerts.confirm.unsubscribe')
+
+    %p= link_to t('buttons.go_to_teaching_vacancies'), jobs_path(keyword: "nqt #{@nqt_job_alerts_form.keywords}", location: @nqt_job_alerts_form.location), class: 'govuk-link govuk-link--no-visited-state'

--- a/app/views/nqt_job_alerts/new.html.haml
+++ b/app/views/nqt_job_alerts/new.html.haml
@@ -4,7 +4,7 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl{ class: 'govuk-!-margin-bottom-6' }= t('nqt_job_alerts.heading')
 
-    %p.govuk-body= t('nqt_job_alerts.intro.teaching_vacancies')
+    %p.govuk-body-l= t('nqt_job_alerts.intro.teaching_vacancies')
     %p.govuk-body= t('nqt_job_alerts.intro.content')
 
     = form_for @nqt_job_alerts_form, url: new_nqt_job_alert_path do |f|
@@ -14,17 +14,20 @@
         label: { text: t('nqt_job_alerts.form.labels.keywords_html'), size: 's' },
         hint_text: t('nqt_job_alerts.form.hints.keywords'),
         placeholder: t('nqt_job_alerts.form.placeholders.keywords'),
+        width: 'two-thirds',
         required: true
 
       = f.govuk_text_field :location,
         label: { text: t('nqt_job_alerts.form.labels.location_html'), size: 's' },
         hint_text: t('nqt_job_alerts.form.hints.location'),
         placeholder: t('nqt_job_alerts.form.placeholders.location'),
+        width: 'two-thirds',
         required: true
 
       = f.govuk_email_field :email,
         label: { text: t('nqt_job_alerts.form.labels.email_html'), size: 's' },
         hint_text: t('nqt_job_alerts.form.hints.email'),
+        width: 'two-thirds',
         required: true
 
       = recaptcha_v3(action: 'subscription')

--- a/app/views/nqt_job_alerts/new.html.haml
+++ b/app/views/nqt_job_alerts/new.html.haml
@@ -1,0 +1,35 @@
+- content_for :page_title_prefix, t('nqt_job_alerts.page_title')
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl{ class: 'govuk-!-margin-bottom-6' }= t('nqt_job_alerts.heading')
+
+    %p.govuk-body= t('nqt_job_alerts.intro.teaching_vacancies')
+    %p.govuk-body= t('nqt_job_alerts.intro.content')
+
+    = form_for @nqt_job_alerts_form, url: new_nqt_job_alert_path do |f|
+      = f.govuk_error_summary
+
+      = f.govuk_text_field :keywords,
+        label: { text: t('nqt_job_alerts.form.labels.keywords_html'), size: 's' },
+        hint_text: t('nqt_job_alerts.form.hints.keywords'),
+        placeholder: t('nqt_job_alerts.form.placeholders.keywords'),
+        required: true
+
+      = f.govuk_text_field :location,
+        label: { text: t('nqt_job_alerts.form.labels.location_html'), size: 's' },
+        hint_text: t('nqt_job_alerts.form.hints.location'),
+        placeholder: t('nqt_job_alerts.form.placeholders.location'),
+        required: true
+
+      = f.govuk_email_field :email,
+        label: { text: t('nqt_job_alerts.form.labels.email_html'), size: 's' },
+        hint_text: t('nqt_job_alerts.form.hints.email'),
+        required: true
+
+      = recaptcha_v3(action: 'subscription')
+
+      .govuk-notification.govuk-notification--notice.govuk-notification--notice__background.alert
+        .govuk-notification__body= t('nqt_job_alerts.intro.unsubscribe')
+
+      = f.govuk_submit t('buttons.subscribe'), classes: 'nqt-job-alert-subscribe-gtm'

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -76,6 +76,15 @@ en:
         job_summary_form:
           attributes:
             <<: *job_summary_errors
+        nqt_job_alerts_form:
+          attributes:
+            keywords:
+              blank: Enter keyword(s)
+            location:
+              blank: Enter a location
+            email:
+              blank: Enter your email address
+              invalid: Enter an email address in the correct format, like name@example.com
   activerecord:
     attributes:
       vacancy/expiry_time: Application deadline (time)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -613,8 +613,8 @@ en:
     location_radius_text: Within %{radius} miles of %{location}
     location_category_text: In %{location}
     reference: 'for'
-    next_steps:
-      "You'll receive a single job alert email at the end of any day when 1 or more matching jobs are first published."
+    next_steps: >-
+      You’ll receive an email every morning with any new job that’s been listed that matches your search criteria.
     confirmation:
       header: 'Your email subscription has started'
       receipt_confirmation: We have sent a confirmation email to %{email}.
@@ -674,11 +674,9 @@ en:
         save money on recruitment and is here to help you to take the first step in your career.
       content: >-
         Setting up an alert can help make your search for a teaching job easier. You’ll receive an email every morning
-        with any new job that’s been listed that matches your search criteria. You can then follow the link to Teaching
-        Vacancies and find out more about the role, or roles, that you’re interested in.
+        with any new job that’s been listed that matches your search criteria.
       unsubscribe: >-
-        You can unsubscribe at any time by following the instructions in the job alert. You’ll also be able to find
-        links to change your search criteria and set up a new or additional alert if you need to.
+        You can unsubscribe at any time by following the instructions in the job alert
     form:
       labels:
         keywords_html: "Keywords (<span class='text-red'>Required</span>)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -670,7 +670,7 @@ en:
     heading: Sign up for NQT job alerts
     intro:
       teaching_vacancies: >-
-        Teaching vacancies is a free job-listing service from the Department for Education. It helps schools to save
+        Teaching Vacancies is a free job-listing service from the Department for Education. It helps schools to save
         money on recruitment and you to take the first step in your new career.
       content: >-
         Setting up an alert can help make your search for a teaching job easier. You’ll receive an email every morning
@@ -694,6 +694,8 @@ en:
       placeholders:
         keywords: Humanities, KS3, primary teacher, for example
         location: City, town or postcode, for example
+      errors:
+        duplicate_alert: A job alert matching this criteria already exists
     confirm:
       heading: What happens next
       splash:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -670,12 +670,12 @@ en:
     heading: Sign up for NQT job alerts
     intro:
       teaching_vacancies: >-
-        Teaching Vacancies is a free job-listing service from the Department for Education. It helps schools to save
-        money on recruitment and you to take the first step in your new career.
+        Teaching Vacancies is a free national job-listing service from the Department for Education. It helps schools to
+        save money on recruitment and is here to help you to take the first step in your career.
       content: >-
         Setting up an alert can help make your search for a teaching job easier. You’ll receive an email every morning
-        with any new jobs matching your search criteria that have been listed. You can then follow the links to Teaching
-        Vacancies and find out more about any role that you’re interested in.
+        with any new job that’s been listed that matches your search criteria. You can then follow the link to Teaching
+        Vacancies and find out more about the role, or roles, that you’re interested in.
       unsubscribe: >-
         You can unsubscribe at any time by following the instructions in the job alert. You’ll also be able to find
         links to change your search criteria and set up a new or additional alert if you need to.
@@ -687,7 +687,8 @@ en:
       hints:
         keywords: >-
           Tell us what teaching job you’re looking for and what kind of school you’d like to teach in.
-          You can use any keywords that describe your ideal role.
+          You can use any keywords that describe your ideal role. This alert is especially for NQT suitable jobs, so you
+          don’t need to add NQT as a keyword.
         location: >-
           Tell us where you’re looking for a job and we’ll email you any results within a 10 mile radius.
         email: Enter your email address. We will only use it to send you job alerts.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -665,6 +665,44 @@ en:
             one: "A new job matching your search criteria '%{reference}' was posted yesterday."
             other: "%{count} new jobs matching your search criteria '%{reference}' were posted yesterday."
           unsubscribe: Don’t want to receive these email alerts? %{unsubscribe_link}
+  nqt_job_alerts:
+    page_title: Sign up for NQT job alerts
+    heading: Sign up for NQT job alerts
+    intro:
+      teaching_vacancies: >-
+        Teaching vacancies is a free job-listing service from the Department for Education. It helps schools to save
+        money on recruitment and you to take the first step in your new career.
+      content: >-
+        Setting up an alert can help make your search for a teaching job easier. You’ll receive an email every morning
+        with any new jobs matching your search criteria that have been listed. You can then follow the links to Teaching
+        Vacancies and find out more about any role that you’re interested in.
+      unsubscribe: >-
+        You can unsubscribe at any time by following the instructions in the job alert. You’ll also be able to find
+        links to change your search criteria and set up a new or additional alert if you need to.
+    form:
+      labels:
+        keywords_html: "Keywords (<span class='text-red'>Required</span>)"
+        location_html: "Location (<span class='text-red'>Required</span>)"
+        email_html: "Email address (<span class='text-red'>Required</span>)"
+      hints:
+        keywords: >-
+          Tell us what teaching job you’re looking for and what kind of school you’d like to teach in.
+          You can use any keywords that describe your ideal role.
+        location: >-
+          Tell us where you’re looking for a job and we’ll email you any results within a 10 mile radius.
+        email: Enter your email address. We will only use it to send you job alerts.
+      placeholders:
+        keywords: Humanities, KS3, primary teacher, for example
+        location: City, town or postcode, for example
+    confirm:
+      heading: What happens next
+      splash:
+        heading: Your job alert has been set up
+        message: We sent a confirmation email to %{email}
+      keywords: 'Keywords:'
+      location: 'Location:'
+      intro: "We'll email you any teaching jobs suitable for NQTs that match your search criteria:"
+      unsubscribe: You can unsubscribe by following the link at the bottom of the email.
   terms_and_conditions:
     page_title: 'Terms and Conditions'
     intro: >-
@@ -702,6 +740,7 @@ en:
     cancel_copy: 'Cancel copy'
     cancel_and_return: Cancel and return
     back_to_manage_jobs: Back to manage jobs
+    go_to_teaching_vacancies: Go to Teaching Vacancies
     subscribe: Subscribe
 
   messages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,9 @@ Rails.application.routes.draw do
     resource :confirmation, only: [:show]
   end
 
+  get 'sign-up-for-NQT-job-alerts', to: 'nqt_job_alerts#new', as: 'nqt_job_alerts'
+  post 'sign-up-for-NQT-job-alerts', to: 'nqt_job_alerts#create', as: 'new_nqt_job_alert'
+
   namespace :api do
     scope 'v:api_version', api_version: /[1]/ do
       resources :jobs, only: %i[index show], controller: 'vacancies'

--- a/spec/controllers/nqt_job_alerts_controller_spec.rb
+++ b/spec/controllers/nqt_job_alerts_controller_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe NqtJobAlertsController, type: :controller do
+  let(:keywords) { 'something' }
+  let(:location) { 'some place' }
+  let(:email) { 'test@gmail.com' }
+
+  let(:form_inputs) { { keywords: keywords, location: location, email: email } }
+
+  before do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  describe '#new' do
+    let(:params) { form_inputs }
+    let(:subject) { get :new, params: params }
+
+    it 'returns 200' do
+      subject
+      expect(response.code).to eql('200')
+    end
+  end
+
+  describe '#create' do
+    let(:params) { { nqt_job_alerts_form: form_inputs } }
+    let(:search_criteria) do
+      { keyword: "nqt #{keywords}", location: location, radius: 10 }.to_json
+    end
+    let(:subscription) { Subscription.last }
+    let(:subject) { post :create, params: params }
+
+    it 'returns 200' do
+      subject
+      expect(response.code).to eql('200')
+    end
+
+    it 'queues a job to audit the subscription' do
+      expect { subject }.to have_enqueued_job(AuditSubscriptionCreationJob)
+    end
+
+    it 'calls SubscriptionMailer' do
+      expect(SubscriptionMailer).to receive_message_chain(:confirmation, :deliver_later)
+      subject
+    end
+
+    it 'creates a subscription' do
+      expect { subject }.to change { Subscription.count }.by(1)
+      expect(subscription.email).to eq(email)
+      expect(subscription.search_criteria).to eq(search_criteria)
+    end
+
+    context 'when parameters include syntax' do
+      let(:keywords) { "<body onload=alert('test1')>Text</script>" }
+      let(:expected_safe_values) { { keywords: 'Text', location: location, email: email } }
+
+      it 'sanitizes form inputs' do
+        subject
+        expect(controller.send(:nqt_job_alerts_params)).to eq(
+          ActionController::Parameters.new(expected_safe_values).permit(:keywords, :location, :email)
+        )
+      end
+    end
+  end
+end

--- a/spec/features/job_seekers_can_subscribe_to_an_nqt_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_an_nqt_job_alert_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.feature 'A job seeker can subscribe to an NQT job alert' do
+  before { allow(EmailAlertsFeature).to receive(:enabled?) { true } }
+
+  describe 'A job seeker' do
+    scenario 'can successfully subscribe to a job alert' do
+      visit nqt_job_alerts_path
+
+      expect(page).to have_content(I18n.t('nqt_job_alerts.heading'))
+
+      fill_in 'nqt_job_alerts_form[keywords]', with: 'Maths'
+      fill_in 'nqt_job_alerts_form[location]', with: 'London'
+      fill_in 'nqt_job_alerts_form[email]', with: 'test@email.com'
+
+      message_delivery = instance_double(ActionMailer::MessageDelivery)
+      expect(SubscriptionMailer).to receive(:confirmation) { message_delivery }
+      expect(message_delivery).to receive(:deliver_later)
+      click_on I18n.t('buttons.subscribe')
+
+      expect(page).to have_content(I18n.t('nqt_job_alerts.confirm.heading'))
+      click_on I18n.t('buttons.go_to_teaching_vacancies')
+
+      expect(page).to have_current_path(jobs_path(keyword: 'nqt Maths', location: 'London'))
+    end
+  end
+end

--- a/spec/form_models/nqt_job_alerts_form_spec.rb
+++ b/spec/form_models/nqt_job_alerts_form_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe NqtJobAlertsForm, type: :model do
       it 'validates uniqueness of job alert' do
         expect(subject.valid?).to be(false)
         expect(subject.errors.messages[:base]).to include(
-          'Job alert already exists'
+          I18n.t('nqt_job_alerts.form.errors.duplicate_alert')
         )
       end
     end

--- a/spec/form_models/nqt_job_alerts_form_spec.rb
+++ b/spec/form_models/nqt_job_alerts_form_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe NqtJobAlertsForm, type: :model do
+  let(:keywords) { 'some keywords' }
+  let(:location) { 'some place' }
+  let(:email) { 'test@email.com' }
+  let(:params) { { keywords: keywords, location: location, email: email } }
+  let(:subject) { described_class.new(params) }
+
+  describe '#job_alert_params' do
+    context 'when location is a LocationCategory' do
+      let(:expected_hash) do
+        { keyword: "nqt #{keywords}", location: location, radius: 10, location_category: location }
+      end
+
+      before do
+        allow(LocationCategory).to receive(:include?).with(location).and_return(true)
+      end
+
+      it 'adds location_category to the search criteria' do
+        expect(subject.job_alert_params[:search_criteria]).to eql(expected_hash.to_json)
+      end
+    end
+
+    context 'when location is not a LocationCategory' do
+      let(:expected_hash) do
+        { keyword: "nqt #{keywords}", location: location, radius: 10 }
+      end
+
+      before do
+        allow(LocationCategory).to receive(:include?).with(location).and_return(false)
+      end
+
+      it 'does not add location_category to the search criteria' do
+        expect(subject.job_alert_params[:search_criteria]).to eql(expected_hash.to_json)
+      end
+    end
+  end
+
+  describe '#validations' do
+    context 'when keywords is blank' do
+      let(:keywords) { '' }
+
+      it 'validates presence of keywords' do
+        expect(subject.valid?).to be(false)
+        expect(subject.errors.messages[:keywords]).to include(
+          I18n.t('activemodel.errors.models.nqt_job_alerts_form.attributes.keywords.blank')
+        )
+      end
+    end
+
+    context 'when location is blank' do
+      let(:location) { '' }
+
+      it 'validates presence of location' do
+        expect(subject.valid?).to be(false)
+        expect(subject.errors.messages[:location]).to include(
+          I18n.t('activemodel.errors.models.nqt_job_alerts_form.attributes.location.blank')
+        )
+      end
+    end
+
+    context '#email' do
+      context 'when email is blank' do
+        let(:email) { '' }
+
+        it 'validates presence of email' do
+          expect(subject.valid?).to be(false)
+          expect(subject.errors.messages[:email]).to include(
+            I18n.t('activemodel.errors.models.nqt_job_alerts_form.attributes.email.blank')
+          )
+        end
+      end
+
+      context 'when email is invalid' do
+        let(:email) { 'invalid' }
+
+        it 'validates validity of email' do
+          expect(subject.valid?).to be(false)
+          expect(subject.errors.messages[:email]).to include(
+            I18n.t('activemodel.errors.models.nqt_job_alerts_form.attributes.email.invalid')
+          )
+        end
+      end
+    end
+
+    context 'when job alert already exists' do
+      before do
+        allow(SubscriptionFinder).to receive_message_chain(:new, :exists?).and_return(true)
+      end
+
+      it 'validates uniqueness of job alert' do
+        expect(subject.valid?).to be(false)
+        expect(subject.errors.messages[:base]).to include(
+          'Job alert already exists'
+        )
+      end
+    end
+  end
+end

--- a/spec/mailers/subscription_spec.rb
+++ b/spec/mailers/subscription_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe SubscriptionMailer, type: :mailer do
     expect(body_lines[3]).to match(/#{I18n.t('subscriptions.email.confirmation.subheading', email: email)}/)
     expect(body_lines[5]).to match(/\* Subject: English/)
     expect(body_lines[6]).to match(/\Suitable for NQTs/)
-    expect(body_lines[8]).to include('You&#39;ll receive')
+    expect(body_lines[8]).to match(/#{I18n.t('subscriptions.next_steps')}/)
   end
 
   it 'has an unsubscribe link' do

--- a/spec/views/nqt_job_alerts/new.html.haml_spec.rb
+++ b/spec/views/nqt_job_alerts/new.html.haml_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'nqt_job_alerts/new.html.haml' do
+  before do
+    assign(:nqt_job_alerts_form, NqtJobAlertsForm.new)
+  end
+
+  context 'recaptcha' do
+    # The recaptcha gem requires that the form element and the checker in the controller both use the same name when
+    # using v3.
+    it 'inserts a hidden recaptcha form element in the page with the name "subscription"' do
+      expect(render).to match(/input type="hidden" name="g-recaptcha-response-data\[subscription\]"/)
+    end
+  end
+end


### PR DESCRIPTION
This PR creates a new page for NQTs to sign up for job alerts. It piggybacks onto the way we currently create and manage subscriptions in the application.

Closes #1740 #1739 

**Todo**
- [x] Confirm all content
- [x] UX sign off
- [x] Content sign off
- [x] Product sign off
- [x] Wider sign off

This PR should only be merged once all the above have been completed.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1010

## Changes in this PR
- NQT specific job alert sign up page
- NQT specific job alert confirmation page
- Create a subscription through NQT specific job alert form

## Designs
https://www.figma.com/file/uRge4QPS2rBADfR9vLlkTO/Sprint-61?node-id=1%3A20
