### PR TITLE
Changed about_school to about_organisation

### DIFF
--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -28,7 +28,7 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
   end
 
   def copy_form_params
-    params.require(:copy_vacancy_form).permit(:state, :job_title, :about_school,
+    params.require(:copy_vacancy_form).permit(:state, :job_title, :about_organisation,
                                               :publish_on, :expires_on, :starts_on,
                                               :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem)
   end

--- a/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_summary_controller.rb
@@ -23,7 +23,7 @@ class HiringStaff::Vacancies::JobSummaryController < HiringStaff::Vacancies::App
   private
 
   def job_summary_form_params
-    params.require(:job_summary_form).permit(:state, :job_summary, :about_school).merge(completed_step: current_step)
+    params.require(:job_summary_form).permit(:state, :job_summary, :about_organisation).merge(completed_step: current_step)
   end
 
   def next_step

--- a/app/form_models/copy_vacancy_form.rb
+++ b/app/form_models/copy_vacancy_form.rb
@@ -20,7 +20,7 @@ class CopyVacancyForm < VacancyForm
     self.vacancy.status = 'draft'
 
     self.job_title = vacancy.job_title
-    self.about_school = vacancy.about_school
+    self.about_organisation = vacancy.about_organisation
     self.publish_on = nil if vacancy.publish_on.past?
 
     reset_date_fields if vacancy.expires_on.past?

--- a/app/models/concerns/vacancy_copy_validations.rb
+++ b/app/models/concerns/vacancy_copy_validations.rb
@@ -7,7 +7,7 @@ module VacancyCopyValidations
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
     validate :job_title_has_no_tags?, if: :job_title?
 
-    validates :about_school, presence: true
+    validates :about_organisation, presence: true
 
     validate :publish_on_must_not_be_before_today
   end

--- a/app/models/concerns/vacancy_job_summary_validations.rb
+++ b/app/models/concerns/vacancy_job_summary_validations.rb
@@ -3,6 +3,6 @@ module VacancyJobSummaryValidations
 
   included do
     validates :job_summary, presence: true
-    validates :about_school, presence: true
+    validates :about_organisation, presence: true
   end
 end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -23,9 +23,9 @@ class VacancyPresenter < BasePresenter
     simple_format(model.job_summary)
   end
 
-  def about_school
-    if model.about_school.present?
-      simple_format(model.about_school)
+  def about_organisation
+    if model.about_organisation.present?
+      simple_format(model.about_organisation)
     elsif school.description.present?
       simple_format(school.description)
     end

--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -32,7 +32,7 @@ json.hiringOrganization do
   json.set! '@type', 'School'
   json.name vacancy.school.name
   json.identifier vacancy.school.urn
-  json.description vacancy.about_school
+  json.description vacancy.about_organisation
 end
 
 json.validThrough vacancy.expires_on.end_of_day.to_time.iso8601

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -24,11 +24,11 @@
         %span#copy_form_job_title-info.govuk-hint.govuk-character-count__message{ "aria-live": "polite" }
           You can enter up to 100 characters
 
-      - unless @vacancy.about_school.present?
-        = f.govuk_text_area :about_school,
-          label: { text: t('helpers.fieldset.job_summary_form.about_school_html', school: current_school.name), size: 's' },
-          hint_text: t('helpers.hint.job_summary_form.about_school'),
-          value: @vacancy.about_school.presence || @vacancy.school.description.presence.to_s,
+      - unless @vacancy.about_organisation.present?
+        = f.govuk_text_area :about_organisation,
+          label: { text: t('helpers.fieldset.job_summary_form.about_organisation_html', school: current_school.name), size: 's' },
+          hint_text: t('helpers.hint.job_summary_form.about_organisation'),
+          value: @vacancy.about_organisation.presence || @vacancy.school.description.presence.to_s,
           rows: 10,
           required: true
 

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_summary.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_summary.html.haml
@@ -13,6 +13,6 @@
     %dd.app-check-your-answers__answer.first-question= @vacancy.job_summary
 
   .app-check-your-answers__contents
-    %dt.app-check-your-answers__question#about_school
-      %h4.govuk-heading-s= t('jobs.about_school', school: current_school.name)
-    %dd.app-check-your-answers__answer= @vacancy.about_school
+    %dt.app-check-your-answers__question#about_organisation
+      %h4.govuk-heading-s= t('jobs.about_organisation', school: current_school.name)
+    %dd.app-check-your-answers__answer= @vacancy.about_organisation

--- a/app/views/hiring_staff/vacancies/job_summary/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_summary/show.html.haml
@@ -22,10 +22,10 @@
         rows: 10,
         required: true
 
-      = f.govuk_text_area :about_school,
-        label: { text: t('helpers.fieldset.job_summary_form.about_school_html', school: current_school.name), size: 's' },
-        hint_text: t('helpers.hint.job_summary_form.about_school'),
-        value: @vacancy.about_school.presence || @vacancy.school.description.presence.to_s,
+      = f.govuk_text_area :about_organisation,
+        label: { text: t('helpers.fieldset.job_summary_form.about_organisation_html', school: current_school.name), size: 's' },
+        hint_text: t('helpers.hint.job_summary_form.about_organisation'),
+        value: @vacancy.about_organisation.presence || @vacancy.school.description.presence.to_s,
         rows: 10,
         required: true
 

--- a/app/views/vacancies/_school_overview_section.html.haml
+++ b/app/views/vacancies/_school_overview_section.html.haml
@@ -44,10 +44,10 @@
           %td.govuk-table__cell
             = mail_to @vacancy.contact_email, @vacancy.contact_email, class: 'govuk-link link-wrap', subject: t('jobs.contact_email_subject', job: @vacancy.job_title), body: t('jobs.contact_email_body', url: url_for(only_path: false))
 
-  - if @vacancy.about_school.present?
+  - if @vacancy.about_organisation.present?
     %h4.govuk-heading-s
       = t('schools.info', organisation: @vacancy.school.name)
-    %p= @vacancy.about_school
+    %p= @vacancy.about_organisation
 
   - if @vacancy.school_visits.present?
     %h4.govuk-heading-s

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -45,7 +45,7 @@ en:
   job_summary_errors: &job_summary_errors
     job_summary:
       blank: Enter a job summary
-    about_school:
+    about_organisation:
       blank: Enter a description of the school
   hiring_staff_user_preference_errors:
     managed_organisations:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,7 +169,7 @@ en:
         application_link: Link to online application
       job_summary_form:
         job_summary_html: "Job summary (<span class='text-red'>Required</span>)"
-        about_school_html: "About %{school} (<span class='text-red'>Required</span>)"
+        about_organisation_html: "About %{school} (<span class='text-red'>Required</span>)"
       organisation_form:
         description: Description of school or trust
     hint:
@@ -212,7 +212,7 @@ en:
         job_summary: >-
           Give a brief summary of the job that job seekers can quickly scan.
           This will be the first thing they see on the listing or in search engine results
-        about_school: "This will appear next to the job details under 'School overview'. Feel free to adapt this text"
+        about_organisation: "This will appear next to the job details under 'School overview'. Feel free to adapt this text"
       organisation_form:
         description: Jobseekers will see this description of the school in the job listing
   organisation:
@@ -371,7 +371,7 @@ en:
     time_at: ' at '
     publication_date: 'Date job will be listed'
     job_summary: 'Job summary'
-    about_school: 'About %{school}'
+    about_organisation: 'About %{school}'
     review: 'Review your entries for each section below, making any changes needed before you publish the listing.'
     review_future:
       'Review your entries for each section below, making any changes before you submit the listing for publication.'

--- a/db/migrate/20200716142704_change_about_school_field_to_about_organisation.rb
+++ b/db/migrate/20200716142704_change_about_school_field_to_about_organisation.rb
@@ -1,0 +1,5 @@
+class ChangeAboutSchoolFieldToAboutOrganisation < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :vacancies, :about_school, :about_organisation
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_10_080945) do
+ActiveRecord::Schema.define(version: 2020_07_16_142704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -256,7 +256,7 @@ ActiveRecord::Schema.define(version: 2020_07_10_080945) do
     t.string "job_roles", array: true
     t.string "salary"
     t.integer "completed_step"
-    t.text "about_school"
+    t.text "about_organisation"
     t.string "state", default: "create"
     t.string "subjects", array: true
     t.text "school_visits"

--- a/lib/job_posting.rb
+++ b/lib/job_posting.rb
@@ -25,7 +25,7 @@ class JobPosting
       publish_on: publish_on_or_today,
       expires_on: expires_on_or_future,
       job_summary: @schema['description'],
-      about_school: @schema['hiringOrganization']['description'],
+      about_organisation: @schema['hiringOrganization']['description'],
       school: school_by_urn_or_random
     }
   end

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Api::VacanciesController, type: :controller do
               '@type': 'School',
               'name': vacancy.school.name,
               'identifier': vacancy.school.urn,
