### PR TITLE
Create a job heading bug

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -71,13 +71,17 @@ module VacanciesHelper
   end
 
   def page_title(vacancy)
-    if vacancy.state == 'copy'
-      I18n.t('jobs.copy_job_title', job_title: vacancy.job_title)
-    elsif %w(create review).include?(vacancy.state)
-      I18n.t('jobs.create_a_job_title', organisation: vacancy.school_or_school_group&.name.presence || '')
-    else
-      I18n.t('jobs.edit_job_title', job_title: vacancy.job_title)
-    end
+    return I18n.t('jobs.copy_job_title', job_title: vacancy.job_title) if vacancy.state == 'copy'
+    return I18n.t('jobs.create_a_job_title', organisation: vacancy.school_or_school_group&.name.presence || '') if
+      %w(create review).include?(vacancy.state)
+    I18n.t('jobs.edit_job_title', job_title: vacancy.job_title)
+  end
+
+  def page_title_no_vacancy
+    return I18n.t('jobs.create_a_job_title', organisation: session[:vacancy_attributes]['readable_job_location']) if
+      session[:vacancy_attributes].present? && session[:vacancy_attributes]['school_id'].present? &&
+      session[:vacancy_attributes]['job_location'] == 'at_one_school'
+    I18n.t('jobs.create_a_job_title', organisation: current_organisation.name)
   end
 
   def missing_subjects?(vacancy)

--- a/app/views/hiring_staff/vacancies/vacancy_form_partials/_heading.html.haml
+++ b/app/views/hiring_staff/vacancies/vacancy_form_partials/_heading.html.haml
@@ -1,5 +1,5 @@
 %h1.govuk-heading-m
-  = @vacancy.present? ? page_title(@vacancy) : t('jobs.create_a_job_title_no_org')
+  = @vacancy.present? ? page_title(@vacancy) : page_title_no_vacancy
   - unless %w(copy edit edit_published).include?(@vacancy&.state)
     %span.govuk-caption-m
-      = t('jobs.current_step', step: current_step,  total: total_steps)
+      = t('jobs.current_step', step: current_step, total: total_steps)


### PR DESCRIPTION
This PR fixes a bug that meant incorrect headings were displayed when a vacancy had not yet been created.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1115

## Changes in this PR
- Use the session to determine which organisation the job is for when creating SchoolGroup jobs
