### PR TITLE
SchoolGroup user dashboard filters

### DIFF
--- a/app/components/hiring_staff/no_vacancies_component.html.haml
+++ b/app/components/hiring_staff/no_vacancies_component.html.haml
@@ -1,19 +1,20 @@
-.govuk-grid-row.no-jobs-border{ class: 'govuk-!-margin-top-5 govuk-!-margin-bottom-5' }
-  .govuk-grid-column-full
-    %h2.govuk-heading-m= t('schools.no_jobs.heading')
+.govuk-grid-column-full
+  .govuk-grid-row.no-jobs-border{ class: 'govuk-!-margin-top-5 govuk-!-margin-bottom-5' }
+    .govuk-grid-column-full
+      %h2.govuk-heading-m= t('schools.no_jobs.heading')
 
-    = link_to t('buttons.create_job'), new_organisation_job_path, class: 'govuk-button govuk-!-margin-bottom-0'
+      = link_to t('buttons.create_job'), new_organisation_job_path, class: 'govuk-button govuk-!-margin-bottom-0'
 
-    %p= t('schools.no_jobs.intro')
+      %p= t('schools.no_jobs.intro')
 
-  .govuk-grid-column-one-third
-    %h2.govuk-heading-s Required
-    %ul.govuk-list.govuk-list--bullet
-      - t('schools.no_jobs.bullets.required').each do |bullet|
-        %li= bullet
+    .govuk-grid-column-one-third
+      %h2.govuk-heading-s Required
+      %ul.govuk-list.govuk-list--bullet
+        - t('schools.no_jobs.bullets.required').each do |bullet|
+          %li= bullet
 
-  .govuk-grid-column-one-third
-    %h2.govuk-heading-s Optional
-    %ul.govuk-list.govuk-list--bullet
-      - t('schools.no_jobs.bullets.optional').each do |bullet|
-        %li= bullet
+    .govuk-grid-column-one-third
+      %h2.govuk-heading-s Optional
+      %ul.govuk-list.govuk-list--bullet
+        - t('schools.no_jobs.bullets.optional').each do |bullet|
+          %li= bullet

--- a/app/components/hiring_staff/vacancies_component.html.haml
+++ b/app/components/hiring_staff/vacancies_component.html.haml
@@ -1,11 +1,25 @@
-.dashboard-header
-  = link_to t("buttons.create_job"), new_organisation_job_path, class: "govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-0"
-.overflow-scroll
-  .govuk-tabs
-    %h2.govuk-tabs__title= t("aria_labels.content")
-    %ul.govuk-tabs__list.tab-list{ class: "govuk-!-margin-top-6" }
-      - @vacancy_types.each do |vacancy_type|
-        %li.govuk-tabs__list-item{ class: selected_class(vacancy_type) }
-          = vacancy_type_tab_link(vacancy_type)
+- if @organisation.is_a?(SchoolGroup)
+  .govuk-grid-column-one-quarter
+    = form_for @filters_form, url: organisation_managed_organisations_path, html: { method: "patch" } do |f|
+      = render 'shared/filter_group', f: f,
+        filters: { title: 'Job filters', items: [{ title: 'Locations', attribute: :managed_school_ids, options: @school_options, value_method: :id, text_method: :name, small: true }] }
 
-    = render "hiring_staff/organisations/vacancies_#{@selected_type}", organisation: @organisation, vacancies: @vacancies, sort: @sort
+      = f.hidden_field :jobs_type, value: @selected_type
+      = f.govuk_submit t('buttons.apply_filters')
+
+%div{ class: grid_column_class }
+  .dashboard-header
+    - if @organisation.is_a?(SchoolGroup)
+      .filters-information
+        %button.govuk-button.govuk-button--secondary{ class: "govuk-!-margin-bottom-0" }= t('buttons.hide_filters')
+        %span.govuk-body{ class: "govuk-!-margin-left-3" }= filters_applied_text
+    = link_to t("buttons.create_job"), new_organisation_job_path, class: "govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-0"
+  .overflow-scroll
+    .govuk-tabs
+      %h2.govuk-tabs__title= t("aria_labels.content")
+      %ul.govuk-tabs__list.tab-list{ class: "govuk-!-margin-top-6" }
+        - @vacancy_types.each do |vacancy_type|
+          %li.govuk-tabs__list-item{ class: selected_class(vacancy_type) }
+            = vacancy_type_tab_link(vacancy_type)
+
+      = render "hiring_staff/organisations/vacancies_#{@selected_type}", organisation: @organisation, vacancies: @vacancies, sort: @sort

