### PR TITLE
Enable creation of reviews apps when PR is raised

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,7 +81,7 @@ jobs:
         TF_VAR_app_stopped : true
         TF_VAR_papertrail_url: ${{ secrets.PAPERTRAIL_URL_DEV }}
     
-    - name: terraform destory (on PR closed)
+    - name: terraform destroy (on PR closed)
       if: github.event_name == 'pull_request' && github.event.action == 'closed'
       working-directory: ./terraform/paas
       run: |


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-797

## Changes in this PR:

- Enables a GitHub actions workflow to create temporary review apps via Terraform
- Reads secrets from AWS SSM Parameter store, which are used as CF env vars

## Next steps:

- [ ] Document review apps lifecycle
- [ ] Set SSM Parameter store secrets
- [ ] Document working with SSM Parameter store
