### PR TITLE
Copy job refactor

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -136,7 +136,7 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
 
   def add_errors_to_form(errors, form_object)
     errors.each do |field, error|
-      form_object.errors.add(field, error)
+      form_object.errors.messages[field].unshift(error)
     end
   end
 end

--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -19,6 +19,8 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
   def set_vacancy
     if params[:job_id]
       @vacancy = current_school.vacancies.find(params[:job_id])
+    elsif params[:id]
+      @vacancy = current_school.vacancies.find(params[:id])
     elsif session_vacancy_id
       @vacancy = current_school.vacancies.find(session_vacancy_id)
     end

--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -1,35 +1,41 @@
 class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::ApplicationController
+  before_action :set_up_copy_form, only: %i[create]
+
   def new
-    @copy_form = CopyVacancyForm.new(vacancy: @vacancy)
+    reset_date_fields if @vacancy.publish_on.past?
+    @copy_form = CopyVacancyForm.new(@vacancy.attributes.symbolize_keys)
   end
 
   def create
-    @copy_form = CopyVacancyForm.new(vacancy: @vacancy)
-    date_errors = convert_multiparameter_attributes_to_dates(
-      :copy_vacancy_form, [:publish_on, :expires_on, :starts_on]
-    )
-    @proposed_vacancy = @copy_form.apply_changes!(copy_form_params)
-    @copy_form.update_expiry_time(@proposed_vacancy, params.require(:copy_vacancy_form))
-    add_errors_to_form(date_errors, @copy_form)
-
-    if valid_copy_form?
-      new_vacancy = CopyVacancy.new(@proposed_vacancy).call
+    if @copy_form.complete_and_valid?
+      new_vacancy = CopyVacancy.new(@vacancy).call
+      update_vacancy(@copy_form.params_to_save, new_vacancy)
+      update_google_index(new_vacancy) if new_vacancy.listed?
       Auditor::Audit.new(new_vacancy, 'vacancy.copy', current_session_id).log
-      return redirect_to organisation_job_review_path(new_vacancy.id)
+      redirect_to organisation_job_review_path(new_vacancy.id)
+    else
+      add_errors_to_form(@date_errors, @copy_form)
+      render :new
     end
-
-    render :new
   end
 
   private
 
-  def valid_copy_form?
-    @copy_form.complete_and_valid? && @proposed_vacancy.valid?
+  def copy_form_params
+    params.require(:copy_vacancy_form).permit(:state, :job_title, :publish_on, :expires_on, :starts_on,
+                                              :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem)
   end
 
-  def copy_form_params
-    params.require(:copy_vacancy_form).permit(:state, :job_title, :about_school,
-                                              :publish_on, :expires_on, :starts_on,
-                                              :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem)
+  def set_up_copy_form
+    @date_errors = convert_multiparameter_attributes_to_dates(
+      :copy_vacancy_form, [:publish_on, :expires_on, :starts_on]
+    )
+    @copy_form = CopyVacancyForm.new(copy_form_params)
+  end
+
+  def reset_date_fields
+    @vacancy.expires_on = nil
+    @vacancy.starts_on = nil
+    @vacancy.publish_on = nil
   end
 end