-              'description': "<p>#{vacancy.about_school}</p>"
+              'description': "<p>#{vacancy.about_organisation}</p>"
             }
           }
           expect(json.to_h).to include(hiring_organization)

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
       create_list :document, 3, vacancy: vacancy
     end
 
-    about_school { Faker::Lorem.paragraph(sentence_count: 4) }
+    about_organisation { Faker::Lorem.paragraph(sentence_count: 4) }
     application_link { Faker::Internet.url }
     benefits { Faker::Lorem.paragraph(sentence_count: 4) }
     contact_email { Faker::Internet.email }

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -186,10 +186,10 @@ RSpec.feature 'Copying a vacancy' do
     end
   end
 
-  context '#about_school' do
-    context 'when a copied job has no about_school set' do
-      scenario 'it shows the about_school field' do
-        original_vacancy = build(:vacancy, :past_publish, about_school: nil, school: school)
+  context '#about_organisation' do
+    context 'when a copied job has no about_organisation set' do
+      scenario 'it shows the about_organisation field' do
+        original_vacancy = build(:vacancy, :past_publish, about_organisation: nil, school: school)
         original_vacancy.save(validate: false)
 
         visit organisation_path
@@ -201,12 +201,12 @@ RSpec.feature 'Copying a vacancy' do
         within('h1.govuk-heading-m') do
           expect(page).to have_content(I18n.t('jobs.copy_job_title', job_title: original_vacancy.job_title))
         end
