### PR TITLE
Make job alerts typo-intolerant

### DIFF
--- a/app/jobs/send_daily_alert_email_job.rb
+++ b/app/jobs/send_daily_alert_email_job.rb
@@ -17,6 +17,7 @@ class SendDailyAlertEmailJob < ApplicationJob
   end
 
   def vacancies_for_subscription(subscription)
-    subscription.vacancies_for_range(Time.zone.yesterday, Time.zone.today).limit(500)
+    subscription.vacancies_for_range(Time.zone.yesterday, Time.zone.today)
+      .limit(VacancyAlgoliaAlertBuilder::MAXIMUM_SUBSCRIPTION_RESULTS)
   end
 end

--- a/app/services/vacancy_algolia_alert_builder.rb
+++ b/app/services/vacancy_algolia_alert_builder.rb
@@ -28,7 +28,7 @@ class VacancyAlgoliaAlertBuilder < VacancyAlgoliaSearchBuilder
       replica: search_replica,
       hitsPerPage: MAXIMUM_SUBSCRIPTION_RESULTS,
       filters: search_filter,
-      typoTolerance: false,
+      typoTolerance: false
     )
     Rails.logger.info(
       "#{vacancies.count} vacancies found for job alert with criteria: #{subscription_hash}, "\

--- a/app/services/vacancy_algolia_alert_builder.rb
+++ b/app/services/vacancy_algolia_alert_builder.rb
@@ -27,7 +27,8 @@ class VacancyAlgoliaAlertBuilder < VacancyAlgoliaSearchBuilder
       aroundRadius: location_filter[:radius],
       replica: search_replica,
       hitsPerPage: MAXIMUM_SUBSCRIPTION_RESULTS,
-      filters: search_filter
+      filters: search_filter,
+      typoTolerance: false,
     )
     Rails.logger.info(
       "#{vacancies.count} vacancies found for job alert with criteria: #{subscription_hash}, "\

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Subscription, type: :model do
     let(:algolia_search_args) do
       {
         filters: search_filter,
-        hitsPerPage: 500
+        hitsPerPage: VacancyAlgoliaAlertBuilder::MAXIMUM_SUBSCRIPTION_RESULTS
       }
     end
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Subscription, type: :model do
         .to receive(:expired_now_filter)
         .and_return(expired_now.to_datetime.to_i)
       allow(vacancies).to receive(:count).and_return(10)
-      mock_algolia_search(vacancies, algolia_search_query, algolia_search_args)
+      mock_algolia_search_for_job_alert(vacancies, algolia_search_query, algolia_search_args)
     end
 
     after { travel_back }

--- a/spec/services/vacancy_algolia_alert_builder_spec.rb
+++ b/spec/services/vacancy_algolia_alert_builder_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
       aroundRadius: location_radius,
       replica: search_replica,
       hitsPerPage: max_subscription_results,
-      filters: search_filter
+      filters: search_filter,
+      typoTolerance: false
     }
   end
 
@@ -100,7 +101,7 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
 
       before do
         allow(vacancies).to receive(:count).and_return(10)
-        mock_algolia_search(vacancies, algolia_search_query, algolia_search_args)
+        mock_algolia_search_for_job_alert(vacancies, algolia_search_query, algolia_search_args)
       end
 
       it 'carries out alert search with correct criteria' do
@@ -132,7 +133,7 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
 
       before do
         allow(vacancies).to receive(:count).and_return(10)
-        mock_algolia_search(vacancies, algolia_search_query, algolia_search_args)
+        mock_algolia_search_for_job_alert(vacancies, algolia_search_query, algolia_search_args)
       end
 
       it 'carries out alert search with correct criteria' do

--- a/spec/support/search_helper.rb
+++ b/spec/support/search_helper.rb
@@ -1,6 +1,19 @@
 module SearchHelper
+  def mock_algolia_search_for_job_alert(result, query, algolia_hash = {})
+    arguments_to_algolia = get_arguments_to_algolia(algolia_hash)
+    arguments_to_algolia[:typoTolerance] = false
+    mock_algolia_search_base(result, query, algolia_hash, arguments_to_algolia)
+  end
+
   def mock_algolia_search(result, query, algolia_hash = {})
-    arguments_to_algolia = {
+    arguments_to_algolia = get_arguments_to_algolia(algolia_hash)
+    mock_algolia_search_base(result, query, algolia_hash, arguments_to_algolia)
+  end
+
+  private
+
+  def get_arguments_to_algolia(algolia_hash)
+    {
       aroundLatLng: algolia_hash[:aroundLatLng] || nil,
       aroundRadius: algolia_hash[:aroundRadius] || nil,
       replica: algolia_hash[:replica] || nil,
@@ -9,8 +22,10 @@ module SearchHelper
         "publication_timestamp <= #{Time.zone.today.to_datetime.to_i} AND "\
         "expires_at_timestamp > #{Time.zone.today.to_datetime.to_i}"
     }
-    arguments_to_algolia[:page] = algolia_hash[:page] if algolia_hash[:page].present?
+  end
 
+  def mock_algolia_search_base(result, query, algolia_hash, arguments_to_algolia)
+    arguments_to_algolia[:page] = algolia_hash[:page] if algolia_hash[:page].present?
     allow(Vacancy).to receive(:search).with(
       query,
       arguments_to_algolia


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-955

## Changes in this PR:

Searches should be typo-tolerant: 'physics' can return 'physical education'
Alerts should not be: 'physics' can NOT return 'physical education'

This commit also removes the use of a magic number by reusing a
pre-existing constant.

## How I tested this

I think we don't have tests for our search results.

I tested this change by firstly creating a job alert job in the console with keyword 'physics' and seeing that it returned only a physics vacancy, and secondly I tested that the regular search was still returning both 'physics' and 'physical education' jobs for that search-term.