--- a/app/components/hiring_staff/vacancies_component.rb
+++ b/app/components/hiring_staff/vacancies_component.rb
@@ -1,14 +1,20 @@
 class HiringStaff::VacanciesComponent < ViewComponent::Base
   delegate :awaiting_feedback_tab, to: :helpers
 
-  def initialize(organisation:, sort:, selected_type:, filters:)
+  def initialize(organisation:, sort:, selected_type:, filters:, filters_form:)
     @organisation = organisation
     @sort = sort
     @filters = filters
+    @filters_form = filters_form
+
+    set_managed_school_ids if organisation.is_a?(SchoolGroup)
+
     @selected_type = selected_type&.to_sym || :published
     @vacancy_types = %i[published pending draft expired awaiting_feedback]
 
     @vacancies = send(@selected_type)
+    @school_options = set_school_options if organisation.is_a?(SchoolGroup)
+
     @vacancies = set_filters(@vacancies, @filters) if organisation.is_a?(SchoolGroup)
     @vacancies = @vacancies.map { |v| OrganisationVacancyPresenter.new(v) }
   end
@@ -19,6 +25,14 @@ class HiringStaff::VacanciesComponent < ViewComponent::Base
 
   def selected_class(vacancy_type)
     'govuk-tabs__list-item--selected' if @selected_type == vacancy_type
+  end
+
+  def grid_column_class
+    @organisation.is_a?(SchoolGroup) ? 'govuk-grid-column-three-quarters' : 'govuk-grid-column-full'
+  end
+
+  def filters_applied_text
+    I18n.t('jobs.dashboard_filters.heading', count: @filters[:managed_school_ids]&.count)
   end
 
   def vacancy_type_tab_link(vacancy_type)
@@ -63,5 +77,19 @@ class HiringStaff::VacanciesComponent < ViewComponent::Base
       filters[:managed_organisations] == 'school_group' && filters[:managed_school_ids]&.none?
 
     vacancies.in_school_ids(filters[:managed_school_ids]).or(vacancies.in_central_office)
+  end
+
+  def set_managed_school_ids
+    @filters[:managed_school_ids] ||= []
+    @filters[:managed_school_ids].push('school_group') if @filters[:managed_organisations]&.include?('school_group')
+  end
+
+  def set_school_options
+    @school_options = @organisation.schools.order(:name).map do |school|
+      OpenStruct.new({ id: school.id, name: "#{school.name} (#{@vacancies.in_school_ids(school.id).count})" })
+    end
+    @school_options.unshift(
+      OpenStruct.new({ id: 'school_group', name: "Trust head office (#{@vacancies.in_central_office.count})" })
+    )
   end
 end

--- a/app/controllers/hiring_staff/base_controller.rb
+++ b/app/controllers/hiring_staff/base_controller.rb
@@ -28,6 +28,12 @@ class HiringStaff::BaseController < ApplicationController
     @current_user ||= User.find_or_create_by(oid: current_session_id)
   end
 
+  def current_user_preferences
+    UserPreference.find_by(
+      user_id: current_user.id, school_group_id: current_organisation.id
+    ) if current_organisation.is_a?(SchoolGroup)
+  end
+
   def check_user_last_activity_at
     return redirect_to logout_endpoint if current_user&.last_activity_at.blank?
 

--- a/app/controllers/hiring_staff/organisations/managed_organisations_controller.rb
+++ b/app/controllers/hiring_staff/organisations/managed_organisations_controller.rb
@@ -11,7 +11,11 @@ class HiringStaff::Organisations::ManagedOrganisationsController < HiringStaff::
   def update
     @managed_organisations_form = ManagedOrganisationsForm.new(managed_organisations_params)
 
-    if @managed_organisations_form.valid? || params[:commit] == 'Skip this step'
+    if params[:commit] == I18n.t('buttons.apply_filters')
+      set_managed_organisations
+      vacancy_filter.update(managed_organisations_params)
+      redirect_to jobs_with_type_organisation_path(params[:managed_organisations_form][:jobs_type])
+    elsif @managed_organisations_form.valid? || params[:commit] == I18n.t('buttons.skip_this_step')
       vacancy_filter.update(managed_organisations_params)
       redirect_to organisation_path
     else
@@ -22,6 +26,7 @@ class HiringStaff::Organisations::ManagedOrganisationsController < HiringStaff::
   private
 
   def managed_organisations_params
