### PR TITLE
Store managed_organisations preferences as school_id instead of urn

### DIFF
--- a/app/components/hiring_staff/vacancies_component.rb
+++ b/app/components/hiring_staff/vacancies_component.rb
@@ -56,9 +56,12 @@ class HiringStaff::VacanciesComponent < ViewComponent::Base
   def set_filters(vacancies, filters)
     return vacancies if filters.none? || filters[:managed_organisations] == 'all'
 
-    in_school_urns = filters[:managed_school_urns]&.any? ? vacancies.in_school_urns(filters[:managed_school_urns]) : []
-    in_central_office = filters[:managed_organisations] == 'school_group' ? vacancies.in_central_office : []
+    return vacancies.in_school_ids(filters[:managed_school_ids]) if
+      filters[:managed_school_ids]&.any? && filters[:managed_organisations] != 'school_group'
 
-    in_school_urns + in_central_office
+    return vacancies.in_central_office if
+      filters[:managed_organisations] == 'school_group' && filters[:managed_school_ids]&.none?
+
+    vacancies.in_school_ids(filters[:managed_school_ids]).or(vacancies.in_central_office)
   end
 end

--- a/app/controllers/hiring_staff/organisations/managed_organisations_controller.rb
+++ b/app/controllers/hiring_staff/organisations/managed_organisations_controller.rb
@@ -22,7 +22,7 @@ class HiringStaff::Organisations::ManagedOrganisationsController < HiringStaff::
   private
 
   def managed_organisations_params
-    params.require(:managed_organisations_form).permit(managed_organisations: [], managed_school_urns: [])
+    params.require(:managed_organisations_form).permit(managed_organisations: [], managed_school_ids: [])
   end
 
   def vacancy_filter
@@ -31,7 +31,7 @@ class HiringStaff::Organisations::ManagedOrganisationsController < HiringStaff::
 
   def set_school_options
     @school_options = current_organisation.schools.order(:name).map do |school|
-      OpenStruct.new({ urn: school.urn, name: school.name, address: full_address(school) })
+      OpenStruct.new({ id: school.id, name: school.name, address: full_address(school) })
     end
   end
 end

--- a/app/form_models/managed_organisations_form.rb
+++ b/app/form_models/managed_organisations_form.rb
@@ -2,19 +2,19 @@ class ManagedOrganisationsForm
   include ActiveModel::Model
   include OrganisationHelper
 
-  attr_accessor :managed_organisations, :managed_school_urns
+  attr_accessor :managed_organisations, :managed_school_ids
 
   validate :at_least_one_option_selected
 
   def initialize(params = {})
     @managed_organisations = params[:managed_organisations]
-    @managed_school_urns = params[:managed_school_urns]
+    @managed_school_ids = params[:managed_school_ids]
   end
 
   private
 
   def at_least_one_option_selected
-    return if managed_organisations.present? || managed_school_urns.any?
+    return if managed_organisations.present? || managed_school_ids.any?
 
     errors.add(:managed_organisations, I18n.t('hiring_staff_user_preference_errors.managed_organisations.blank'))
   end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -253,7 +253,7 @@ class Vacancy < ApplicationRecord
   scope :pending, (-> { published.where('publish_on > ?', Time.zone.today) })
   scope :published_on_count, (->(date) { published.where(publish_on: date.all_day).count })
   scope :unindexed, (-> { live.where(initially_indexed: false) })
-  scope :in_school_urns, (-> (urns) { joins(:school).where('schools.urn': urns) })
+  scope :in_school_ids, (-> (ids) { where(school_id: ids) })
   scope :in_central_office, (-> { where(job_location: 'central_office') })
 
   paginates_per 10

--- a/app/services/hiring_staff/vacancy_filter.rb
+++ b/app/services/hiring_staff/vacancy_filter.rb
@@ -1,30 +1,30 @@
 class HiringStaff::VacancyFilter
-  attr_reader :managed_school_urns, :managed_organisations
+  attr_reader :managed_school_ids, :managed_organisations
 
   def initialize(user, school_group)
     @user_preference = UserPreference.find_or_initialize_by(user: user, school_group: school_group)
-    @managed_school_urns = @user_preference.managed_school_urns
+    @managed_school_ids = @user_preference.managed_school_ids
     @managed_organisations = @user_preference.managed_organisations
   end
 
   def update(params)
