### PR TITLE
[TEVA-1006] Fix worker dev app name

### DIFF
--- a/paas/worker/manifest-docker-dev.yml
+++ b/paas/worker/manifest-docker-dev.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-  - name: teaching-vacancies-worker-docker-dev
+  - name: teaching-vacancies-worker-dev
     docker:
       image: ((IMAGE_NAME))
     env:


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1006

## Changes in this PR:
The name of the worker dev app is wrong in the manifest

## After merging
Redeploy the worker dev app manually