+    strip_empty_checkboxes(:managed_organisations_form, [:managed_organisations, :managed_school_ids])
     params.require(:managed_organisations_form).permit(managed_organisations: [], managed_school_ids: [])
   end
 
@@ -33,5 +38,11 @@ class HiringStaff::Organisations::ManagedOrganisationsController < HiringStaff::
     @school_options = current_organisation.schools.order(:name).map do |school|
       OpenStruct.new({ id: school.id, name: school.name, address: full_address(school) })
     end
+  end
+
+  def set_managed_organisations
+    params[:managed_organisations_form][:managed_organisations] ||= []
+    params[:managed_organisations_form][:managed_organisations].push('school_group') if
+      params[:managed_organisations_form][:managed_school_ids].include?('school_group')
   end
 end

--- a/app/controllers/hiring_staff/organisations/managed_organisations_controller.rb
+++ b/app/controllers/hiring_staff/organisations/managed_organisations_controller.rb
@@ -12,7 +12,6 @@ class HiringStaff::Organisations::ManagedOrganisationsController < HiringStaff::
     @managed_organisations_form = ManagedOrganisationsForm.new(managed_organisations_params)
 
     if params[:commit] == I18n.t('buttons.apply_filters')
-      set_managed_organisations
       vacancy_filter.update(managed_organisations_params)
       redirect_to jobs_with_type_organisation_path(params[:managed_organisations_form][:jobs_type])
     elsif @managed_organisations_form.valid? || params[:commit] == I18n.t('buttons.skip_this_step')
@@ -38,11 +37,10 @@ class HiringStaff::Organisations::ManagedOrganisationsController < HiringStaff::
     @school_options = current_organisation.schools.order(:name).map do |school|
       OpenStruct.new({ id: school.id, name: school.name, address: full_address(school) })
     end
-  end
-
-  def set_managed_organisations
-    params[:managed_organisations_form][:managed_organisations] ||= []
-    params[:managed_organisations_form][:managed_organisations].push('school_group') if
-      params[:managed_organisations_form][:managed_school_ids].include?('school_group')
+    @school_options.unshift(
+      OpenStruct.new({ id: 'school_group',
+                       name: I18n.t('hiring_staff.managed_organisations.options.school_group'),
+                       address: full_address(current_organisation) })
+    )
   end
 end

--- a/app/controllers/hiring_staff/organisations_controller.rb
+++ b/app/controllers/hiring_staff/organisations_controller.rb
@@ -6,6 +6,7 @@ class HiringStaff::OrganisationsController < HiringStaff::BaseController
     @organisation = current_organisation
     @sort = VacancySort.new.update(column: sort_column, order: sort_order)
     @filters = HiringStaff::VacancyFilter.new(current_user, current_school_group).to_h
+    @managed_organisations_form = ManagedOrganisationsForm.new(@filters)
     @selected_type = params[:type]
     @awaiting_feedback_count = @organisation.vacancies.awaiting_feedback.count
 
@@ -43,12 +44,6 @@ class HiringStaff::OrganisationsController < HiringStaff::BaseController
     if current_organisation.is_a?(SchoolGroup) && current_user_preferences.nil?
       redirect_to organisation_managed_organisations_path
     end
-  end
-
-  def current_user_preferences
-    UserPreference.find_by(
-      user_id: current_user.id, school_group_id: current_organisation.id
-    ) if current_organisation.is_a?(SchoolGroup)
   end
 
   def session_has_multiple_organisations?

