### PR TITLE
correct layout for dashboard header

### DIFF
--- a/app/frontend/styles/components/hiring-staff.scss
+++ b/app/frontend/styles/components/hiring-staff.scss
@@ -20,8 +20,11 @@ body.hiring-staff {
 
 }
 
-.create-a-job > a {
-  margin-bottom: 0;
+.create-a-job {
+  text-align: right;
+  > a {
+    margin-bottom: 0;
+  }
 }
 
 .button-link {

--- a/app/frontend/styles/components/hiring-staff.scss
+++ b/app/frontend/styles/components/hiring-staff.scss
@@ -20,7 +20,7 @@ body.hiring-staff {
 
 }
 
-.create-a-job {
+.dashboard-header {
   text-align: right;
   > a {
     margin-bottom: 0;

--- a/app/views/hiring_staff/organisations/show.html.haml
+++ b/app/views/hiring_staff/organisations/show.html.haml
@@ -13,7 +13,7 @@
   .govuk-grid-column-full{ class: 'govuk-!-margin-top-5' }
     .govuk-form-group
       - if @organisation.vacancies.active.any?
-        .create-a-job
+        .dashboard-header
           = link_to t('buttons.create_job'), new_organisation_job_path, class: 'govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-0'
         .overflow-scroll
           = render partial: 'vacancies', locals: { organisation: @organisation, vacancies: @vacancies }

--- a/app/views/hiring_staff/organisations/show.html.haml
+++ b/app/views/hiring_staff/organisations/show.html.haml
@@ -2,7 +2,7 @@
 
 .school.govuk-grid-row
   .govuk-grid-column-full
-    %h1.govuk-heading-l{ class: 'govuk-!-margin-bottom-2' }
+    %h1.govuk-heading-l{ class: 'govuk-!-margin-bottom-1' }
       = t('schools.jobs.index', organisation: @organisation.name)
     - if @multiple_organisations
       - if AuthenticationFallback.enabled?
@@ -10,10 +10,11 @@
       - else
         = link_to t('sign_in.organisation.change'), auth_dfe_callback_path, class: 'govuk-link'
 
-  .govuk-grid-column-full{ class: 'govuk-!-margin-top-9' }
-    .govuk-form-group.create-a-job
+  .govuk-grid-column-full{ class: 'govuk-!-margin-top-5' }
+    .govuk-form-group
       - if @organisation.vacancies.active.any?
-        = link_to t('buttons.create_job'), new_organisation_job_path, class: 'govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-0'
+        .create-a-job
+          = link_to t('buttons.create_job'), new_organisation_job_path, class: 'govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-0'
         .overflow-scroll
           = render partial: 'vacancies', locals: { organisation: @organisation, vacancies: @vacancies }
       - else


### PR DESCRIPTION
this corrects the layout for dashboard header to be exactly as per https://www.figma.com/file/jcScod22AfWwcMCKCmv0Br/Sprint-55?node-id=222%3A450

![Screenshot 2020-07-15 at 15 04 36](https://user-images.githubusercontent.com/1792451/87554822-89fdaf00-c6ac-11ea-8c10-993bb5ca73bc.png)