### PR TITLE
Do not display view count for now

### DIFF
--- a/app/views/hiring_staff/organisations/_vacancies_expired.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_expired.html.haml
@@ -9,7 +9,6 @@
                     %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'expired', column: 'job_title', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), 'expired', column: 'publish_on', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.expired_on'), 'expired', column: 'expires_on', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.page_views'), 'expired', column: 'total_pageviews', sort: @sort)
                     %th.govuk-table__header{ colspan: 2 }= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.vacancies.each do |vacancy|

--- a/app/views/hiring_staff/organisations/_vacancies_published.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_published.html.haml
@@ -8,7 +8,6 @@
                     %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'published', column: 'job_title', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), 'published', column: 'publish_on', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.expires_on'), 'published', column: 'expires_on', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.page_views'), 'published', column: 'total_pageviews', sort: @sort)
                     %th.govuk-table__header{ colspan: 3}= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.vacancies.each do |vacancy|

--- a/app/views/hiring_staff/organisations/_vacancy_expired.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancy_expired.html.haml
@@ -2,6 +2,5 @@
   %td.govuk-table__cell= link_to vacancy.job_title, vacancy.preview_path, class: 'govuk-link view-vacancy-link'
   %td.govuk-table__cell= vacancy.publish_on
   %td.govuk-table__cell= vacancy.expires_on
-  %td.govuk-table__cell= vacancy.page_views
   %td.govuk-table__cell= link_to t('jobs.copy_link'), vacancy.copy_path, class: 'govuk-link', method: :get
   %td.govuk-table__cell= link_to t('jobs.delete_link'), vacancy.delete_path, class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/app/views/hiring_staff/organisations/_vacancy_published.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancy_published.html.haml
@@ -2,7 +2,6 @@
   %td.govuk-table__cell= link_to vacancy.job_title, vacancy.preview_path, class: 'govuk-link view-vacancy-link'
   %td.govuk-table__cell= vacancy.publish_on
   %td.govuk-table__cell= vacancy.expires_on
-  %td.govuk-table__cell= vacancy.page_views
   %td.govuk-table__cell= link_to t('jobs.edit_link'), vacancy.edit_path, class: 'govuk-link'
   %td.govuk-table__cell= link_to t('jobs.copy_link'), vacancy.copy_path, class: 'govuk-link', method: :get
   %td.govuk-table__cell= link_to t('jobs.delete_link'), vacancy.delete_path, class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/spec/features/hiring_staff_can_see_vacancy_statistics_spec.rb
+++ b/spec/features/hiring_staff_can_see_vacancy_statistics_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Hiring staff can see vacancy statistics' do
+RSpec.feature 'Hiring staff can NOT see vacancy statistics' do
   let(:school) { create(:school) }
   let(:total_pageviews) { nil }
   let(:total_get_more_info_clicks) { nil }
@@ -22,22 +22,10 @@ RSpec.feature 'Hiring staff can see vacancy statistics' do
       visit organisation_path(school)
     end
 
-    context 'page views are nil' do
-      scenario 'page views show zero' do
-        within("tr#organisation_vacancy_presenter_#{vacancy.id}") do
-          expect(page.find('td[4]')).to have_content('0')
-        end
-      end
-    end
+    # The removed tests for page view displays can be found in the git history.
 
-    context 'page views are present' do
-      let(:total_pageviews) { 100 }
-
-      scenario 'page views show the page view count' do
-        within("tr#organisation_vacancy_presenter_#{vacancy.id}") do
-          expect(page.find('td[4]')).to have_content(total_pageviews)
-        end
-      end
+    scenario 'page views are not shown' do
+      expect(page).not_to have_content('Total views')
     end
   end
 
@@ -56,22 +44,11 @@ RSpec.feature 'Hiring staff can see vacancy statistics' do
       visit jobs_with_type_organisation_path(:expired)
     end
 
-    context 'page views are nil' do
-      scenario 'page views show zero' do
-        within("tr#organisation_vacancy_presenter_#{vacancy.id}") do
-          expect(page.find('td[4]')).to have_content('0')
-        end
-      end
-    end
 
-    context 'page views are present' do
-      let(:total_pageviews) { 100 }
+    # The removed tests for page view displays can be found in the git history.
 
-      scenario 'page views show the page view count' do
-        within("tr#organisation_vacancy_presenter_#{vacancy.id}") do
-          expect(page.find('td[4]')).to have_content(total_pageviews)
-        end
-      end
+    scenario 'page views are not shown' do
+      expect(page).not_to have_content('Total views')
     end
   end
 end


### PR DESCRIPTION
# This change has not been seen by UX

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-980

## Changes in this PR:

Page views counter is broken. This interim solution prevents users being told that their listing got 0 views, which might damage their confidence in the service.

Slack conversation: https://ukgovernmentdfe.slack.com/archives/CG9A8H1HP/p1595846233147900

## Screenshots of UI changes:

### Before

<img width="1216" alt="Screenshot 2020-07-27 at 12 10 53" src="https://user-images.githubusercontent.com/60350599/88535671-40915600-d002-11ea-8abf-a78cda321084.png">
<img width="1216" alt="Screenshot 2020-07-27 at 12 10 43" src="https://user-images.githubusercontent.com/60350599/88535681-45eea080-d002-11ea-8c14-1b95371bd674.png">


### After

<img width="1216" alt="Screenshot 2020-07-27 at 11 55 00" src="https://user-images.githubusercontent.com/60350599/88535585-1b044c80-d002-11ea-88e8-6a321fef5ada.png">
<img width="1216" alt="Screenshot 2020-07-27 at 11 55 19" src="https://user-images.githubusercontent.com/60350599/88535588-1c357980-d002-11ea-9a44-871eb06d39ff.png">

## Next steps:

- [x] Interim solution approved?

- [ ] Signed off by UX
