### PR TITLE
Managed organisations bug

### DIFF
--- a/app/controllers/hiring_staff/vacancies/school_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/school_controller.rb
@@ -1,4 +1,6 @@
 class HiringStaff::Vacancies::SchoolController < HiringStaff::Vacancies::ApplicationController
+  include OrganisationHelper
+
   before_action :verify_school_group
   before_action :set_up_url
   before_action :set_school_options, only: %i[show update]
@@ -56,7 +58,9 @@ class HiringStaff::Vacancies::SchoolController < HiringStaff::Vacancies::Applica
   end
 
   def set_school_options
-    @school_options = current_organisation.schools
+    @school_options = current_organisation.schools.order(:name).map do |school|
+      OpenStruct.new({ id: school.id, name: school.name, address: full_address(school) })
+    end
   end
 
   def readable_job_location(job_location, school_name)

--- a/app/form_models/managed_organisations_form.rb
+++ b/app/form_models/managed_organisations_form.rb
@@ -1,5 +1,6 @@
 class ManagedOrganisationsForm
   include ActiveModel::Model
+  include OrganisationHelper
 
   attr_accessor :current_preference, :current_organisation, :current_user,
                 :managed_organisations, :managed_school_urns, :school_options
@@ -14,8 +15,9 @@ class ManagedOrganisationsForm
     )
     @managed_organisations = params[:managed_organisations] || current_preference.managed_organisations
     @managed_school_urns = params[:managed_school_urns] || current_preference.managed_school_urns
-    @school_options = current_organisation.schools.present? ?
-      current_organisation.schools.sort_by { |school| school.name } : []
+    @school_options = current_organisation.schools.order(:name).map do |school|
+      OpenStruct.new({ name: school.name, urn: school.urn, address: full_address(school) })
+    end
   end
 
   def save

--- a/app/views/hiring_staff/organisations/managed_organisations/show.html.haml
+++ b/app/views/hiring_staff/organisations/managed_organisations/show.html.haml
@@ -24,7 +24,7 @@
         = f.govuk_check_box :managed_organisations,
           'school_group',
           label: { text: t('hiring_staff.managed_organisations.options.school_group') },
-          hint_text: 'Replace this with current_organisation.address'
+          hint_text: full_address(current_organisation)
 
         = f.govuk_collection_check_boxes :managed_school_urns,
           @managed_organisations_form.school_options,


### PR DESCRIPTION
This PR fixes a small bug/todo where the complete school addresses weren't shown in either the schools vacancy form or the managed organisations form.

## Changes in this PR
- Order school options by name
- Map school options to OpenStructs, using the OrganisationHelper to populate the address
