### PR TITLE
Link scraped vacancies to TV vacancies if possible

### DIFF
--- a/bigquery/link-scraped-vacancies-to-schools-and-vacancies.sql
+++ b/bigquery/link-scraped-vacancies-to-schools-and-vacancies.sql
@@ -25,13 +25,6 @@ WITH
       JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(DATA,
           '$.json'),
         '$.title') AS title,
-      ARRAY(
-      SELECT
-        *
-      FROM
-        UNNEST(SPLIT(LOWER(REGEXP_REPLACE(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(DATA,
-                    '$.json'),
-                  '$.title'),r'[^a-zA-Z0-9]', '')),' '))) AS words_from_scraped_title,
       JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(DATA,
           '$.json'),
         '$.description') AS description,


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-935

## Changes in this PR:

Previously we just matched scraped vacancies to schools in our database.
This matches them to vacancies those schools posted if:
1. The vacancy was posted by a school AND
2. The vacancy was posted within a fortnight either side of the matched vacancy AND
3. No more than 1 in 5 words in one vacancy title is not included in the matched vacancy title (ignoring a list of small words which don't add meaning) [this last part boosts the match rate by ~50% over just comparing the two strings directly]