-    @managed_school_urns = params[:managed_school_urns]&.reject(&:blank?)
+    @managed_school_ids = params[:managed_school_ids]&.reject(&:blank?)
     @managed_organisations = params[:managed_organisations]
 
-    if managed_organisations&.include?('all') || (managed_organisations.blank? && managed_school_urns&.none?)
+    if managed_organisations&.include?('all') || (managed_organisations.blank? && managed_school_ids&.none?)
       @managed_organisations = 'all'
-      @managed_school_urns = []
+      @managed_school_ids = []
     elsif managed_organisations&.include?('school_group')
       @managed_organisations = 'school_group'
     end
 
-    @user_preference.update(managed_organisations: managed_organisations, managed_school_urns: managed_school_urns)
+    @user_preference.update(managed_organisations: managed_organisations, managed_school_ids: managed_school_ids)
   end
 
   def to_h
     {
       managed_organisations: managed_organisations,
-      managed_school_urns: managed_school_urns
+      managed_school_ids: managed_school_ids
     }
   end
 end

--- a/app/views/hiring_staff/organisations/managed_organisations/show.html.haml
+++ b/app/views/hiring_staff/organisations/managed_organisations/show.html.haml
@@ -26,9 +26,9 @@
           label: { text: t('hiring_staff.managed_organisations.options.school_group') },
           hint_text: full_address(current_organisation)
 
-        = f.govuk_collection_check_boxes :managed_school_urns,
+        = f.govuk_collection_check_boxes :managed_school_ids,
           @school_options,
-          :urn,
+          :id,
           :name,
           :address,
           legend: { text: t('hiring_staff.managed_organisations.labels.select_organisations'), hidden: true },