--- a/app/frontend/styles/components/hiring-staff.scss
+++ b/app/frontend/styles/components/hiring-staff.scss
@@ -21,10 +21,14 @@ body.hiring-staff {
 }
 
 .dashboard-header {
-  text-align: right;
   > a {
+    float: right;
     margin-bottom: 0;
   }
+}
+
+.filters-information {
+  display: inline-block;
 }
 
 .button-link {

--- a/app/services/hiring_staff/vacancy_filter.rb
+++ b/app/services/hiring_staff/vacancy_filter.rb
@@ -14,8 +14,6 @@ class HiringStaff::VacancyFilter
     if managed_organisations&.include?('all') || (managed_organisations.blank? && managed_school_ids&.none?)
       @managed_organisations = 'all'
       @managed_school_ids = []
-    elsif managed_organisations&.include?('school_group')
-      @managed_organisations = 'school_group'
     end
 
     @user_preference.update(managed_organisations: managed_organisations, managed_school_ids: managed_school_ids)

--- a/app/views/hiring_staff/organisations/managed_organisations/show.html.haml
+++ b/app/views/hiring_staff/organisations/managed_organisations/show.html.haml
@@ -21,11 +21,6 @@
 
         .govuk-body{ class: 'govuk-!-margin-left-2 govuk-!-margin-bottom-2' } Or
 
-        = f.govuk_check_box :managed_organisations,
-          'school_group',
-          label: { text: t('hiring_staff.managed_organisations.options.school_group') },
-          hint_text: full_address(current_organisation)
-
         = f.govuk_collection_check_boxes :managed_school_ids,
           @school_options,
           :id,

--- a/app/views/hiring_staff/organisations/show.html.haml
+++ b/app/views/hiring_staff/organisations/show.html.haml
@@ -10,9 +10,7 @@
       - else
         = link_to t('sign_in.organisation.change'), auth_dfe_callback_path, class: 'govuk-link'
 
-  .govuk-grid-column-full
-    .govuk-form-group
-      = render(HiringStaff::VacanciesComponent.new(organisation: @organisation, sort: @sort, selected_type: @selected_type, filters: @filters))
-      = render(HiringStaff::NoVacanciesComponent.new(organisation: @organisation))
+  = render(HiringStaff::VacanciesComponent.new(organisation: @organisation, sort: @sort, selected_type: @selected_type, filters: @filters, filters_form: @managed_organisations_form))
+  = render(HiringStaff::NoVacanciesComponent.new(organisation: @organisation))
 
   = render(HiringStaff::SchoolOverviewComponent.new(organisation: @organisation))

--- a/app/views/shared/_checkbox_group.html.haml
+++ b/app/views/shared/_checkbox_group.html.haml
@@ -5,4 +5,9 @@
       %input.govuk-input.search-input__input{ placeholder: "Search" }
       %button{type: "submit"}
         %i.fa.fa-search
-  = f.govuk_collection_check_boxes attribute_name, options, value_method, text_method, hint_method, small: small
+  = f.govuk_collection_check_boxes attribute_name,
+    options,
+    value_method,
+    text_method,
+    hint_method = hint_method,
+    small: small

--- a/app/views/shared/_filter_group.html.haml
+++ b/app/views/shared/_filter_group.html.haml
@@ -66,4 +66,11 @@
             = filter[:title]
 
       .govuk-accordion__section-content{ id: "accordion-default-content-#{index}", aria: { labelledby: "accordion-default-heading-#{index}" } }
-        = render 'shared/checkbox_group', filter[:search], f: f, attribute_name: :subjects, options: filter[:options], value_method: :first, text_method: :first, hint_method: :last
+        = render 'shared/checkbox_group', f: f,
+          search: filter[:search],
+          attribute_name: filter[:attribute],
+          options: filter[:options],
+          value_method: filter[:value_method],
+          text_method: filter[:text_method],
+          hint_method: filter[:hint_method],
+          small: filter[:small]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,6 +230,14 @@ en:
     view_more_or_change: View more or change
   jobs:
     current_step: "Step %{step} of %{total}"
+    dashboard_filters:
+      apply_filters: Apply filters
+      hide_filters: Hide filters
+      show_filters: Show filters
+      heading:
+        zero: Showing all jobs
+        one: 1 filter applied
+        other: '%{count} filters applied'
     notification_labels:
       new: new
       action_required: action required
@@ -775,6 +783,7 @@ en:
       (the date we began recording statistics).
   buttons:
     accept_and_continue: Accept and continue
+    apply_filters: Apply filters
     back: Back
     back_to_manage_jobs: Back to manage jobs
     cancel_copy: Cancel copy
@@ -786,6 +795,7 @@ en:
     dismiss: Dismiss
     find: Find
     go_to_teaching_vacancies: Go to Teaching Vacancies
+    hide_filters: Hide filters
     save_and_return_later: Save and return later
     save_changes: Save changes
     search: Search

--- a/spec/components/hiring_staff/vacancies_component_spec.rb
+++ b/spec/components/hiring_staff/vacancies_component_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe HiringStaff::VacanciesComponent, type: :component do
   let(:sort) { VacancySort.new.update(column: 'job_title', order: 'desc') }
   let(:selected_type) { 'published' }
   let(:filters) { {} }
+  let(:filters_form) { ManagedOrganisationsForm.new(filters) }
 
   subject do
-    described_class.new(organisation: organisation, sort: sort, selected_type: selected_type, filters: filters)
+    described_class.new(
+      organisation: organisation, sort: sort, selected_type: selected_type, filters: filters, filters_form: filters_form
+    )
   end
 
   context 'when organisation has no active vacancies' do
@@ -42,16 +45,29 @@ RSpec.describe HiringStaff::VacanciesComponent, type: :component do
       it 'does not render the vacancy readable job location in the table' do
         expect(inline_component.css('.govuk-table.vacancies > tbody > tr > td#vacancy_location').to_html).to be_blank
       end
+
+      it 'does not render the filters sidebar' do
+        expect(
+          inline_component.css('.new_managed_organisations_form > input[type="submit"]')
+        ).to be_blank
+      end
     end
 
     context 'when the organisation is a school group' do
       let(:organisation) { create(:school_group) }
       let!(:vacancy) { create(:vacancy, :published, :with_school_group, school_group: organisation) }
+      let(:filters) { { managed_school_ids: [], managed_organisations: 'school_group' } }
 
       it 'renders the vacancy readable job location in the table' do
         expect(
           inline_component.css('.govuk-table.vacancies > tbody > tr > td#vacancy_location').to_html
         ).to include(vacancy.readable_job_location)
+      end
+
+      it 'renders the filters sidebar' do
+        expect(
+          inline_component.css('.new_managed_organisations_form > input[type="submit"]').attribute('value').value
+        ).to eql(I18n.t('buttons.apply_filters'))
       end
     end
   end

--- a/spec/features/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
+++ b/spec/features/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+RSpec.feature 'Hiring staff can filter vacancies in their dashboard' do
+  let(:school_group) { create(:school_group) }
+  let(:school_1) { create(:school, name: 'Happy Rainbows School') }
+  let(:school_2) { create(:school, name: 'Dreary Grey School') }
+  let!(:school_group_vacancy) { create(:vacancy, :published, :with_school_group, school_group: school_group) }
+  let!(:school_1_vacancy) { create(:vacancy, :published, :with_school_group_at_school,
+                                   school: school_1, school_group: school_group) }
+  let!(:school_1_draft_vacancy) { create(:vacancy, :draft, :with_school_group_at_school,
+                                         school: school_1, school_group: school_group) }
+  let!(:school_2_draft_vacancy) { create(:vacancy, :draft, :with_school_group_at_school,
+                                         school: school_2, school_group: school_group) }
+
+  before do
+    allow(SchoolGroupJobsFeature).to receive(:enabled?).and_return(true)
+
+    SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
+
+    stub_accepted_terms_and_conditions
+    OmniAuth.config.test_mode = true
+
+    stub_authentication_step(school_urn: nil, school_group_uid: school_group.uid)
+    stub_authorisation_step
+    stub_sign_in_with_multiple_organisations
+
+    visit root_path
+    sign_in_user
+
+    UserPreference.find_or_create_by(
+      user_id: User.last.id, school_group_id: school_group.id,
+      managed_organisations: managed_organisations, managed_school_ids: managed_school_ids
+    )
+  end
+
+  after do
+    OmniAuth.config.mock_auth[:default] = nil
+    OmniAuth.config.mock_auth[:dfe] = nil
+    OmniAuth.config.test_mode = false
+  end
+
+  context 'when managed_organisations is all' do
+    let(:managed_organisations) { 'all' }
+    let(:managed_school_ids) { [] }
+
+    context 'when viewing published jobs tab' do
+      scenario 'it shows all published vacancies' do
+        visit jobs_with_type_organisation_path(:published)
+
+        expect(page).to have_content('Showing all jobs')
+
+        expect(page).to have_content(school_group_vacancy.job_title)
+        expect(page).to have_content(school_1_vacancy.job_title)
+        expect(page).to_not have_content(school_1_draft_vacancy.job_title)
+        expect(page).to_not have_content(school_2_draft_vacancy.job_title)
+      end
+
+      context 'when applying filters' do
+        scenario 'it shows filtered published vacancies' do
+          visit jobs_with_type_organisation_path(:published)
+
+          check 'Happy Rainbows School (1)', name: 'managed_organisations_form[managed_school_ids][]', visible: false
+          click_on I18n.t('buttons.apply_filters')
+
+          expect(page).to have_content('1 filter applied')
+
+          expect(page).to_not have_content(school_group_vacancy.job_title)
+          expect(page).to have_content(school_1_vacancy.job_title)
+          expect(page).to_not have_content(school_1_draft_vacancy.job_title)
+          expect(page).to_not have_content(school_2_draft_vacancy.job_title)
+        end
+      end
+    end
+
+    context 'when viewing draft jobs tab' do
+      scenario 'it shows all draft vacancies' do
+        visit jobs_with_type_organisation_path(:draft)
+
+        expect(page).to have_content('Showing all jobs')
+
+        expect(page).to_not have_content(school_group_vacancy.job_title)
+        expect(page).to_not have_content(school_1_vacancy.job_title)
+        expect(page).to have_content(school_1_draft_vacancy.job_title)
+        expect(page).to have_content(school_2_draft_vacancy.job_title)
+      end
+    end
+  end
+
+  context 'when managed_organisations is school_group' do
+    let(:managed_organisations) { 'school_group' }
+    let(:managed_school_ids) { [] }
+
+    scenario 'it shows filtered published vacancies' do
+      visit organisation_path
+
+      expect(page).to have_content('1 filter applied')
+
+      expect(page).to have_content(school_group_vacancy.job_title)
+      expect(page).to_not have_content(school_1_vacancy.job_title)
+      expect(page).to_not have_content(school_1_draft_vacancy.job_title)
+      expect(page).to_not have_content(school_2_draft_vacancy.job_title)
+    end
+  end
+
+  context 'when managed_school_ids is not empty' do
+    let(:managed_organisations) { '' }
+    let(:managed_school_ids) { [school_1.id, school_2.id] }
+
+    scenario 'it shows filtered published vacancies' do
+      visit organisation_path
+
+      expect(page).to have_content('2 filters applied')
+
+      expect(page).to_not have_content(school_group_vacancy.job_title)
+      expect(page).to have_content(school_1_vacancy.job_title)
+      expect(page).to_not have_content(school_1_draft_vacancy.job_title)
+      expect(page).to_not have_content(school_2_draft_vacancy.job_title)
+    end
+  end
+end

--- a/spec/features/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
+++ b/spec/features/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
@@ -87,9 +87,9 @@ RSpec.feature 'Hiring staff can filter vacancies in their dashboard' do
     end
   end
 
-  context 'when managed_organisations is school_group' do
-    let(:managed_organisations) { 'school_group' }
-    let(:managed_school_ids) { [] }
+  context 'when managed_school_ids contains school_group' do
+    let(:managed_organisations) { '' }
+    let(:managed_school_ids) { ['school_group'] }
 
     scenario 'it shows filtered published vacancies' do
       visit organisation_path

--- a/spec/features/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
+++ b/spec/features/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
@@ -37,13 +37,30 @@ RSpec.feature 'Hiring staff can set managed organisations user preferences' do
     )
 
     check I18n.t('hiring_staff.managed_organisations.options.school_group'),
