### PR TITLE
expand scope of linting to include all custom JS

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,8 @@
         "describe": "readonly",
         "test": "readonly",
         "expect": "readonly",
-        "history": "readonly"
+        "history": true,
+        "GOVUK": "readonly"
     },
     "parserOptions": {
         "ecmaVersion": 2018,
@@ -28,7 +29,8 @@
         "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 1 }],
         "import/prefer-default-export": 0,
         "import/no-named-as-default-member": 0,
-        "no-unused-expressions": ["error", { "allowTernary": true }]
+        "no-unused-expressions": ["error", { "allowTernary": true }],
+        "no-param-reassign": [2, { "props": false }]
     },
     "root": true
 }

--- a/app/frontend/src/addTitleToGoogleMapsIframe.js
+++ b/app/frontend/src/addTitleToGoogleMapsIframe.js
@@ -1,3 +1,4 @@
-$(window).bind("load", function() {
-  $('#map_zoom div div.gm-style iframe').attr("title", "School location map");
+/* eslint-disable */
+$(window).bind('load', () => {
+  $('#map_zoom div div.gm-style iframe').attr('title', 'School location map');
 });

--- a/app/frontend/src/addVacancyStateToDataLayer.js
+++ b/app/frontend/src/addVacancyStateToDataLayer.js
@@ -1,4 +1,5 @@
-document.addEventListener("DOMContentLoaded", function(e) {
+/* eslint-disable */
+document.addEventListener('DOMContentLoaded', (e) => {
   const element = document.querySelector('.new_copy_vacancy_form') || document.body || {};
   const dataset = element.dataset || {};
   dataLayer.push({ vacancy_state: dataset.vacancyState });

--- a/app/frontend/src/deleteAccordionControl.js
+++ b/app/frontend/src/deleteAccordionControl.js
@@ -1,3 +1,4 @@
-$(document).ready(function(){
+/* eslint-disable */
+$(document).ready(() => {
   $('.govuk-accordion__controls', '.search_panel').remove();
 });

--- a/app/frontend/src/deleteDocument.js
+++ b/app/frontend/src/deleteDocument.js
@@ -1,153 +1,152 @@
-import { nodeListForEach } from 'govuk-frontend/govuk/common'
+/* eslint-disable */
+import { nodeListForEach } from 'govuk-frontend/govuk/common';
 
-window.GOVUK = window.GOVUK || {}
+window.GOVUK = window.GOVUK || {};
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function DeleteDocumentConfirmationDialogue () { }
+  function DeleteDocumentConfirmationDialogue() { }
 
   DeleteDocumentConfirmationDialogue.prototype.start = function ($module) {
-    this.$module = $module[0]
-    this.$dialogBox = this.$module.querySelector('.gem-c-modal-dialogue__box')
-    this.$closeButton = this.$module.querySelector('.gem-c-modal-dialogue__close-link')
-    this.$html = document.querySelector('html')
-    this.$body = document.querySelector('body')
+    this.$module = $module[0];
+    this.$dialogBox = this.$module.querySelector('.gem-c-modal-dialogue__box');
+    this.$closeButton = this.$module.querySelector('.gem-c-modal-dialogue__close-link');
+    this.$html = document.querySelector('html');
+    this.$body = document.querySelector('body');
 
-    this.$module.resize = this.handleResize.bind(this)
-    this.$module.open = this.handleOpen.bind(this)
-    this.$module.close = this.handleClose.bind(this)
-    this.$module.focusDialog = this.handleFocusDialog.bind(this)
-    this.$module.boundKeyDown = this.handleKeyDown.bind(this)
+    this.$module.resize = this.handleResize.bind(this);
+    this.$module.open = this.handleOpen.bind(this);
+    this.$module.close = this.handleClose.bind(this);
+    this.$module.focusDialog = this.handleFocusDialog.bind(this);
+    this.$module.boundKeyDown = this.handleKeyDown.bind(this);
 
-    var $triggerElements = document.querySelectorAll(
-      '[data-toggle="modal"][data-target="' + this.$module.id + '"]'
-    )
+    const $triggerElements = document.querySelectorAll(
+      `[data-toggle="modal"][data-target="${this.$module.id}"]`,
+    );
 
-    var $element = this
+    const $element = this;
 
-    nodeListForEach($triggerElements, function($triggerElement) {
-      $triggerElement.addEventListener('click', $element.$module.open)
-    })
+    nodeListForEach($triggerElements, ($triggerElement) => {
+      $triggerElement.addEventListener('click', $element.$module.open);
+    });
 
     if (this.$closeButton) {
-      this.$closeButton.addEventListener('click', this.$module.close)
+      this.$closeButton.addEventListener('click', this.$module.close);
     }
-  }
+  };
 
   DeleteDocumentConfirmationDialogue.prototype.handleResize = function (size) {
     if (size === 'narrow') {
-      this.$dialogBox.classList.remove('gem-c-modal-dialogue__box--wide')
+      this.$dialogBox.classList.remove('gem-c-modal-dialogue__box--wide');
     }
 
     if (size === 'wide') {
-      this.$dialogBox.classList.add('gem-c-modal-dialogue__box--wide')
+      this.$dialogBox.classList.add('gem-c-modal-dialogue__box--wide');
     }
-  }
+  };
 
   DeleteDocumentConfirmationDialogue.prototype.handleOpen = function (event) {
     if (event) {
-      event.preventDefault()
-      event.stopPropagation()
+      event.preventDefault();
+      event.stopPropagation();
     }
 
-    this.$html.classList.add('gem-o-template--modal')
-    this.$body.classList.add('gem-o-template__body--modal')
-    this.$body.classList.add('gem-o-template__body--blur')
+    this.$html.classList.add('gem-o-template--modal');
+    this.$body.classList.add('gem-o-template__body--modal');
+    this.$body.classList.add('gem-o-template__body--blur');
 
-    var $target = event.target
+    const $target = event.target;
 
-    this.$dialogBox.querySelector('#js-gem-c-modal-dialogue__file-name').innerText = $target.dataset.fileName
-    this.$dialogBox.querySelector('#js-gem-c-modal-dialogue__confirm-action').setAttribute('href', $target.dataset.deletePath)
-    this.$dialogBox.querySelector('#js-gem-c-modal-dialogue__confirm-action').dataset.documentId = $target.dataset.documentId
-    this.$dialogBox.querySelector('#js-gem-c-modal-dialogue__error').style.display = 'none'
+    this.$dialogBox.querySelector('#js-gem-c-modal-dialogue__file-name').innerText = $target.dataset.fileName;
+    this.$dialogBox.querySelector('#js-gem-c-modal-dialogue__confirm-action').setAttribute('href', $target.dataset.deletePath);
+    this.$dialogBox.querySelector('#js-gem-c-modal-dialogue__confirm-action').dataset.documentId = $target.dataset.documentId;
+    this.$dialogBox.querySelector('#js-gem-c-modal-dialogue__error').style.display = 'none';
 
-    this.$focusedElementBeforeOpen = document.activeElement
-    this.$module.style.display = 'block'
-    this.$dialogBox.focus()
+    this.$focusedElementBeforeOpen = document.activeElement;
+    this.$module.style.display = 'block';
+    this.$dialogBox.focus();
 
-    document.addEventListener('keydown', this.$module.boundKeyDown, true)
-  }
+    document.addEventListener('keydown', this.$module.boundKeyDown, true);
+  };
 
   DeleteDocumentConfirmationDialogue.prototype.handleClose = function (event) {
     if (event) {
-      event.preventDefault()
+      event.preventDefault();
     }
 
-    this.$html.classList.remove('gem-o-template--modal')
-    this.$body.classList.remove('gem-o-template__body--modal')
-    this.$body.classList.remove('gem-o-template__body--blur')
-    this.$module.style.display = 'none'
-    this.$focusedElementBeforeOpen.focus()
+    this.$html.classList.remove('gem-o-template--modal');
+    this.$body.classList.remove('gem-o-template__body--modal');
+    this.$body.classList.remove('gem-o-template__body--blur');
+    this.$module.style.display = 'none';
+    this.$focusedElementBeforeOpen.focus();
 
-    document.removeEventListener('keydown', this.$module.boundKeyDown, true)
-  }
+    document.removeEventListener('keydown', this.$module.boundKeyDown, true);
+  };
 
   DeleteDocumentConfirmationDialogue.prototype.handleFocusDialog = function () {
-    this.$dialogBox.focus()
-  }
+    this.$dialogBox.focus();
+  };
 
   // while open, prevent tabbing to outside the dialogue
   // and listen for ESC key to close the dialogue
   DeleteDocumentConfirmationDialogue.prototype.handleKeyDown = function (event) {
-    var KEY_TAB = 9
-    var KEY_ESC = 27
+    const KEY_TAB = 9;
+    const KEY_ESC = 27;
 
     switch (event.keyCode) {
       case KEY_TAB:
         if (event.shiftKey) {
           if (document.activeElement === this.$dialogBox) {
-            event.preventDefault()
-            this.$closeButton.focus()
+            event.preventDefault();
+            this.$closeButton.focus();
           }
-        } else {
-          if (document.activeElement === this.$closeButton) {
-            event.preventDefault()
-            this.$dialogBox.focus()
-          }
+        } else if (document.activeElement === this.$closeButton) {
+          event.preventDefault();
+          this.$dialogBox.focus();
         }
 
-        break
+        break;
       case KEY_ESC:
-        this.$module.close()
-        break
+        this.$module.close();
+        break;
       default:
-        break
+        break;
     }
-  }
+  };
 
-  Modules.DeleteDocumentConfirmationDialogue = DeleteDocumentConfirmationDialogue
-})(window.GOVUK.Modules)
+  Modules.DeleteDocumentConfirmationDialogue = DeleteDocumentConfirmationDialogue;
+}(window.GOVUK.Modules));
 
