### PR TITLE
Trust or School overview should be conditional on vacancy.job_location

### DIFF
--- a/app/components/jobseekers/school_group_overview_component.rb
+++ b/app/components/jobseekers/school_group_overview_component.rb
@@ -5,4 +5,8 @@ class Jobseekers::SchoolGroupOverviewComponent < ViewComponent::Base
   def initialize(vacancy:)
     @vacancy = vacancy
   end
+
+  def render?
+    @vacancy.job_location == 'central_office'
+  end
 end

--- a/app/components/jobseekers/school_overview_component.rb
+++ b/app/components/jobseekers/school_overview_component.rb
@@ -5,4 +5,8 @@ class Jobseekers::SchoolOverviewComponent < ViewComponent::Base
   def initialize(vacancy:)
     @vacancy = vacancy
   end
+
+  def render?
+    @vacancy.job_location != 'central_office'
+  end
 end

--- a/app/views/shared/vacancy/_jobseeker_view.html.haml
+++ b/app/views/shared/vacancy/_jobseeker_view.html.haml
@@ -30,11 +30,8 @@
               = t('schools.school_overview')
 
       = render(Jobseekers::VacancyDetailsComponent.new(vacancy: @vacancy))
-
-      - if @vacancy.school_group
-        = render(Jobseekers::SchoolGroupOverviewComponent.new(vacancy: @vacancy))
-      - else
-        = render(Jobseekers::SchoolOverviewComponent.new(vacancy: @vacancy))
+      = render(Jobseekers::SchoolGroupOverviewComponent.new(vacancy: @vacancy))
+      = render(Jobseekers::SchoolOverviewComponent.new(vacancy: @vacancy))
 
     %section
       %h4.govuk-heading-s.share-this-job

--- a/spec/components/jobseekers/school_group_overview_component_spec.rb
+++ b/spec/components/jobseekers/school_group_overview_component_spec.rb
@@ -2,10 +2,36 @@ require 'rails_helper'
 
 RSpec.describe Jobseekers::SchoolGroupOverviewComponent, type: :component do
   let(:school_group) { create(:school_group) }
-  let(:vacancy) { create(:vacancy, school_group: school_group) }
+  let(:vacancy) { create(:vacancy, :with_school_group, school_group: school_group) } # use factory helper
   let(:vacancy_presenter) { VacancyPresenter.new(vacancy) }
 
   before { render_inline(described_class.new(vacancy: vacancy_presenter)) }
+
+  describe '#render?' do
+    let(:school) { create(:school) }
+
+    context 'when vacancy is at a school without a trust' do
+      let(:vacancy) { create(:vacancy, school: school) }
+
+      it 'does not render the component' do
+        expect(rendered_component).to be_blank
+      end
+    end
+
+    context 'when vacancy is at a single school in a trust' do
+      let(:vacancy) { create(:vacancy, :with_school_group_at_school, school_group: school_group) }
+
+      it 'does not render the component' do
+        expect(rendered_component).to be_blank
+      end
+    end
+
+    context 'when vacancy is at a trust head office' do
+      it 'renders the component' do
+        expect(rendered_component).not_to be_blank
+      end
+    end
+  end
 
   it 'renders the trust type' do
     expect(rendered_component).to include(organisation_type(vacancy.school_group))

--- a/spec/components/jobseekers/school_overview_component_spec.rb
+++ b/spec/components/jobseekers/school_overview_component_spec.rb
@@ -7,6 +7,26 @@ RSpec.describe Jobseekers::SchoolOverviewComponent, type: :component do
 
   before { render_inline(described_class.new(vacancy: vacancy_presenter)) }
 
+  describe '#render?' do
+    let(:school_group) { create(:school_group) }
+
+    context 'when vacancy is at a trust head office' do
+      let(:vacancy) { create(:vacancy, :with_school_group, school_group: school_group) }
+
+      it 'does not render the component' do
+        expect(rendered_component).to be_blank
+      end
+    end
+
+    context 'when vacancy is at a single school in a trust' do
+      let(:vacancy) { create(:vacancy, :with_school_group_at_school, school_group: school_group) }
+
+      it 'renders the component' do
+        expect(rendered_component).not_to be_blank
+      end
+    end
+  end
+
   it 'renders the school type' do
     expect(rendered_component).to include(organisation_type(vacancy.school))
   end


### PR DESCRIPTION
A job belonging to a school group which is located at a single school should display the school overview tab not the trust overview tab.