-        expect(page).to have_content(I18n.t('jobs.about_school', school: school.name))
+        expect(page).to have_content(I18n.t('jobs.about_organisation', school: school.name))
       end
     end
 
-    context 'when a copied job has about_school set' do
-      scenario 'it does not show the about_school field' do
+    context 'when a copied job has about_organisation set' do
+      scenario 'it does not show the about_organisation field' do
         original_vacancy = create(:vacancy, school: school)
 
         visit organisation_path
@@ -218,7 +218,7 @@ RSpec.feature 'Copying a vacancy' do
         within('h1.govuk-heading-m') do
           expect(page).to have_content(I18n.t('jobs.copy_job_title', job_title: original_vacancy.job_title))
         end
-        expect(page).to_not have_content(I18n.t('jobs.about_school', school: school.name))
+        expect(page).to_not have_content(I18n.t('jobs.about_organisation', school: school.name))
       end
     end
   end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -461,7 +461,7 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content((I18n.t('activerecord.errors.models.vacancy.attributes.job_summary.blank')))
         end
 
-        within_row_for(text: I18n.t('jobs.about_school', school: school.name)) do
+        within_row_for(text: I18n.t('jobs.about_organisation', school: school.name)) do
           expect(page).to have_content(school.description)
         end
       end

--- a/spec/features/hiring_staff_can_save_and_return_later_spec.rb
+++ b/spec/features/hiring_staff_can_save_and_return_later_spec.rb
@@ -209,7 +209,7 @@ RSpec.feature 'Hiring staff can save and return later' do
         expect(page.current_path).to eql(organisation_job_job_summary_path(created_vacancy.id))
 
         fill_in 'job_summary_form[job_summary]', with: ''
-        fill_in 'job_summary_form[about_school]', with: @vacancy.about_school
+        fill_in 'job_summary_form[about_organisation]', with: @vacancy.about_organisation
         click_on I18n.t('buttons.save_and_return_later')
 
         expect(page.current_path).to eql(jobs_with_type_organisation_path('draft'))
@@ -219,7 +219,7 @@ RSpec.feature 'Hiring staff can save and return later' do
 
         expect(page.current_path).to eql(organisation_job_job_summary_path(created_vacancy.id))
         expect(find_field('job_summary_form[job_summary]').value).to eql('')
-        expect(find_field('job_summary_form[about_school]').value).to eql(@vacancy.about_school)
+        expect(find_field('job_summary_form[about_organisation]').value).to eql(@vacancy.about_organisation)
       end
     end
   end

--- a/spec/form_models/job_summary_form_spec.rb
+++ b/spec/form_models/job_summary_form_spec.rb
@@ -18,17 +18,17 @@ RSpec.describe JobSummaryForm, type: :model do
       end
     end
 
-    describe '#about_school' do
-      job_summary_form = JobSummaryForm.new(about_school: nil)
+    describe '#about_organisation' do
+      job_summary_form = JobSummaryForm.new(about_organisation: nil)
 
       context 'when about school is blank' do
-        let(:about_school) { nil }
+        let(:about_organisation) { nil }
 
         it 'requests an entry in the field' do
           expect(job_summary_form.valid?).to be false
