### PR TITLE
Do not send email alerts unless production environment

### DIFF
--- a/app/jobs/send_daily_alert_email_job.rb
+++ b/app/jobs/send_daily_alert_email_job.rb
@@ -2,6 +2,8 @@ class SendDailyAlertEmailJob < ApplicationJob
   queue_as :queue_daily_alerts
 
   def perform
+    return unless Rails.env.production?
+
     Subscription.all.each do |s|
       next if s.alert_run_today?
 

--- a/spec/jobs/send_daily_alert_email_job_spec.rb
+++ b/spec/jobs/send_daily_alert_email_job_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe SendDailyAlertEmailJob, type: :job do
   context 'with vacancies' do
     before do
       allow_any_instance_of(described_class).to receive(:vacancies_for_subscription) { vacancies }
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
     end
 
     it 'sends an email' do


### PR DESCRIPTION
In staging and dev environment we have a quota of 50K operations per
month in Algolia. Daily alerts produce ~10K operations per day and 
consume the whole quota in 5 days. This change will not send email
alerts on non-production environments.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1081