--- a/db/migrate/20200804075056_change_managed_school_urns_to_managed_school_ids.rb
+++ b/db/migrate/20200804075056_change_managed_school_urns_to_managed_school_ids.rb
@@ -1,0 +1,5 @@
+class ChangeManagedSchoolUrnsToManagedSchoolIds < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :user_preferences, :managed_school_urns, :managed_school_ids
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_30_091409) do
+ActiveRecord::Schema.define(version: 2020_08_04_075056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -210,7 +210,7 @@ ActiveRecord::Schema.define(version: 2020_07_30_091409) do
     t.string "managed_organisations"
     t.uuid "user_id"
     t.uuid "school_group_id"
-    t.string "managed_school_urns", array: true
+    t.string "managed_school_ids", array: true
     t.index ["school_group_id"], name: "index_user_preferences_on_school_group_id"
     t.index ["user_id"], name: "index_user_preferences_on_user_id"
   end

--- a/spec/components/hiring_staff/vacancies_component_spec.rb
+++ b/spec/components/hiring_staff/vacancies_component_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe HiringStaff::VacanciesComponent, type: :component do
 
     let!(:inline_component) { render_inline(subject) }
 
-    let(:filters) { { managed_school_urns: [school_oxford.urn], managed_organisations: '' } }
+    let(:filters) { { managed_school_ids: [school_oxford.id], managed_organisations: '' } }
 
     it 'renders the vacancy in Oxford' do
       expect(rendered_component).to include(school_oxford.name)

--- a/spec/factories/user_preferences.rb
+++ b/spec/factories/user_preferences.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     association :school_group
     association :user
     managed_organisations { 'all' }
-    managed_school_urns { [] }
+    managed_school_ids { [] }
   end
 end

--- a/spec/features/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
+++ b/spec/features/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
@@ -38,12 +38,12 @@ RSpec.feature 'Hiring staff can set managed organisations user preferences' do
 
     check I18n.t('hiring_staff.managed_organisations.options.school_group'),
           name: 'managed_organisations_form[managed_organisations][]', visible: false
-    check school_1.name, name: 'managed_organisations_form[managed_school_urns][]', visible: false
+    check school_1.name, name: 'managed_organisations_form[managed_school_ids][]', visible: false
 
     click_on I18n.t('buttons.continue')
 
     expect(page.current_path).to eql(organisation_path)
     expect(user_preference.managed_organisations).to eql('school_group')
-    expect(user_preference.managed_school_urns).to eql([school_1.urn])
+    expect(user_preference.managed_school_ids).to eql([school_1.id])
   end
 end

--- a/spec/form_models/managed_organisations_form_spec.rb
+++ b/spec/form_models/managed_organisations_form_spec.rb
@@ -2,24 +2,24 @@ require 'rails_helper'
 
 RSpec.describe ManagedOrganisationsForm, type: :model do
   let(:managed_organisations) { ['school_group'] }
-  let(:managed_school_urns) { ['12345', '23456'] }
+  let(:managed_school_ids) { ['12345', '23456'] }
 
-  let(:params) { { managed_organisations: managed_organisations, managed_school_urns: managed_school_urns } }
+  let(:params) { { managed_organisations: managed_organisations, managed_school_ids: managed_school_ids } }
   let(:subject) { described_class.new(params) }
 
   describe '#initialize' do
     it 'assigns attributes' do
       expect(subject.managed_organisations).to eql(managed_organisations)
-      expect(subject.managed_school_urns).to eql(managed_school_urns)
+      expect(subject.managed_school_ids).to eql(managed_school_ids)
     end
   end
 
   describe '#validations' do
-    context 'when managed_organisations and managed_school_urns are blank' do
+    context 'when managed_organisations and managed_school_ids are blank' do
       let(:managed_organisations) { '' }
-      let(:managed_school_urns) { [] }
+      let(:managed_school_ids) { [] }
 
-      it 'validates presence of managed_organisations or managed_school_urns' do
+      it 'validates presence of managed_organisations or managed_school_ids' do
         expect(subject.valid?).to be(false)
         expect(subject.errors.messages[:managed_organisations]).to include(
           I18n.t('hiring_staff_user_preference_errors.managed_organisations.blank')

--- a/spec/services/hiring_staff/vacancy_filter_spec.rb
+++ b/spec/services/hiring_staff/vacancy_filter_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe HiringStaff::VacancyFilter do
   let(:user) { create :user }
   let(:school_group) { create :school_group }
   let(:managed_organisations) { 'school_group' }
-  let(:managed_school_urns) { ['1234', '5678'] }
+  let(:managed_school_ids) { ['1234', '5678'] }
   let!(:user_preference) { create :user_preference, user: user, school_group: school_group,
-    managed_organisations: managed_organisations, managed_school_urns: managed_school_urns
+    managed_organisations: managed_organisations, managed_school_ids: managed_school_ids
   }
 
   subject { described_class.new(user, school_group) }
@@ -16,37 +16,37 @@ RSpec.describe HiringStaff::VacancyFilter do
       expect(subject.managed_organisations).to eq managed_organisations
     end
 
-    it 'sets the managed_school_urns from user_preference' do
-      expect(subject.managed_school_urns).to eq managed_school_urns
+    it 'sets the managed_school_ids from user_preference' do
+      expect(subject.managed_school_ids).to eq managed_school_ids
     end
   end
 
   describe '#update' do
-    before { subject.update(managed_organisations: new_organisations, managed_school_urns: new_school_urns) }
+    before { subject.update(managed_organisations: new_organisations, managed_school_ids: new_school_ids) }
 
     context 'when new_managed_organisations is not all' do
       let(:new_organisations) { nil }
-      let(:new_school_urns) { ['4321', '8765'] }
+      let(:new_school_ids) { ['4321', '8765'] }
 
       it 'updates user_preference managed_organisations' do
         expect(user_preference.reload.managed_organisations).to eq new_organisations
       end
 
-      it 'updates user_preference managed_school_urns' do
-        expect(user_preference.reload.managed_school_urns).to eq new_school_urns
+      it 'updates user_preference managed_school_ids' do
+        expect(user_preference.reload.managed_school_ids).to eq new_school_ids
       end
     end
 
     context 'when new_managed_organisations is all' do
       let(:new_organisations) { ['all'] }
-      let(:new_school_urns) { ['4321', '8765'] }
+      let(:new_school_ids) { ['4321', '8765'] }
 
       it 'updates user_preference managed_organisations to all' do
         expect(user_preference.reload.managed_organisations).to eq 'all'
       end
 
-      it 'updates user_preference managed_school_urns to empty array' do
-        expect(user_preference.reload.managed_school_urns).to eq []
+      it 'updates user_preference managed_school_ids to empty array' do
+        expect(user_preference.reload.managed_school_ids).to eq []
       end
     end
   end


### PR DESCRIPTION
This PR follows on from #1832. User preferences now store school_ids instead of school_urns. This removes the need for a table join since school is a foreign key field on the vacancy model. This means the ActiveRecord `.or` query can be used to combine vacancies in trust and managed schools, which means that sorting of vacancies in the dashboard is no longer regressed.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1133

## Changes in this PR
- Use `.or` ActiveRecord query when filtering vacancies