+          name: 'managed_organisations_form[managed_school_ids][]', visible: false
+    check school_1.name, name: 'managed_organisations_form[managed_school_ids][]', visible: false
+
+    click_on I18n.t('buttons.continue')
+
+    expect(page.current_path).to eql(organisation_path)
+    expect(user_preference.managed_school_ids).to eql(['school_group', school_1.id])
+  end
+
+  scenario 'it allows school group users to select to manage all jobs' do
+    visit organisation_managed_organisations_path
+
+    expect(page).to have_content(
+      I18n.t('hiring_staff.managed_organisations.panel.title', organisation: school_group.name)
+    )
+
+    check I18n.t('hiring_staff.managed_organisations.options.all'),
           name: 'managed_organisations_form[managed_organisations][]', visible: false
     check school_1.name, name: 'managed_organisations_form[managed_school_ids][]', visible: false
 
     click_on I18n.t('buttons.continue')
 
     expect(page.current_path).to eql(organisation_path)
-    expect(user_preference.managed_organisations).to eql('school_group')
-    expect(user_preference.managed_school_ids).to eql([school_1.id])
+    expect(user_preference.managed_organisations).to eql('all')
+    expect(user_preference.managed_school_ids).to eql([])
   end
 end


### PR DESCRIPTION
This PR implements filtering on the hiring staff jobs dashboard page for SchoolGroup users.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-995

## Changes in this PR
- Minor refactor of checkbox and filter components
- Add job location filters to the SchoolGroup user dashboard
- Refactor 'school_group' user preference to 'managed_school_ids' for consistency between forms on the initial 'Set your preferences' page and the dashboard job_location filter

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/25187547/89400247-88536400-d70b-11ea-9b14-ee8ea51a37af.png)

## Next steps
- Integrate JS functionality
- Vertical align filters applied text
