### PR TITLE
Persist readable job location to model

### DIFF
--- a/app/controllers/hiring_staff/vacancies/job_location_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_location_controller.rb
@@ -15,8 +15,8 @@ class HiringStaff::Vacancies::JobLocationController < HiringStaff::Vacancies::Ap
   end
 
   def create
+    @form.vacancy.readable_job_location = readable_job_location(@form.vacancy.job_location)
     store_vacancy_attributes(@form.vacancy.attributes)
-
     if @form.valid?
       redirect_to_next_step_if_continue(@vacancy&.persisted? ? @vacancy.id : session_vacancy_id)
     else
@@ -26,6 +26,7 @@ class HiringStaff::Vacancies::JobLocationController < HiringStaff::Vacancies::Ap
 
   def update
     if @form.valid?
+      @vacancy.update(readable_job_location: readable_job_location(@form.vacancy.job_location))
       @vacancy.update(school_id: nil) if @form.job_location == 'central_office'
       update_vacancy(form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
@@ -61,5 +62,9 @@ class HiringStaff::Vacancies::JobLocationController < HiringStaff::Vacancies::Ap
     else
       redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
     end
+  end
+
+  def readable_job_location(job_location)
+    I18n.t('hiring_staff.organisations.school_groups.readable_job_location') if job_location == 'central_office'
   end
 end

--- a/app/controllers/hiring_staff/vacancies/school_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/school_controller.rb
@@ -16,6 +16,9 @@ class HiringStaff::Vacancies::SchoolController < HiringStaff::Vacancies::Applica
   end
 
   def create
+    @form.vacancy.readable_job_location = readable_job_location(
+      session[:vacancy_attributes]['job_location'], @form.vacancy.school.name
+    )
     store_vacancy_attributes(@form.vacancy.attributes)
     if @form.valid?
       redirect_to_next_step_if_continue(@vacancy&.persisted? ? @vacancy.id : session_vacancy_id)
@@ -26,6 +29,9 @@ class HiringStaff::Vacancies::SchoolController < HiringStaff::Vacancies::Applica
 
   def update
     if @form.valid?
+      @vacancy.update(
+        readable_job_location: readable_job_location(@vacancy.job_location, @form.vacancy.school.name)
+      )
       update_vacancy(form_params, @vacancy)
       update_google_index(@vacancy) if @vacancy.listed?
       redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
@@ -51,5 +57,9 @@ class HiringStaff::Vacancies::SchoolController < HiringStaff::Vacancies::Applica
 
   def set_school_options
     @school_options = current_organisation.schools
+  end
+
+  def readable_job_location(job_location, school_name)
+    school_name if job_location == 'at_one_school'
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,8 @@ en:
             or the information isn't correct, please %{mail_to}.
         edit:
           title: Change description
+      school_groups:
+        readable_job_location: Trust head office
     temp_login:
       heading: Temporary login
       please_use_email: DfE Sign In is experiencing problems. Please sign in using your email address.

--- a/db/migrate/20200730091409_add_readable_job_location_to_vacancies.rb
+++ b/db/migrate/20200730091409_add_readable_job_location_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddReadableJobLocationToVacancies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :vacancies, :readable_job_location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_145709) do
+ActiveRecord::Schema.define(version: 2020_07_30_091409) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -275,6 +275,7 @@ ActiveRecord::Schema.define(version: 2020_07_28_145709) do
     t.boolean "initially_indexed", default: false
     t.uuid "school_group_id"
     t.string "job_location"
+    t.string "readable_job_location"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["expiry_time"], name: "index_vacancies_on_expiry_time"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -37,11 +37,13 @@ FactoryBot.define do
       association :school, strategy: :null
       association :school_group
       job_location { 'central_office' }
+      readable_job_location { 'Trust head office' }
     end
 
     trait :with_school_group_at_school do
       association :school_group
       job_location { 'at_one_school' }
+      readable_job_location { school.name }
     end
 
     trait :fail_minimum_validation do

--- a/spec/features/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
@@ -20,6 +20,9 @@ RSpec.feature 'Editing a draft vacancy' do
 
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
       expect(page).to have_content(location(school_group))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
+        I18n.t('hiring_staff.organisations.school_groups.readable_job_location')
+      )
 
       click_header_link(I18n.t('jobs.job_location'))
       vacancy.job_location = 'at_one_school'
@@ -33,6 +36,7 @@ RSpec.feature 'Editing a draft vacancy' do
       expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
       expect(page).to have_content(location(school_1))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_1.name)
 
       click_header_link(I18n.t('jobs.job_location'))
       vacancy.job_location = 'at_one_school'
@@ -46,6 +50,7 @@ RSpec.feature 'Editing a draft vacancy' do
       expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
       expect(page).to have_content(location(school_2))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_2.name)
 
       click_header_link(I18n.t('jobs.job_location'))
       vacancy.job_location = 'central_office'
@@ -55,6 +60,9 @@ RSpec.feature 'Editing a draft vacancy' do
       expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
       expect(page).to have_content(location(school_group))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
+        I18n.t('hiring_staff.organisations.school_groups.readable_job_location')
+      )
     end
   end
 end

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
@@ -20,6 +20,9 @@ RSpec.feature 'Editing a published vacancy' do
 
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
       expect(page).to have_content(location(school_group))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
+        I18n.t('hiring_staff.organisations.school_groups.readable_job_location')
+      )
 
       click_header_link(I18n.t('jobs.job_location'))
       vacancy.job_location = 'at_one_school'
@@ -33,6 +36,7 @@ RSpec.feature 'Editing a published vacancy' do
       expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
       expect(page).to have_content(location(school_1))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_1.name)
 
       click_header_link(I18n.t('jobs.job_location'))
       vacancy.job_location = 'at_one_school'
@@ -46,6 +50,7 @@ RSpec.feature 'Editing a published vacancy' do
       expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
       expect(page).to have_content(location(school_2))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_2.name)
 
       click_header_link(I18n.t('jobs.job_location'))
       vacancy.job_location = 'central_office'
@@ -55,6 +60,9 @@ RSpec.feature 'Editing a published vacancy' do
       expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
       expect(page).to have_content(location(school_group))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
+        I18n.t('hiring_staff.organisations.school_groups.readable_job_location')
+      )
     end
   end
 end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_as_a_school_group_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_as_a_school_group_spec.rb
@@ -46,6 +46,9 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.continue')
 
         expect(Vacancy.last.state).to eql('create')
+        expect(Vacancy.last.readable_job_location).to eql(
+          I18n.t('hiring_staff.organisations.school_groups.readable_job_location')
+        )
         activity = Vacancy.last.activities.last
         expect(activity.session_id).to eql(session_id)
         expect(activity.key).to eql('vacancy.create')
@@ -104,6 +107,7 @@ RSpec.feature 'Creating a vacancy' do
         click_on I18n.t('buttons.continue')
 
         expect(Vacancy.last.state).to eql('create')
+        expect(Vacancy.last.readable_job_location).to eql(school.name)
         activity = Vacancy.last.activities.last
         expect(activity.session_id).to eql(session_id)
         expect(activity.key).to eql('vacancy.create')


### PR DESCRIPTION
This PR is part of the work required to complete [TEVA-682](https://dfedigital.atlassian.net/browse/TEVA-682). This will allow the readable job location to be sorted easily on the vacancies dashboard page.

## Changes in this PR
- Add `readable_job_location` field to `Vacancy`
- Update readable field to ensure it remains consistent with `job_location`

## Next steps
- [x] Deploy to staging to ensure migration happens smoothly
