### PR TITLE
Change GDS FormBuilder default error summary text

### DIFF
--- a/config/initializers/govuk_design_system_formbuilder.rb
+++ b/config/initializers/govuk_design_system_formbuilder.rb
@@ -1,5 +1,5 @@
 GOVUKDesignSystemFormBuilder.configure do |conf|
-  conf.default_error_summary_title  = 'Please correct the following errors'
+  conf.default_error_summary_title  = 'There is a problem'
   conf.default_legend_tag           = 'h3'
   conf.default_legend_size          = 's'
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,7 +219,6 @@ en:
     view_more_or_change: View more or change
   jobs:
     current_step: "Step %{step} of %{total}"
-    errors_present: Please correct the following errors
     notification_labels:
       new: new
       action_required: action required

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Creating a vacancy' do
         mandatory_fields = %w[job_title working_patterns]
 
         within('.govuk-error-summary') do
-          expect(page).to have_content(I18n.t('jobs.errors_present'))
+          expect(page).to have_content('There is a problem')
         end
 
         mandatory_fields.each do |field|
@@ -106,7 +106,7 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.continue')
 
         within('.govuk-error-summary') do
-          expect(page).to have_content(I18n.t('jobs.errors_present'))
+          expect(page).to have_content('There is a problem')
         end
 
         within_row_for(text: I18n.t('jobs.salary')) do
@@ -143,7 +143,7 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.continue')
 
         within('.govuk-error-summary') do
-          expect(page).to have_content(I18n.t('jobs.errors_present'))
+          expect(page).to have_content('There is a problem')
         end
 
         within_row_for(element: 'legend',
@@ -398,7 +398,7 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.continue')
 
         within('.govuk-error-summary') do
-          expect(page).to have_content(I18n.t('jobs.errors_present'))
+          expect(page).to have_content('There is a problem')
         end
 
         within_row_for(text: strip_tags(I18n.t('helpers.fieldset.application_details_form.contact_email_html'))) do
@@ -454,7 +454,7 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.continue')
 
         within('.govuk-error-summary') do
-          expect(page).to have_content(I18n.t('jobs.errors_present'))
+          expect(page).to have_content('There is a problem')
         end
 
         within_row_for(text: I18n.t('jobs.job_summary')) do
@@ -957,7 +957,7 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.continue')
 
         within('.govuk-error-summary') do
-          expect(page).to have_content(I18n.t('jobs.errors_present'))
+          expect(page).to have_content('There is a problem')
         end
 
         within_row_for(element: 'legend',

--- a/spec/features/hiring_staff_have_to_accept_terms_spec.rb
+++ b/spec/features/hiring_staff_have_to_accept_terms_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Hiring staff accepts terms and conditions' do
 
       current_user.reload
 
-      expect(page).to have_content(I18n.t('jobs.errors_present'))
+      expect(page).to have_content('There is a problem')
       expect(current_user).not_to be_accepted_terms_and_conditions
     end
 

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
         fill_in 'subscription[email]', with: 'jane.doe@example'
         click_on 'Subscribe'
 
-        expect(page).to have_content('Please correct the following error')
+        expect(page).to have_content('There is a problem')
         expect(page).to have_content('Enter an email address in the correct format, like name@example.com')
       end
 


### PR DESCRIPTION
## Changes in this PR:

Remove unused part of en.yml

The error message is now sourced from GDS FormBuilder config and is the same across all error summary messages.

- [x] Confirmed with Content that this is the new preferred default error summary text across all forms, replacing `Please correct the following errors`

- Why is it 4am, you ask? I couldn't sleep.