-$(document).ready(function() {
-  var $deleteDocumentConfirmationDialogue = $('[data-module="file-remove-confirmation-dialogue"]')
+$(document).ready(() => {
+  const $deleteDocumentConfirmationDialogue = $('[data-module="file-remove-confirmation-dialogue"]');
 
-  $deleteDocumentConfirmationDialogue.each(function() {
-    (new window.GOVUK.Modules.DeleteDocumentConfirmationDialogue).start($(this))
-  })
-})
+  $deleteDocumentConfirmationDialogue.each(function () {
+    (new window.GOVUK.Modules.DeleteDocumentConfirmationDialogue()).start($(this));
+  });
+});
 
 $('#js-gem-c-modal-dialogue__confirm-action')
-  .on('ajax:beforeSend', function() {
-    $('#js-gem-c-modal-dialogue__error').hide()
-    $(this).addClass('govuk-button--disabled')
+  .on('ajax:beforeSend', function () {
+    $('#js-gem-c-modal-dialogue__error').hide();
+    $(this).addClass('govuk-button--disabled');
   })
-  .on('ajax:success', function(event) {
-    var xhr = event.detail[2]
-    var $documentRow = document.querySelector('.js-document-row[data-document-id="' + this.dataset.documentId + '"]')
-    $documentRow.parentNode.removeChild($documentRow)
+  .on('ajax:success', function (event) {
+    const xhr = event.detail[2];
+    const $documentRow = document.querySelector(`.js-document-row[data-document-id="${this.dataset.documentId}"]`);
+    $documentRow.parentNode.removeChild($documentRow);
 
     if (document.querySelectorAll('.js-document-row').length === 0) {
-      document.querySelector('.js-documents').classList.add('js-documents--empty')
+      document.querySelector('.js-documents').classList.add('js-documents--empty');
     }
 
-    var $errorContainer = document.querySelector('#js-xhr-flashes')
-    $errorContainer.insertAdjacentHTML('beforeend', xhr.responseText)
+    const $errorContainer = document.querySelector('#js-xhr-flashes');
+    $errorContainer.insertAdjacentHTML('beforeend', xhr.responseText);
 
-    document.querySelector('[data-module="file-remove-confirmation-dialogue"]').close()
+    document.querySelector('[data-module="file-remove-confirmation-dialogue"]').close();
   })
-  .on('ajax:error', function() {
-    $('#js-gem-c-modal-dialogue__error').show()
+  .on('ajax:error', () => {
+    $('#js-gem-c-modal-dialogue__error').show();
   })
-  .on('ajax:complete', function() {
-    $(this).removeClass('govuk-button--disabled')
-  })
+  .on('ajax:complete', function () {
+    $(this).removeClass('govuk-button--disabled');
+  });

--- a/app/frontend/src/details.js
+++ b/app/frontend/src/details.js
@@ -1,24 +1,25 @@
+/* eslint-disable */
 function addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(detailsElement) {
-    var expandedText = detailsElement.getAttribute('data-summary-expanded');
-    var collapsedText = detailsElement.getAttribute('data-summary-collapsed');
-    var summaryTextElement = detailsElement.getElementsByClassName('govuk-details__summary-text').item(0);
-    var hasAllPropertiesToBeDynamic = summaryTextElement && collapsedText && expandedText;
+  const expandedText = detailsElement.getAttribute('data-summary-expanded');
+  const collapsedText = detailsElement.getAttribute('data-summary-collapsed');
+  const summaryTextElement = detailsElement.getElementsByClassName('govuk-details__summary-text').item(0);
+  const hasAllPropertiesToBeDynamic = summaryTextElement && collapsedText && expandedText;
 
-    if(hasAllPropertiesToBeDynamic) {
+  if (hasAllPropertiesToBeDynamic) {
+    summaryTextElement.textContent = collapsedText;
+
+    detailsElement.addEventListener('toggle', () => {
+      if (detailsElement.open) {
+        summaryTextElement.textContent = expandedText;
+      } else {
         summaryTextElement.textContent = collapsedText;
-
-        detailsElement.addEventListener('toggle', function () {
-            if (detailsElement.open) {
-                summaryTextElement.textContent = expandedText;
-            } else {
-                summaryTextElement.textContent = collapsedText;
-            }
-        });
-    }
+      }
+    });
+  }
 }
 
-$( document ).ready(function() {
-    $('details').each(function(_, details) {
-        addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(details);
-    });
+$(document).ready(() => {
+  $('details').each((_, details) => {
+    addDynamicSummaryTextForExpandedAndCollapsedDetailsTag(details);
+  });
 });

--- a/app/frontend/src/disabledInputs.js
+++ b/app/frontend/src/disabledInputs.js
@@ -1,16 +1,17 @@
-document.addEventListener('DOMContentLoaded', function() {
-  var allInputs = document.querySelectorAll('input');
-  var textAreaInputs = document.querySelectorAll('textarea.govuk-textarea');
-  var submitInput = document.querySelector('input[type="submit"].disabled-on-load');
+/* eslint-disable */
+document.addEventListener('DOMContentLoaded', () => {
+  const allInputs = document.querySelectorAll('input');
+  const textAreaInputs = document.querySelectorAll('textarea.govuk-textarea');
+  const submitInput = document.querySelector('input[type="submit"].disabled-on-load');
 
   if (allInputs && submitInput) {
     submitInput.disabled = true;
 
-    var inputArray = [];
+    const inputArray = [];
     Array.prototype.push.apply(inputArray, allInputs);
 
-    inputArray.forEach(function(input) {
-      input.addEventListener('input', function() {
+    inputArray.forEach((input) => {
+      input.addEventListener('input', () => {
         if (submitInput.disabled) {
           submitInput.disabled = false;
         }
@@ -21,11 +22,11 @@ document.addEventListener('DOMContentLoaded', function() {
   if (textAreaInputs && submitInput) {
     submitInput.disabled = true;
 
-    var textAreaInputArray = [];
+    const textAreaInputArray = [];
     Array.prototype.push.apply(textAreaInputArray, textAreaInputs);
 
-    textAreaInputArray.forEach(function(input) {
-      input.addEventListener('input', function() {
+    textAreaInputArray.forEach((input) => {
+      input.addEventListener('input', () => {
         if (submitInput.disabled) {
           submitInput.disabled = false;
         }

--- a/app/frontend/src/dismissableElement.js
+++ b/app/frontend/src/dismissableElement.js
@@ -1,4 +1,5 @@
-$(document).on('click', '.js-dismissable__link', function(e) {
-  e.preventDefault()
-  $(this).closest('.js-dismissable').fadeOut()
-})
+/* eslint-disable */
+$(document).on('click', '.js-dismissable__link', function (e) {
+  e.preventDefault();
+  $(this).closest('.js-dismissable').fadeOut();
+});

--- a/app/frontend/src/googleOptimise.js
+++ b/app/frontend/src/googleOptimise.js
@@ -1,6 +1,7 @@
-var google_optimize_activate = function() {
+/* eslint-disable */
+const google_optimize_activate = function () {
   window.dataLayer = window.dataLayer || [];
-  dataLayer.push({'event': 'optimize.activate'});
+  dataLayer.push({ event: 'optimize.activate' });
 };
 
 $(document).ready(google_optimize_activate);

--- a/app/frontend/src/googleTagManagerUrlSnippet.js
+++ b/app/frontend/src/googleTagManagerUrlSnippet.js
@@ -1,6 +1,7 @@
-document.addEventListener("DOMContentLoaded", function(event) {
+/* eslint-disable */
+document.addEventListener('DOMContentLoaded', (event) => {
   dataLayer.push({
     dePIIedURL: window.location.pathname,
-    event: "parametersRemoved"
+    event: 'parametersRemoved',
   });
 });

--- a/app/frontend/src/lib/polyfill/URLSearchParams.polyfill.js
+++ b/app/frontend/src/lib/polyfill/URLSearchParams.polyfill.js
@@ -1,4 +1,5 @@
 /*! (c) Andrea Giammarchi - ISC */
+/* eslint-disable */
 var self = this || /* istanbul ignore next */ {};
 try {
   (function (URLSearchParams, plus) {

--- a/app/frontend/src/lib/polyfill/after.polyfill.js
+++ b/app/frontend/src/lib/polyfill/after.polyfill.js
@@ -1,4 +1,6 @@
 // from: https://github.com/jserz/js_piece/blob/master/DOM/ChildNode/after()/after().md
+
+/* eslint-disable */
 (function (arr) {
     arr.forEach(function (item) {
       if (item.hasOwnProperty('after')) {

--- a/app/frontend/src/lib/polyfill/remove.polyfill.js
+++ b/app/frontend/src/lib/polyfill/remove.polyfill.js
@@ -1,4 +1,5 @@
-(function (arr) {
+/* eslint-disable */
+ (function (arr) {
     arr.forEach(function (item) {
       if (item.hasOwnProperty('remove')) {
         return;

--- a/app/frontend/src/lib/ui/components/searchCheckbox.js
+++ b/app/frontend/src/lib/ui/components/searchCheckbox.js
@@ -1,5 +1,3 @@
-
-
 export const init = (container) => {
   const checkboxes = container.getElementsByClassName('govuk-checkboxes__input');
   const input = container.getElementsByClassName('search-input__input')[0];
@@ -11,9 +9,9 @@ export const init = (container) => {
   input.addEventListener('change', (e) => {
     filterCheckboxes(checkboxes, e.target);
   });
-}
+};
 
-export const filterCheckboxes = (checkboxes, input) => Array.from(checkboxes).map(checkbox => checkboxDisplay(checkbox, input));
+export const filterCheckboxes = (checkboxes, input) => Array.from(checkboxes).map((checkbox) => checkboxDisplay(checkbox, input));
 
 export const substringExistsInString = (original, input) => original.toUpperCase().indexOf(input.toUpperCase()) > -1;
 
@@ -23,11 +21,11 @@ export const checkboxDisplay = (checkbox, input) => {
   } else {
     checkbox.parentElement.style.display = 'none';
   }
-}
+};
 
 window.addEventListener('DOMContentLoaded', () => {
   const groups = document.getElementsByClassName('tv-checkbox__group');
   if (groups.length) {
-    Array.from(groups).filter(group => group.getElementsByClassName('search-input').length).map(group => init(group));
+    Array.from(groups).filter((group) => group.getElementsByClassName('search-input').length).map((group) => init(group));
   }
 });

--- a/app/frontend/src/lib/ui/components/searchCheckbox.test.js
+++ b/app/frontend/src/lib/ui/components/searchCheckbox.test.js
@@ -1,9 +1,16 @@
 import { init, substringExistsInString } from './searchCheckbox';
 
 describe('search group of checkboxes', () => {
-
   beforeEach(() => {
-    document.body.innerHTML = '<div class="accordion-content__group"><input type="text" class="search-input__input" /><div class="govuk-checkboxes__item"><input type="checkbox" value="abc" class="govuk-checkboxes__input" /></div><div class="govuk-checkboxes__item"><input type="checkbox" value="xyz" class="govuk-checkboxes__input" /></div></div>';
+    document.body.innerHTML = `<div class="accordion-content__group">
+<input type="text" class="search-input__input" />
+<div class="govuk-checkboxes__item">
+<input type="checkbox" value="abc" class="govuk-checkboxes__input" />
+</div>
+<div class="govuk-checkboxes__item">
+<input type="checkbox" value="xyz" class="govuk-checkboxes__input" />
+</div>
+</div>`;
   });
 
   describe('module behaviour', () => {

--- a/app/frontend/src/lib/ui/patterns/autocomplete.js
+++ b/app/frontend/src/lib/ui/patterns/autocomplete.js
@@ -18,7 +18,7 @@ export const getOptions = (dataset, query) => dataset.filter((option) => option.
 
 const autocomplete = {
   view,
-  renderAutocomplete
-}
+  renderAutocomplete,
+};
 
 export default autocomplete;

--- a/app/frontend/src/lib/ui/patterns/autocomplete.test.js
+++ b/app/frontend/src/lib/ui/patterns/autocomplete.test.js
@@ -37,8 +37,8 @@ describe('autocomplete', () => {
 });
 
 describe('autocomplete view', () => {
-
-  let hideMock = null, showMock = null, focusMock = null, renderMock = null, onSelect = jest.fn();
+  let hideMock = null; let showMock = null; let focusMock = null; let renderMock = null; const
+    onSelect = jest.fn();
 
   document.body.innerHTML = '<div id="container"><input id="input" /></div>';
 
@@ -60,7 +60,7 @@ describe('autocomplete view', () => {
       input,
       dataset: ['option 1', 'option 2', 'choice 3'],
       threshold: 3,
-      onSelect
+      onSelect,
     });
   });
 
@@ -70,7 +70,7 @@ describe('autocomplete view', () => {
 
   describe('create method', () => {
     test('sets correct a11y attributes', () => {
-      const optionList = container.querySelector('ul')
+      const optionList = container.querySelector('ul');
       expect(optionList.getAttribute('tabindex')).toBe('-1');
       expect(optionList.getAttribute('role')).toBe('listbox');
     });
@@ -82,7 +82,6 @@ describe('autocomplete view', () => {
       expect(onSelect).toHaveBeenCalledTimes(1);
     });
 
-
     test('clicking on page closes hide autocomplete options', () => {
       const event = new Event('click');
       document.dispatchEvent(event);
@@ -91,7 +90,7 @@ describe('autocomplete view', () => {
     });
 
     test('shows correct autocomplete options', () => {
-      input.value = 'option'
+      input.value = 'option';
       const event = new Event('input');
       input.dispatchEvent(event);
       expect(showMock).toHaveBeenCalledTimes(1);
@@ -116,17 +115,17 @@ describe('autocomplete view', () => {
     beforeAll(() => {
       view.render = jest.fn();
       renderMock = jest.spyOn(view, 'render');
-  
+
       renderAutocomplete({
         container,
         input,
         dataset: ['option 1', 'option 2', 'choice 3'],
         threshold: 3,
-        onSelect
+        onSelect,
       });
     });
 
-    test('show sets appropriate class and a11y attributes',() => {
+    test('show sets appropriate class and a11y attributes', () => {
       const options = ['option 1', 'option 2', 'choice 3'];
       show(options, container, input);
       const optionList = container.querySelector('ul');
@@ -137,7 +136,7 @@ describe('autocomplete view', () => {
       expect(optionList.classList.contains('autocomplete__menu--hidden')).toBe(false);
     });
 
-    test('hide sets appropriate class and a11y attributes',() => {
+    test('hide sets appropriate class and a11y attributes', () => {
       hide(container, input);
       const optionList = container.querySelector('ul');
 

--- a/app/frontend/src/lib/ui/patterns/autocomplete.view.js
+++ b/app/frontend/src/lib/ui/patterns/autocomplete.view.js
@@ -32,6 +32,8 @@ export const create = (container, input, onSelect = () => {}) => {
         case 'ArrowUp':
           autocomplete.focus(container, 'previous', input);
           break;
+        default:
+          break;
       }
     });
   }
@@ -45,7 +47,11 @@ export const show = (options, container, input) => {
   input.setAttribute('aria-expanded', true);
 
   Array.from(getCurrentOptionElementsArray(container))
-    .forEach((element) => element.addEventListener('focus', (e) => input.value = e.target.dataset.location, true));
+    .forEach((element) => element.addEventListener('focus', (e) => setInputValue(input, e.target.dataset.location), true));
+};
+
+export const setInputValue = (input, value) => {
+  input.value = value;
 };
 
 export const hide = (container, input) => {
@@ -65,8 +71,15 @@ export const isPopulated = (container) => getCurrentOptionElementsArray(containe
 export const focus = (container, direction, input) => {
   if (isPopulated(container)) {
     const elements = getFocusableOptions(container);
-    elements.current && elements.current.classList.remove('autocomplete__option--focused');
-    elements[direction] && elements[direction].classList.add('autocomplete__option--focused');
+
+    if (elements.current) {
+      elements.current.classList.remove('autocomplete__option--focused');
+    }
+
+    if (elements[direction]) {
+      elements[direction].classList.add('autocomplete__option--focused');
+    }
+
     input.value = elements[direction] ? elements[direction].dataset.location : '';
   }
 };
@@ -88,7 +101,12 @@ export const getOptionIndex = (el) => parseInt(el.getAttribute('aria-posinset'),
 
 export const getFocusedOption = (container) => container.getElementsByClassName('autocomplete__option--focused')[0];
 
-export const getOptionHtml = (refinement) => (hit, index, options) => `<li class="autocomplete__option" id="autocomplete__input__option--${index}" role="option" tabindex="-1" aria-setsize="${options.length + 1}" aria-posinset=${index} data-location="${hit.toLowerCase()}">${highlightRefinement(hit, refinement)}</li>`;
+export const getOptionHtml = (refinement) => (hit, index, options) => `
+<li class="autocomplete__option" id="autocomplete__input__option--${index}"
+role="option" tabindex="-1" aria-setsize="${options.length + 1}" aria-posinset=${index}
+data-location="${hit.toLowerCase()}">
+${highlightRefinement(hit, refinement)}
+</li>`;
 
 export const highlightRefinement = (text, refinement) => {
   const index = text.toLowerCase().indexOf(refinement.toLowerCase());
@@ -96,6 +114,8 @@ export const highlightRefinement = (text, refinement) => {
   if (index >= 0) {
     return `${text.substring(0, index)}<span class='highlight'>${text.substring(index, index + refinement.length)}</span><span>${text.substring(index + refinement.length, text.length)}</span>`;
   }
+
+  return false;
 };
 
 const autocomplete = {
@@ -103,7 +123,7 @@ const autocomplete = {
   hide,
   focus,
   create,
-  render
+  render,
 };
 
 export default autocomplete;

--- a/app/frontend/src/lib/ui/patterns/currentLocation.js
+++ b/app/frontend/src/lib/ui/patterns/currentLocation.js
@@ -104,7 +104,7 @@ export default currentLocation;
 
 window.addEventListener('DOMContentLoaded', () => {
   if (navigator.geolocation && containerEl) {
-      showLocationLink(containerEl);
-      init();
+    showLocationLink(containerEl);
+    init();
   }
 });

--- a/app/frontend/src/lib/utils.js
+++ b/app/frontend/src/lib/utils.js
@@ -6,7 +6,7 @@ export const constructNewUrlWithParam = (key, value, url) => {
 };
 
 export const updateUrlQueryParams = (key, value, url) => {
-  history.replaceState({}, null, constructNewUrlWithParam(key, value, url));
+  window.history.replaceState({}, null, constructNewUrlWithParam(key, value, url));
 };
 
 export const extractQueryParams = (url, keys) => {
@@ -23,12 +23,12 @@ export const extractQueryParams = (url, keys) => {
 };
 
 export const stringMatchesPostcode = (postcode) => {
-  postcode = postcode.replace(/\s/g, '');
+  const noSpacePostcode = postcode.replace(/\s/g, '');
   const regex = /^[A-Za-z]{1,2}[0-9]{1,2}[A-Za-z]? ?[0-9][A-Z]{2}$/i;
-  return regex.test(postcode);
+  return regex.test(noSpacePostcode);
 };
 
-export const stringContainsNumber = string => /\d/.test(string)
+export const stringContainsNumber = (string) => /\d/.test(string);
 
 export const convertMilesToMetres = (miles) => Math.ceil(parseInt(miles, 10) * 1609.34);
 

--- a/app/frontend/src/lib/utils.test.js
+++ b/app/frontend/src/lib/utils.test.js
@@ -1,5 +1,5 @@
 import {
-  getNewState, getUnixTimestampForDayStart, constructNewUrlWithParam, stringMatchesPostcode, convertMilesToMetres, convertEpochToUnixTimestamp, extractQueryParams, stringContainsNumber
+  getNewState, getUnixTimestampForDayStart, constructNewUrlWithParam, stringMatchesPostcode, convertMilesToMetres, convertEpochToUnixTimestamp, extractQueryParams, stringContainsNumber,
 } from './utils';
 
 describe('getNewState', () => {
@@ -90,7 +90,7 @@ describe('stringContainsNumber', () => {
   test('is falsy when supplied string doesnt contain a number', () => {
     expect(stringContainsNumber('alex')).toBe(false);
   });
-})
+});
 
 describe('convertMilesToMetres', () => {
   test('converts an integer of number of miles to the equivalent in metres', () => {

--- a/app/frontend/src/loader.js
+++ b/app/frontend/src/loader.js
@@ -1,4 +1,5 @@
-;(function (global) {
+/* eslint-disable */
+  ;(function (global) {
   'use strict'
 
   var $ = global.jQuery

--- a/app/frontend/src/locationAutocomplete.js
+++ b/app/frontend/src/locationAutocomplete.js
@@ -1,14 +1,14 @@
-import { renderAutocomplete } from './lib/autocomplete';
+import { renderAutocomplete } from './lib/ui/patterns/autocomplete';
 import { locations } from './search/data/locations';
 
 window.addEventListener('DOMContentLoaded', () => {
-    if (document.getElementById('new_')) {
-        renderAutocomplete({
-            container: document.getElementById('new_'),
-            input: document.getElementById('location'),
-            dataset: locations,
-            threshold: 3,
-            onSelection: () => { }
-        });
-    }
+  if (document.getElementById('new_')) {
+    renderAutocomplete({
+      container: document.getElementById('new_'),
+      input: document.getElementById('location'),
+      dataset: locations,
+      threshold: 3,
+      onSelection: () => { },
+    });
+  }
 });

--- a/app/frontend/src/removeCommaFromNumber.js
+++ b/app/frontend/src/removeCommaFromNumber.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 function removeCommaFromNumber(number) {
   return number.replace(/,/g, '');
 }

--- a/app/frontend/src/shareUrl.js
+++ b/app/frontend/src/shareUrl.js
@@ -1,9 +1,10 @@
-import ClipboardJS from 'clipboard'
+/* eslint-disable */
+import ClipboardJS from 'clipboard';
 
-$(document).ready(function(){
+$(document).ready(() => {
   new ClipboardJS('.copy-to-clipboard');
 
-  $('.copy-to-clipboard').click(function(event) {
+  $('.copy-to-clipboard').click((event) => {
     event.preventDefault();
   });
 });

--- a/app/frontend/src/submitFeedback.js
+++ b/app/frontend/src/submitFeedback.js
@@ -1,27 +1,28 @@
-$(document).ready(function(){
-  $('.submit_feedback').on('submit', function(event) {
-    var valid = true;
-    var id = $(event.target).attr('id');
-    var form = $(event.target);
+/* eslint-disable */
+$(document).ready(() => {
+  $('.submit_feedback').on('submit', (event) => {
+    let valid = true;
+    const id = $(event.target).attr('id');
+    const form = $(event.target);
 
-    $('select[form="'+ id +'"]').each(function() {
+    $(`select[form="${id}"]`).each(function () {
       if ($(this).val() == '') {
         valid = false;
         if (!$(this).hasClass('govuk-input--error')) {
           $(this).addClass('govuk-input--error');
-          $(this).wrap("<div class='govuk-form-group--error'></div>");
+          $(this).wrap('<div class=\'govuk-form-group--error\'></div>');
           text = form.data('optionNotSelectedMessage');
-          $(this).parent('div').prepend('<span class="govuk-error-message">'+ '<span class="govuk-visually-hidden">' + 'Error:' +'</span>' + text + '</span>')
+          $(this).parent('div').prepend(`${'<span class="govuk-error-message">' + '<span class="govuk-visually-hidden">' + 'Error:' + '</span>'}${text}</span>`);
         }
       } else {
         $(this).removeClass('govuk-input--error');
         $(this).parents('div').children('span').remove();
-        if($(this).parents('div').hasClass('govuk-form-group--error')){
+        if ($(this).parents('div').hasClass('govuk-form-group--error')) {
           $(this).unwrap();
         }
       }
-    })
+    });
 
     return valid;
-  })
+  });
 });

--- a/app/frontend/src/uploadDocuments.js
+++ b/app/frontend/src/uploadDocuments.js
@@ -1,16 +1,17 @@
-document.addEventListener('DOMContentLoaded', function() {
+/* eslint-disable */
+document.addEventListener('DOMContentLoaded', () => {
   const inputFileUpload = document.getElementsByClassName('govuk-file-upload')[0];
   const selectFileButton = document.getElementsByClassName('govuk-button--secondary')[0];
   const uploadFileButton = document.getElementsByClassName('govuk-button--secondary')[1];
   const saveContinueButton = document.getElementsByName('commit')[1];
 
   if (inputFileUpload && selectFileButton && uploadFileButton && saveContinueButton) {
-    selectFileButton.addEventListener('click', function(e) {
+    selectFileButton.addEventListener('click', (e) => {
       e.preventDefault();
       inputFileUpload.click();
     });
 
-    inputFileUpload.addEventListener('change', function(e) {
+    inputFileUpload.addEventListener('change', (e) => {
       saveContinueButton.disabled = true;
       injectDocumentsTable(inputFileUpload);
       inputFileUpload.form.submit();
@@ -22,29 +23,29 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
 
-injectDocumentsTable = function(documentsInput) {
-  const filesList = documentsInput.files
+injectDocumentsTable = function (documentsInput) {
+  const filesList = documentsInput.files;
 
   if (filesList && filesList.length) {
-    const documentsContainerElement = document.querySelector('.js-documents')
-    const tableBodyElement = documentsContainerElement.querySelector('#js-documents__table-body')
+    const documentsContainerElement = document.querySelector('.js-documents');
+    const tableBodyElement = documentsContainerElement.querySelector('#js-documents__table-body');
 
-    documentsContainerElement.classList.remove('js-documents--empty')
+    documentsContainerElement.classList.remove('js-documents--empty');
 
     for (let i = 0; i < filesList.length; i++) {
-      const rowHTML = " \
+      const rowHTML = ` \
         <tr class='govuk-table__row'> \
-          <td class='govuk-table__cell' scope='row'>" +
-            filesList[i].name +
-          "</td>  \
-          <td class='govuk-table__cell'>" +
-            "Uploading" + "<span class='upload-progress'><div class='upload-progress-spinner'></div></span>" +
-          "</td>  \
-          <td class='govuk-table__cell' scope='row'></td>  \
-          <td class='govuk-table__cell' scope='row'></td>  \
+          <td class='govuk-table__cell' scope='row'>${
+  filesList[i].name
+}</td>  \
+          <td class='govuk-table__cell'>`
+            + 'Uploading' + '<span class=\'upload-progress\'><div class=\'upload-progress-spinner\'></div></span>'
+          + '</td>  \
+          <td class=\'govuk-table__cell\' scope=\'row\'></td>  \
+          <td class=\'govuk-table__cell\' scope=\'row\'></td>  \
         </tr> \
-      "
-      tableBodyElement.insertAdjacentHTML("beforeend", rowHTML);
+      ';
+      tableBodyElement.insertAdjacentHTML('beforeend', rowHTML);
     }
   }
-}
+};

--- a/app/frontend/src/vacancyShow.js
+++ b/app/frontend/src/vacancyShow.js
@@ -1,4 +1,5 @@
-$(document).on('click', '.govuk-back-link.with-referrer', function(event) {
+/* eslint-disable */
+$(document).on('click', '.govuk-back-link.with-referrer', (event) => {
   history.back();
   event.preventDefault();
 });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clipboard": "^2.0.4",
     "govuk-frontend": "3.4.0",
     "jquery": "^3.5.0",
+    "jsdom": "^16.2.2",
     "rails-ujs": "^5.2.3",
     "rollbar": "^2.17.0"
   },
@@ -20,7 +21,6 @@
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.21.2",
     "jest": "^25.4.0",
-    "jsdom": "^16.2.2",
     "stylelint": "^13.5.0",
     "stylelint-config-sass-guidelines": "^7.0.0",
     "stylelint-config-standard": "^20.0.0",
@@ -36,7 +36,7 @@
     "sass:check": "yarn run sass:lint",
     "js:test": "jest",
     "js:test:coverage": "jest --coverage",
-    "js:lint": "eslint ./app/frontend/src/search",
+    "js:lint": "eslint ./app/frontend/src",
     "sass:lint": "yarn stylelint app/frontend/**/*.scss -q"
   },
   "jest": {
@@ -47,7 +47,7 @@
       "<rootDir>/app/frontend/src/lib/testSetup.js"
     ],
     "coveragePathIgnorePatterns": [
-      "<rootDir>/app/frontend/src/polyfill/*"
+      "<rootDir>/app/frontend/src/lib/polyfill/*"
     ]
   }
 }


### PR DESCRIPTION
linting was only being performed on search JS previously and this PR expands on it to lint all custom JS. All legacy JS (at root of src folder) that was previously not linted has been eslint-ignored as these files will be refactored over coming weeks (https://dfedigital.atlassian.net/browse/TEVA-872) and so it is a waste of time to fix linting now