--- a/app/controllers/hiring_staff/vacancies/important_dates_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/important_dates_controller.rb
@@ -16,10 +16,11 @@ class HiringStaff::Vacancies::ImportantDatesController < HiringStaff::Vacancies:
     if @important_dates_form.complete_and_valid?
       update_vacancy(@important_dates_form.params_to_save, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
-      return redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
+      redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
+    else
+      add_errors_to_form(@date_errors, @important_dates_form)
+      render :show
     end
-
-    render :show
   end
 
   private
@@ -28,9 +29,8 @@ class HiringStaff::Vacancies::ImportantDatesController < HiringStaff::Vacancies:
     publish_in_past = @vacancy.published? && @vacancy.reload.publish_on.past?
     delete_publish_on_params if publish_in_past
     dates_to_convert = publish_in_past ? [:starts_on, :expires_on] : [:starts_on, :publish_on, :expires_on]
-    date_errors = convert_multiparameter_attributes_to_dates(:important_dates_form, dates_to_convert)
+    @date_errors = convert_multiparameter_attributes_to_dates(:important_dates_form, dates_to_convert)
     @important_dates_form = ImportantDatesForm.new(important_dates_params)
-    add_errors_to_form(date_errors, @important_dates_form)
   end
 
   def important_dates_params

--- a/app/form_models/copy_vacancy_form.rb
+++ b/app/form_models/copy_vacancy_form.rb
@@ -1,55 +1,5 @@
-class CopyVacancyForm < VacancyForm
-  include ActiveModel::Model
-  include DateHelper
-
-  include VacancyImportantDateValidations
-  include VacancyExpiryTimeFieldValidations
+class CopyVacancyForm < ImportantDatesForm
   include VacancyCopyValidations
 
-  delegate :publish_on, :expires_on, :starts_on, :errors,
-           :publish_on_changed?, :expires_on_changed?, :starts_on_changed?, to: :vacancy
-
-  attr_accessor :expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem
-
-  def initialize(vacancy:)
-    @expiry_time_hh = vacancy.expiry_time&.strftime('%-l')
-    @expiry_time_mm = vacancy.expiry_time&.strftime('%-M')
-    @expiry_time_meridiem = vacancy.expiry_time&.strftime('%P')
-
-    self.vacancy = vacancy
-    self.vacancy.status = 'draft'
-
-    self.job_title = vacancy.job_title
-    self.about_school = vacancy.about_school
-    self.publish_on = nil if vacancy.publish_on.past?
-
-    reset_date_fields if vacancy.expires_on.past?
-  end
-
-  def apply_changes!(params = {})
-    assign_attributes(params.extract!(:expiry_time_hh, :expiry_time_mm, :expiry_time_meridiem))
-    vacancy.assign_attributes(params)
-    vacancy
-  end
-
-  def update_expiry_time(vacancy, params)
-    expiry_time_attr = {
-      day: vacancy.expires_on&.day,
-      month: vacancy.expires_on&.month,
-      year: vacancy.expires_on&.year,
-      hour: params[:expiry_time_hh],
-      min: params[:expiry_time_mm],
-      meridiem: params[:expiry_time_meridiem]
-    }
-    expiry_time = compose_expiry_time(expiry_time_attr)
-    vacancy.expiry_time = expiry_time unless expiry_time.nil?
-  end
-
-  private
-
-  def reset_date_fields
-    self.starts_on  = nil
-    self.expires_on = nil
-    self.publish_on = nil
-  end
+  delegate :job_title, to: :vacancy
 end

--- a/app/form_models/important_dates_form.rb
+++ b/app/form_models/important_dates_form.rb
@@ -18,22 +18,8 @@ class ImportantDatesForm < VacancyForm
     super(params)
   end
 
-  def completed?
-    publish_on && expires_on && expiry_time
-  end
-
   def disable_editing_publish_on?
     published? && vacancy.reload.publish_on.past?
-  end
-
-  def attributes
-    vacancy_attributes = @vacancy.attributes
-    vacancy_attributes.merge!(
-      expiry_time_hh: expiry_time_hh,
-      expiry_time_mm: expiry_time_mm,
-      expiry_time_meridiem: expiry_time_meridiem,
-    )
-    vacancy_attributes
   end
 
   def params_to_save

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -13,7 +13,6 @@ import 'src/deleteAccordionControl';
 import 'src/deleteDocument';
 import 'src/details';
 import 'src/dismissableElement';
-import 'src/disabledInputs';
 import 'src/googleOptimise';
 import 'src/googleTagManagerUrlSnippet';
 import 'src/removeCommaFromNumber';

--- a/app/frontend/styles/components/check_your_answers.scss
+++ b/app/frontend/styles/components/check_your_answers.scss
@@ -101,7 +101,8 @@ dt.app-check-your-answers__question > h4 {
   vertical-align: middle;
 }
 
-.action-required {
+.action-required-tag {
+  @extend .notification-tag;
   background-color: govuk-colour('red');
 }
 

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -72,7 +72,7 @@ module VacanciesHelper
 
   def page_title(vacancy, organisation = current_organisation)
     if vacancy.state == 'copy'
-      I18n.t('jobs.copy_job_title', job_title: vacancy.job_title.downcase)
+      I18n.t('jobs.copy_job_title', job_title: vacancy.job_title)
     elsif %w(create review).include?(vacancy.state)
       I18n.t('jobs.create_a_job_title', organisation: organisation.name)
     else

--- a/app/models/concerns/vacancy_copy_validations.rb
+++ b/app/models/concerns/vacancy_copy_validations.rb
@@ -1,25 +1,20 @@
 module VacancyCopyValidations
   extend ActiveSupport::Concern
   include ApplicationHelper
+  include DateHelper
+
+  include VacancyImportantDateValidations
+  include VacancyExpiryTimeFieldValidations
 
   included do
     validates :job_title, presence: true
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
     validate :job_title_has_no_tags?, if: :job_title?
-
-    validates :about_school, presence: true
-
-    validate :publish_on_must_not_be_before_today
   end
 
   def job_title_has_no_tags?
     errors.add(
       :job_title, I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.invalid_characters')
     ) unless job_title == sanitize(job_title, tags: [])
-  end
-
-  def publish_on_must_not_be_before_today
-    errors.add(:publish_on, I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.before_today')) if
-      publish_on && publish_on < Time.zone.today
   end
 end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -24,11 +24,7 @@ class VacancyPresenter < BasePresenter
   end
 
   def about_school
-    if model.about_school.present?
-      simple_format(model.about_school)
-    elsif school.description.present?
-      simple_format(school.description)
-    end
+    simple_format(model.about_school)
   end
 
   def school_visits

--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -5,30 +5,15 @@ class CopyVacancy
 
   def initialize(vacancy)
     @vacancy = vacancy
+    setup_new_vacancy
+    reset_candidate_specification if @vacancy.any_candidate_specification?
+    copy_legacy_subjects
   end
 
   def call
-    @new_vacancy = @vacancy.dup
-    @new_vacancy.status = :draft
-    @new_vacancy.weekly_pageviews = 0
-    @new_vacancy.weekly_pageviews_updated_at = Time.zone.now
-    @new_vacancy.total_pageviews = 0
-    @new_vacancy.total_pageviews_updated_at = Time.zone.now
-    @new_vacancy.total_get_more_info_clicks = 0
-    @new_vacancy.total_get_more_info_clicks_updated_at = Time.zone.now
-
-    if @vacancy.any_candidate_specification?
-      @new_vacancy.experience = nil
-      @new_vacancy.education = nil
-      @new_vacancy.qualifications = nil
-    end
-
-    copy_legacy_subjects
-
-    @new_vacancy.save
-
+    @new_vacancy.send(:set_slug)
+    @new_vacancy.save(validate: false)
     copy_documents
-
     @new_vacancy
   end
 
@@ -55,5 +40,25 @@ class CopyVacancy
       get_subject_name(@vacancy.first_supporting_subject),
       get_subject_name(@vacancy.second_supporting_subject)
     ].uniq.reject(&:blank?) unless @new_vacancy.subjects.any?
+    @new_vacancy.subject = nil
+    @new_vacancy.first_supporting_subject = nil
+    @new_vacancy.second_supporting_subject = nil
+  end
+
+  def reset_candidate_specification
+    @new_vacancy.experience = nil
+    @new_vacancy.education = nil
+    @new_vacancy.qualifications = nil
+  end
+
+  def setup_new_vacancy
+    @new_vacancy = @vacancy.dup
+    @new_vacancy.status = :draft
+    @new_vacancy.weekly_pageviews = 0
+    @new_vacancy.weekly_pageviews_updated_at = Time.zone.now
+    @new_vacancy.total_pageviews = 0
+    @new_vacancy.total_pageviews_updated_at = Time.zone.now
+    @new_vacancy.total_get_more_info_clicks = 0
+    @new_vacancy.total_get_more_info_clicks_updated_at = Time.zone.now
   end
 end

--- a/app/views/hiring_staff/vacancies/_error_messages.html.haml
+++ b/app/views/hiring_staff/vacancies/_error_messages.html.haml
@@ -1,11 +1,8 @@
 - if errors.any?
-  #errors.govuk-error-summary{ role: 'alert', tabindex: '-1' }
-    %h2.govuk-error-summary__title
-      = t('errors.title', count: errors.count)
-    .govuk-error-summary__body
-      %ul.govuk-list.govuk-error-summary__list
-        - errors.each do |attribute, error|
-          - if attribute == :expiry_time
-            %li= link_to error, "##{attribute}"
-          - else
-            %li= link_to errors.full_message(attribute, error), "##{attribute}"
+  #errors.govuk-notification.govuk-notification--danger{ role: 'alert', tabindex: '-1' }
+    .govuk-notification__title= t('messages.jobs.action_required.heading')
+    .govuk-notification__body= t('messages.jobs.action_required.message')
+    %ul.govuk-list.govuk-notification__list
+      - errors.each do |attribute, error|
+        %li
+          %a.govuk-link.govuk-link--no-visited-state{ href: "##{attribute}" }= error

--- a/app/views/hiring_staff/vacancies/_error_tag.html.haml
+++ b/app/views/hiring_staff/vacancies/_error_tag.html.haml
@@ -1,0 +1,4 @@
+- attributes.each do |attribute|
+  - if @vacancy.errors.messages.keys.include?(attribute)
+    %strong.govuk-tag.action-required-tag{ class: "action-required--#{section}" }= t('jobs.notification_labels.action_required')
+    - break

--- a/app/views/hiring_staff/vacancies/_section_tag.html.haml
+++ b/app/views/hiring_staff/vacancies/_section_tag.html.haml
@@ -1,2 +1,2 @@
 - if new_sections(@vacancy).include?(section)
-  %strong.govuk-tag.notification-tag{ class: "new-#{section}" }= t('jobs.notification_labels.new')
+  %strong.govuk-tag.notification-tag{ class: "new--#{section}" }= t('jobs.notification_labels.new')

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, "#{@copy_form.errors.present? ? 'Error: ' : ''}Copy a job for #{current_school.name}"
 
-%h1.govuk-heading-m= t('jobs.copy_job_title', job_title: @copy_form.vacancy.job_title.downcase)
+%h1.govuk-heading-m= t('jobs.copy_job_title', job_title: @copy_form.vacancy.job_title)
 
 = link_to t('buttons.cancel_copy'), organisation_path, class: 'govuk-back-link govuk-!-margin-bottom-5'
 
@@ -23,14 +23,6 @@
           required: true
         %span#copy_form_job_title-info.govuk-hint.govuk-character-count__message{ "aria-live": "polite" }
           You can enter up to 100 characters
-
-      - unless @vacancy.about_school.present?
-        = f.govuk_text_area :about_school,
-          label: { text: t('helpers.fieldset.job_summary_form.about_school_html', school: current_school.name), size: 's' },
-          hint_text: t('helpers.hint.job_summary_form.about_school'),
-          value: @vacancy.about_school.presence || @vacancy.school.description.presence.to_s,
-          rows: 10,
-          required: true
 
       = f.govuk_date_field :publish_on,
         legend: { text: t('helpers.fieldset.important_dates_form.publish_on_html') },

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -4,6 +4,7 @@
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds
     = render 'hiring_staff/vacancies/edit_heading'
+    = render 'hiring_staff/vacancies/error_messages', errors: @vacancy.errors
 
     %ol.app-task-list
       %li= render 'hiring_staff/vacancies/edit_vacancy_sections/edit_job_specification'

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_application_details.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_application_details.html.haml
@@ -1,4 +1,5 @@
 = render 'hiring_staff/vacancies/section_tag', section: 'application_details'
+= render 'hiring_staff/vacancies/error_tag', attributes: [:contact_email, :school_visits, :how_to_apply, :application_link], section: 'application_details'
 
 %h2.govuk-heading-m.app-task-list__section#application_details_heading
   %span.app-task-list__section-number 5.

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_important_dates.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_important_dates.html.haml
@@ -1,4 +1,5 @@
 = render 'hiring_staff/vacancies/section_tag', section: 'important_dates'
+= render 'hiring_staff/vacancies/error_tag', attributes: [:publish_on, :expires_on, :starts_on], section: 'important_dates'
 
 %h2.govuk-heading-m.app-task-list__section#important_dates_heading
   %span.app-task-list__section-number 3.

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -1,4 +1,5 @@
 = render 'hiring_staff/vacancies/section_tag', section: 'job_details'
+= render 'hiring_staff/vacancies/error_tag', attributes: [:job_title, :job_roles, :subjects, :working_patterns], section: 'job_details'
 
 %h2.govuk-heading-m.app-task-list__section#job_details_heading
   %span.app-task-list__section-number 1.

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_summary.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_summary.html.haml
@@ -1,4 +1,5 @@
 = render 'hiring_staff/vacancies/section_tag', section: 'job_summary'
+= render 'hiring_staff/vacancies/error_tag', attributes: [:job_summary, :about_school], section: 'job_summary'
 
 %h2.govuk-heading-m.app-task-list__section#job_summary_heading
   %span.app-task-list__section-number 6.

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_pay_package.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_pay_package.html.haml
@@ -1,4 +1,5 @@
 = render 'hiring_staff/vacancies/section_tag', section: 'pay_package'
+= render 'hiring_staff/vacancies/error_tag', attributes: [:salary, :benefits], section: 'pay_package'
 
 %h2.govuk-heading-m.app-task-list__section#pay_package_heading
   %span.app-task-list__section-number 2.

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -4,14 +4,13 @@
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds
     = render 'hiring_staff/vacancies/edit_heading'
+    = render 'hiring_staff/vacancies/error_messages', errors: @vacancy.errors
 
     %p.govuk-body-l
       - if @vacancy.publish_on.today?
         = t('jobs.review')
       - else
         = t('jobs.review_future')
-
-    = render 'hiring_staff/vacancies/error_messages', errors: @vacancy.errors
 
     %ol.app-task-list
       %li= render 'hiring_staff/vacancies/edit_vacancy_sections/edit_job_specification'

--- a/app/views/vacancies/_school_overview_section.html.haml
+++ b/app/views/vacancies/_school_overview_section.html.haml
@@ -44,7 +44,7 @@
           %td.govuk-table__cell
             = mail_to @vacancy.contact_email, @vacancy.contact_email, class: 'govuk-link link-wrap', subject: t('jobs.contact_email_subject', job: @vacancy.job_title), body: t('jobs.contact_email_body', url: url_for(only_path: false))
 
-  - if @vacancy.about_school.present?
+  - if strip_tags(@vacancy.about_school).present?
     %h4.govuk-heading-s
       = t('schools.info', organisation: @vacancy.school.name)
     %p= @vacancy.about_school

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -79,6 +79,10 @@ en:
         job_summary_form:
           attributes:
             <<: *job_summary_errors
+        copy_vacancy_form:
+          attributes:
+            <<: *job_specification_errors
+            <<: *important_dates_errors
         nqt_job_alerts_form:
           attributes:
             keywords:
@@ -104,24 +108,6 @@ en:
             <<: *supporting_documents_errors
             <<: *application_details_errors
             <<: *job_summary_errors
-            publish_on:
-              blank: Enter the date job will be listed
-              before_today: Date job will be listed must be either today or in the future
-              invalid: Use the correct format for date job will be listed
-            expires_on:
-              blank: Enter the date application is due
-              before_today: Date application is due must be in the future
-              before_publish_on: Date application is due must be after date job will be listed
-              invalid: Use the correct format for date application is due
-            expiry_time:
-              blank: Enter the time application is due
-              wrong_format: Use the correct format for time application is due
-              must_be_am_pm: Select am or pm
-            starts_on:
-              before_today: Date job starts must be in the future
-              before_publish_on: Date job starts must be after date job will be listed
-              before_expires_on: Date job starts must be after date application is due
-              invalid: Use the correct format for date the job starts
         vacancy_publish_feedback:
           attributes:
             user_participation_response:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -762,8 +762,11 @@ en:
     jobs:
       already_published: This job has already been published
       new_sections:
-        heading: 'New section'
-        message: 'Improve your job listing using the new sections and features below'
+        heading: New section
+        message: Improve your job listing using the new sections and features below
+      action_required:
+        heading: Action required
+        message: You must complete the required actions below in order to publish this listing
       feedback:
         awaiting:
           one: You have %{count} job awaiting feedback

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -61,7 +61,6 @@ RSpec.feature 'Copying a vacancy' do
     end
   end
 
-
   scenario 'a job can be successfully copied and published' do
     original_vacancy = build(:vacancy, :past_publish, school: school)
     original_vacancy.save(validate: false) # Validation prevents publishing on a past date
@@ -183,43 +182,6 @@ RSpec.feature 'Copying a vacancy' do
 
       click_on I18n.t('buttons.continue')
       expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.invalid'))
-    end
-  end
-
-  context '#about_school' do
-    context 'when a copied job has no about_school set' do
-      scenario 'it shows the about_school field' do
-        original_vacancy = build(:vacancy, :past_publish, about_school: nil, school: school)
-        original_vacancy.save(validate: false)
-
-        visit organisation_path
-
-        within('table.vacancies') do
-          click_on I18n.t('jobs.copy_link')
-        end
-
-        within('h1.govuk-heading-m') do
-          expect(page).to have_content(I18n.t('jobs.copy_job_title', job_title: original_vacancy.job_title))
-        end
-        expect(page).to have_content(I18n.t('jobs.about_school', school: school.name))
-      end
-    end
-
-    context 'when a copied job has about_school set' do
-      scenario 'it does not show the about_school field' do
-        original_vacancy = create(:vacancy, school: school)
-
-        visit organisation_path
-
-        within('table.vacancies') do
-          click_on I18n.t('jobs.copy_link')
-        end
-
-        within('h1.govuk-heading-m') do
-          expect(page).to have_content(I18n.t('jobs.copy_job_title', job_title: original_vacancy.job_title))
-        end
-        expect(page).to_not have_content(I18n.t('jobs.about_school', school: school.name))
-      end
     end
   end
 

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -104,6 +104,65 @@ RSpec.feature 'Copying a vacancy' do
     expect(page).to have_content(new_application_deadline)
   end
 
+  context 'when the original job is now invalid' do
+    scenario 'the job can be successfully copied but not published until valid' do
+      original_vacancy = build(:vacancy, :complete, school: school, about_school: nil)
+      original_vacancy.send(:set_slug)
+      original_vacancy.save(validate: false)
+
+      visit organisation_path
+
+      new_vacancy = original_vacancy.dup
+      new_vacancy.job_title = 'A new job title'
+      new_vacancy.starts_on = 35.days.from_now
+      new_vacancy.publish_on = 0.days.from_now
+      new_vacancy.expiry_time = new_vacancy.expires_on = 30.days.from_now
+
+      within('table.vacancies') do
+        click_on I18n.t('jobs.copy_link')
+      end
+
+      within('h1.govuk-heading-m') do
+        expect(page).to have_content(I18n.t('jobs.copy_job_title', job_title: original_vacancy.job_title))
+      end
+
+      fill_in_copy_vacancy_form_fields(new_vacancy)
+      click_on I18n.t('buttons.continue')
+
+      within('h2.govuk-heading-l') do
+        expect(page).to have_content(I18n.t('jobs.copy_review_heading'))
+      end
+
+      within '#errors.govuk-notification--danger' do
+        expect(page).to have_content(I18n.t('messages.jobs.action_required.heading'))
+        expect(page).to have_content(I18n.t('messages.jobs.action_required.message'))
+        expect(page).to have_content(I18n.t('job_summary_errors.about_school.blank'))
+      end
+
+      click_on I18n.t('jobs.submit_listing.button')
+      within '#errors.govuk-notification--danger' do
+        expect(page).to have_content(I18n.t('messages.jobs.action_required.heading'))
+        expect(page).to have_content(I18n.t('messages.jobs.action_required.message'))
+        expect(page).to have_content(I18n.t('job_summary_errors.about_school.blank'))
+      end
+
+      click_header_link(I18n.t('jobs.job_summary'))
+      fill_in 'job_summary_form[about_school]', with: 'Some description about the school'
+      click_on I18n.t('buttons.update_job')
+
+      within('h2.govuk-heading-l') do
+        expect(page).to have_content(I18n.t('jobs.copy_review_heading'))
+      end
+      expect(page).to have_content('Some description about the school')
+
+      click_on I18n.t('jobs.submit_listing.button')
+      expect(page).to have_content(I18n.t('jobs.confirmation_page.submitted'))
+
+      click_on I18n.t('jobs.confirmation_page.view_posted_job')
+      expect(page).to have_content('Some description about the school')
+    end
+  end
+
   context 'when the original job is pending/scheduled/future_publish' do
     scenario 'a job can be successfully copied' do
       original_vacancy = create(:vacancy, :future_publish, school: school)

--- a/spec/features/hiring_staff_can_delete_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_delete_vacancies_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'School deleting vacancies' do
   let(:vacancy) { create(:vacancy, school: school) }
   let(:session_id) { SecureRandom.uuid }
 
-  before(:each) do
+  before do
     stub_hiring_staff_auth(urn: school.urn, session_id: session_id)
     stub_document_deletion_of_vacancy
   end
@@ -65,9 +65,9 @@ RSpec.feature 'School deleting vacancies' do
     # to wrap the vacancy, instead of creating its own new vacancy object.
     # We need to use a `vacancy` object created in the test so that we can stub out the method
     # Vacancy#delete_documents, which otherwise will attempt HTTP connections.
-    hiring_staff_vacancies_controller = HiringStaff::VacanciesController.new
-    allow(HiringStaff::VacanciesController).to receive(:new).and_return(hiring_staff_vacancies_controller)
-    allow(hiring_staff_vacancies_controller).to receive(:find_active_vacancy_by_id).and_return(vacancy)
+    allow_any_instance_of(HiringStaff::Vacancies::ApplicationController).to receive_message_chain(
+      :current_school, :vacancies, :find
+    ).and_return(vacancy)
     allow(vacancy).to receive(:delete_documents).and_return(nil)
   end
 end

--- a/spec/form_models/copy_vacancy_form_spec.rb
+++ b/spec/form_models/copy_vacancy_form_spec.rb
@@ -1,92 +1,62 @@
 require 'rails_helper'
 
 RSpec.describe CopyVacancyForm, type: :model do
-  it 'copies the vacancy attributes to the form object' do
-    original_vacancy = build(:vacancy)
+  describe 'validations' do
+    describe '#job_title' do
+      let(:copy_form) { CopyVacancyForm.new(job_title: job_title) }
 
-    form_object = described_class.new(vacancy: original_vacancy)
+      context 'when title is blank' do
+        let(:job_title) { nil }
 
-    expect(form_object.job_title).to eq(original_vacancy.job_title)
-    expect(form_object.starts_on).to eq(original_vacancy.starts_on)
-    expect(form_object.expires_on).to eq(original_vacancy.expires_on)
-    expect(form_object.expiry_time_hh).to eq(original_vacancy.expiry_time&.strftime('%-l'))
-    expect(form_object.expiry_time_mm).to eq(original_vacancy.expiry_time&.strftime('%-M'))
-    expect(form_object.expiry_time_meridiem).to eq(original_vacancy.expiry_time&.strftime('%P'))
-    expect(form_object.expiry_time).to eq(original_vacancy.expiry_time)
-    expect(form_object.publish_on).to eq(original_vacancy.publish_on)
-  end
-
-  it 'doesn\'t copy any dates for expired vacancies' do
-    expired_vacancy = build(:vacancy, :expired)
-
-    form_object = described_class.new(vacancy: expired_vacancy)
-
-    expect(form_object.starts_on).to be_nil
-    expect(form_object.expires_on).to be_nil
-    expect(form_object.publish_on).to be_nil
-  end
-
-  describe '#apply_changes!' do
-    it 'updates the original vacancy with the users new preferences' do
-      original_vacancy = build(:vacancy)
-
-      new_choices = {
-        job_title: 'Foo',
-        starts_on: 20.days.from_now.to_date,
-        expires_on: 5.days.from_now.to_date,
-        publish_on: 0.days.from_now.to_date,
-      }
-
-      new_vacancy = described_class.new(vacancy: original_vacancy)
-                                   .apply_changes!(new_choices)
-
-      expect(new_vacancy).to be_kind_of(Vacancy)
-      expect(new_vacancy.job_title).to eq(new_choices[:job_title])
-      expect(new_vacancy.starts_on).to eq(new_choices[:starts_on])
-      expect(new_vacancy.expires_on).to eq(new_choices[:expires_on])
-      expect(new_vacancy.publish_on).to eq(new_choices[:publish_on])
-    end
-
-    describe '#update_expiry_time' do
-      it 'updates the original vacancy with the users new preferences' do
-        vacancy = build(:vacancy, expires_on: 5.days.from_now.to_date)
-
-        new_choices = {
-          expires_on: 5.days.from_now.to_date,
-          expiry_time_hh: 11,
-          expiry_time_mm: 11,
-          expiry_time_meridiem: 'am'
-        }
-
-        expiry_time_string = "#{new_choices[:expires_on].day}-#{new_choices[:expires_on].month}-"\
-                            "#{new_choices[:expires_on].year} #{new_choices[:expiry_time_hh]}" \
-                           ":#{new_choices[:expiry_time_mm]} #{new_choices[:expiry_time_meridiem]}"
-        new_expiry_time = Time.zone.parse(expiry_time_string)
-
-        described_class.new(vacancy: vacancy)
-                       .update_expiry_time(vacancy, new_choices)
-
-        expect(vacancy.expiry_time).to eq(new_expiry_time)
+        it 'requests an entry in the field' do
+          expect(copy_form.valid?).to be false
+          expect(copy_form.errors.messages[:job_title][0])
+            .to eq('Enter a job title')
+        end
       end
-    end
 
-    it 'does not make changes to the form_object so the form can be repopulated on error' do
-      original_vacancy = build(:vacancy)
+      context 'when title is too short' do
+        let(:job_title) { 'aa' }
 
-      new_choices = {
-        job_title: 'Foo',
-        starts_on: 20.days.from_now.to_date,
-        expires_on: 5.days.from_now.to_date,
-        publish_on: 0.days.from_now.to_date,
-      }
+        it 'validates minimum length' do
+          expect(copy_form.valid?).to be false
+          expect(copy_form.errors.messages[:job_title][0])
+            .to eq(I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.too_short', count: 4))
+        end
+      end
 
-      form_object = described_class.new(vacancy: original_vacancy)
-      form_object.apply_changes!(new_choices)
+      context 'when title is too long' do
+        let(:job_title) { 'Long title' * 100 }
 
-      expect(form_object.job_title).to eq(new_choices[:job_title])
-      expect(form_object.starts_on).to eq(new_choices[:starts_on])
-      expect(form_object.expires_on).to eq(new_choices[:expires_on])
-      expect(form_object.publish_on).to eq(new_choices[:publish_on])
+        it 'validates max length' do
+          expect(copy_form.valid?).to be false
+          expect(copy_form.errors.messages[:job_title][0])
+            .to eq(I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.too_long', count: 100))
+        end
+      end
+
+      context 'when title contains HTML tags' do
+        let(:job_title) { 'Title with <p>tags</p>' }
+
+        it 'validates presence of HTML tags' do
+          expect(copy_form.valid?).to be false
+          expect(copy_form.errors.messages[:job_title]).to include(
+            I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.invalid_characters')
+          )
+        end
+      end
+
+      context 'when title does not contain HTML tags' do
+        context 'job title contains &' do
+          let(:job_title) { 'Job & another job' }
+
+          it 'does not validate presence of HTML tags' do
+            expect(copy_form.errors.messages[:job_title]).to_not include(
+              I18n.t('activemodel.errors.models.job_specification_form.attributes.job_title.invalid_characters')
+            )
+          end
+        end
+      end
     end
   end
 end

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe VacanciesHelper, type: :helper do
       allow(vacancy).to receive(:state).and_return('copy')
       allow(vacancy).to receive(:job_title).and_return('Test job title')
 
-      expect(page_title(vacancy, school)).to eql(I18n.t('jobs.copy_job_title', job_title: 'test job title'))
+      expect(page_title(vacancy, school)).to eql(I18n.t('jobs.copy_job_title', job_title: 'Test job title'))
     end
 
     it 'returns create a job title if vacancy state is create' do

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -63,33 +63,11 @@ RSpec.describe VacancyPresenter do
   end
 
   describe '#about_school' do
-    context 'vacancy about_school is NOT nil' do
-      it 'returns the about_school content' do
-        vacancy = VacancyPresenter.new(
-          build(:vacancy, about_school: 'Information about the school')
-        )
-        expect(vacancy.about_school).to eq('<p>Information about the school</p>')
-      end
-    end
+    it 'sanitizes and transforms about_school into HTML' do
+      vacancy = build(:vacancy, about_school: '<script> call();</script>Sanitized content')
+      presenter = VacancyPresenter.new(vacancy)
 
-    context 'vacancy about_school is nil' do
-      context 'school description is NOT nil' do
-        it 'returns the school description' do
-          vacancy = VacancyPresenter.new(
-            build(:vacancy, about_school: nil, school: build(:school, description: 'School description'))
-          )
-          expect(vacancy.about_school).to eq('<p>School description</p>')
-        end
-      end
-
-      context 'school description is nil' do
-        it 'returns nil' do
-          vacancy = VacancyPresenter.new(
-            build(:vacancy, about_school: nil, school: build(:school, description: nil))
-          )
-          expect(vacancy.about_school).to be nil
-        end
-      end
+      expect(presenter.about_school).to eq('<p> call();Sanitized content</p>')
     end
   end
 


### PR DESCRIPTION
This PR is part of the work required in TEVA-757 and TEVA-1019. It refactors the copy process in order to simplify it and keep it more maintainable going forwards. This will remove the need for extra steps or fields to be added to the copy job journey at any stage in the future.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-757

## Changes in this PR
- Remove disabling of submit inputs on page load due to functionality and accessibility concerns
- Refactor copy process
- When copying or editing published jobs that are now invalid, redirect to the review/edit page and display errors
- Implement the 'Action required' design for these errors
- Fix a bug that meant `About {school}` heading was shown even when if the field wasn't present

## Screenshots of UI changes:
![image](https://user-images.githubusercontent.com/25187547/87782496-855f0500-c82a-11ea-9041-8ac323952e35.png)