-          expect(job_summary_form.errors.messages[:about_school])
+          expect(job_summary_form.errors.messages[:about_organisation])
             .to include(
-              I18n.t('activemodel.errors.models.job_summary_form.attributes.about_school.blank')
+              I18n.t('activemodel.errors.models.job_summary_form.attributes.about_organisation.blank')
             )
         end
       end
@@ -37,12 +37,12 @@ RSpec.describe JobSummaryForm, type: :model do
 
   context 'when all attributes are valid' do
     job_summary_form = JobSummaryForm.new(state: 'create', job_summary: 'Summary about the job',
-                                          about_school: 'Description of the school')
+                                          about_organisation: 'Description of the school')
 
     it 'a JobSummaryForm can be converted to a vacancy' do
       expect(job_summary_form.valid?).to be true
       expect(job_summary_form.vacancy.job_summary).to eq('Summary about the job')
-      expect(job_summary_form.vacancy.about_school).to eq('Description of the school')
+      expect(job_summary_form.vacancy.about_organisation).to eq('Description of the school')
     end
   end
 end

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -62,32 +62,32 @@ RSpec.describe VacancyPresenter do
     end
   end
 
-  describe '#about_school' do
-    context 'vacancy about_school is NOT nil' do
-      it 'returns the about_school content' do
+  describe '#about_organisation' do
+    context 'vacancy about_organisation is NOT nil' do
+      it 'returns the about_organisation content' do
         vacancy = VacancyPresenter.new(
-          build(:vacancy, about_school: 'Information about the school')
+          build(:vacancy, about_organisation: 'Information about the school')
         )
-        expect(vacancy.about_school).to eq('<p>Information about the school</p>')
+        expect(vacancy.about_organisation).to eq('<p>Information about the school</p>')
       end
     end
 
-    context 'vacancy about_school is nil' do
+    context 'vacancy about_organisation is nil' do
       context 'school description is NOT nil' do
         it 'returns the school description' do
           vacancy = VacancyPresenter.new(
-            build(:vacancy, about_school: nil, school: build(:school, description: 'School description'))
+            build(:vacancy, about_organisation: nil, school: build(:school, description: 'School description'))
           )
-          expect(vacancy.about_school).to eq('<p>School description</p>')
+          expect(vacancy.about_organisation).to eq('<p>School description</p>')
         end
       end
 
       context 'school description is nil' do
         it 'returns nil' do
           vacancy = VacancyPresenter.new(
-            build(:vacancy, about_school: nil, school: build(:school, description: nil))
+            build(:vacancy, about_organisation: nil, school: build(:school, description: nil))
           )
-          expect(vacancy.about_school).to be nil
+          expect(vacancy.about_organisation).to be nil
         end
       end
     end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -68,7 +68,7 @@ module VacancyHelpers
 
   def fill_in_job_summary_form_fields(vacancy)
     fill_in 'job_summary_form[job_summary]', with: vacancy.job_summary
-    fill_in 'job_summary_form[about_school]', with: vacancy.about_school
+    fill_in 'job_summary_form[about_organisation]', with: vacancy.about_organisation
   end
 
   def fill_in_copy_vacancy_form_fields(vacancy)
@@ -112,7 +112,7 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.application_link)
 
     expect(page.html).to include(vacancy.job_summary)
-    expect(page.html).to include(vacancy.about_school)
+    expect(page.html).to include(vacancy.about_organisation)
   end
 
   def verify_vacancy_show_page_details(vacancy)
@@ -132,7 +132,7 @@ module VacancyHelpers
     expect(page.html).to include(vacancy.how_to_apply)
 
     expect(page.html).to include(vacancy.job_summary)
-    expect(page.html).to include(vacancy.about_school)
+    expect(page.html).to include(vacancy.about_organisation)
 
     if vacancy.documents.any?
       expect(page).to have_content(I18n.t('jobs.supporting_documents'))
@@ -185,7 +185,7 @@ module VacancyHelpers
         '@type': 'School',
         'name': vacancy.school.name,
         'identifier': vacancy.school.urn,
-        'description': vacancy.about_school
+        'description': vacancy.about_organisation
       },
       'validThrough': vacancy.expires_on.end_of_day.to_time.iso8601,
     }


### PR DESCRIPTION
Added migration file to change about_school field in vacancies table to about_organisation. Replaced all references to about_school to about_organisation


## Changes in this PR:

- Created a migration file to change about_school field to about_organisation
- Replaced all references to about_school to about_organisation

