### PR TITLE
Server-side polygon search

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,7 +86,7 @@ Metrics/BlockLength:
     Exclude:
       - 'spec/**/*'
       - 'config/routes.rb'
-      - 'lib/tasks/**'
+      - 'lib/tasks/data.rake'
 
 Layout/EmptyLinesAroundAccessModifier:
     Enabled: false

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -9,7 +9,7 @@ class VacanciesController < ApplicationController
       @vacancies_search.vacancies,
       searched: @vacancies_search.any?,
       total_count: @vacancies_search.vacancies.raw_answer['nbHits'],
-      coordinates: @vacancies_search.coordinates
+      coordinates: @vacancies_search.point_coordinates
     )
     AuditSearchEventJob.perform_later(audit_row) if valid_search?
     expires_in 5.minutes, public: true

--- a/app/services/vacancy_algolia_alert_builder.rb
+++ b/app/services/vacancy_algolia_alert_builder.rb
@@ -16,16 +16,16 @@ class VacancyAlgoliaAlertBuilder < VacancyAlgoliaSearchBuilder
     build_subscription_filters(subscription_hash)
     build_search_filter
     initialize_sort_by(subscription_hash[:jobs_sort])
-    initialize_location(subscription_hash[:location_category], subscription_hash[:location], subscription_hash[:radius])
+    initialize_location(subscription_hash)
     initialize_search
   end
 
   def call
     self.vacancies = Vacancy.search(
-      search_query,
+      keyword,
       aroundLatLng: location_filter[:point_coordinates],
       aroundRadius: location_filter[:radius],
-      insidePolygon: location_polygon,
+      insidePolygon: location_polygon_boundary,
       replica: search_replica,
       hitsPerPage: MAXIMUM_SUBSCRIPTION_RESULTS,
       filters: search_filter,
@@ -33,7 +33,7 @@ class VacancyAlgoliaAlertBuilder < VacancyAlgoliaSearchBuilder
     )
     Rails.logger.info(
       "#{vacancies.count} vacancies found for job alert with criteria: #{subscription_hash}, "\
-      "search_query: #{search_query}, replica: #{search_replica}, location_filter: #{location_filter} "\
+      "search_query: #{keyword}, replica: #{search_replica}, location_filter: #{location_filter} "\
       "and filters: #{search_filter}"
     )
     vacancies

--- a/app/services/vacancy_algolia_alert_builder.rb
+++ b/app/services/vacancy_algolia_alert_builder.rb
@@ -23,8 +23,9 @@ class VacancyAlgoliaAlertBuilder < VacancyAlgoliaSearchBuilder
   def call
     self.vacancies = Vacancy.search(
       search_query,
-      aroundLatLng: location_filter[:coordinates],
+      aroundLatLng: location_filter[:point_coordinates],
       aroundRadius: location_filter[:radius],
+      insidePolygon: location_polygon,
       replica: search_replica,
       hitsPerPage: MAXIMUM_SUBSCRIPTION_RESULTS,
       filters: search_filter,

--- a/app/views/pages/home/_search.html.haml
+++ b/app/views/pages/home/_search.html.haml
@@ -17,7 +17,7 @@
     'aria-autocomplete': 'list',
     'aria-describedby': 'js-location-finder__error',
     'role': 'combobox',
-    'data-coordinates': @vacancies_search&.coordinates
+    'data-coordinates': @vacancies_search&.point_coordinates
 
   = f.govuk_collection_select :radius,
     radius_filter_options,

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -19,7 +19,7 @@
       'aria-autocomplete': 'list',
       'aria-describedby': 'js-location-finder__error',
       'role': 'combobox',
-      'data-coordinates': @vacancies_search&.coordinates
+      'data-coordinates': @vacancies_search&.point_coordinates
 
     .js-location-finder__link.govuk-body-s
       or

--- a/spec/services/vacancy_algolia_alert_builder_spec.rb
+++ b/spec/services/vacancy_algolia_alert_builder_spec.rb
@@ -9,16 +9,18 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
   let(:location) { 'SW1A 1AA' }
   let(:default_radius) { 10 }
   let(:date_today) { Time.zone.today.to_datetime }
-  let(:location_coordinates) { Geocoder::DEFAULT_STUB_COORDINATES }
+  let(:location_point_coordinates) { Geocoder::DEFAULT_STUB_COORDINATES }
   let(:location_radius) { subject.convert_radius_in_miles_to_metres(default_radius) }
+  let(:location_polygon) { nil }
   let(:search_replica) { nil }
   let(:max_subscription_results) { 500 }
 
   let(:algolia_search_query) { search_query }
   let(:algolia_search_args) do
     {
-      aroundLatLng: location_coordinates,
+      aroundLatLng: location_point_coordinates,
       aroundRadius: location_radius,
+      insidePolygon: location_polygon,
       replica: search_replica,
       hitsPerPage: max_subscription_results,
       filters: search_filter,

--- a/spec/services/vacancy_algolia_alert_builder_spec.rb
+++ b/spec/services/vacancy_algolia_alert_builder_spec.rb
@@ -11,16 +11,15 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
   let(:date_today) { Time.zone.today.to_datetime }
   let(:location_point_coordinates) { Geocoder::DEFAULT_STUB_COORDINATES }
   let(:location_radius) { subject.convert_radius_in_miles_to_metres(default_radius) }
-  let(:location_polygon) { nil }
+  let(:location_polygon_boundary) { nil }
   let(:search_replica) { nil }
   let(:max_subscription_results) { 500 }
 
-  let(:algolia_search_query) { search_query }
-  let(:algolia_search_args) do
+  let(:expected_algolia_search_args) do
     {
       aroundLatLng: location_point_coordinates,
       aroundRadius: location_radius,
-      insidePolygon: location_polygon,
+      insidePolygon: location_polygon_boundary,
       replica: search_replica,
       hitsPerPage: max_subscription_results,
       filters: search_filter,
@@ -59,7 +58,7 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
     context '#initialize' do
       context '#keyword' do
         it 'adds subject and job_title to the keyword' do
-          expect(subject.search_query).to eql(search_query)
+          expect(subject.keyword).to eql(search_query)
         end
       end
 
@@ -103,7 +102,7 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
 
       before do
         allow(vacancies).to receive(:count).and_return(10)
-        mock_algolia_search_for_job_alert(vacancies, algolia_search_query, algolia_search_args)
+        mock_algolia_search_for_job_alert(vacancies, search_query, expected_algolia_search_args)
       end
 
       it 'carries out alert search with correct criteria' do
@@ -115,7 +114,6 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
 
   context 'subscription created after algolia' do
     let(:vacancies) { double('vacancies') }
-    let(:search_query) { keyword }
     let(:subscription_hash) do
       {
         location: location,
@@ -135,7 +133,7 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
 
       before do
         allow(vacancies).to receive(:count).and_return(10)
-        mock_algolia_search_for_job_alert(vacancies, algolia_search_query, algolia_search_args)
+        mock_algolia_search_for_job_alert(vacancies, keyword, expected_algolia_search_args)
       end
 
       it 'carries out alert search with correct criteria' do

--- a/spec/services/vacancy_algolia_search_builder_spec.rb
+++ b/spec/services/vacancy_algolia_search_builder_spec.rb
@@ -19,12 +19,14 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
   let(:location) { 'SW1A 1AA' }
   let(:location_category) { 'London' }
   let(:default_radius) { 10 }
+  let(:location_polygon) { nil }
 
   let(:algolia_search_query) { search_query }
   let(:algolia_search_args) do
     {
-      aroundLatLng: location_coordinates,
+      aroundLatLng: location_point_coordinates,
       aroundRadius: location_radius,
+      insidePolygon: location_polygon,
       replica: search_replica,
       hitsPerPage: default_hits_per_page,
       filters: search_filter,
@@ -58,7 +60,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
           it 'carries out geographical search around a coordinate location with the default radius' do
             expect(subject.search_query).not_to include(location)
             expect(subject.location_filter).to eql({
-              coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
+              point_coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
               radius: subject.convert_radius_in_miles_to_metres(default_radius)
             })
           end
@@ -71,7 +73,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
           it 'carries out geographical search around a coordinate location with the specified radius' do
             expect(subject.search_query).not_to include(location)
             expect(subject.location_filter).to eql({
-              coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
+              point_coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
               radius: subject.convert_radius_in_miles_to_metres(radius)
             })
           end
@@ -216,10 +218,11 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
     after { travel_back }
 
     context 'a location category search' do
-      let(:location) { 'London' }
+      let(:location) { 'Bath' }
       let(:search_query) { "#{keyword} #{location}" }
-      let(:location_coordinates) { nil }
+      let(:location_point_coordinates) { nil }
       let(:location_radius) { nil }
+      let(:location_polygon) { [[51.406361958644, -2.3780576677997, 51.4063596372237, -2.3787764623145]] }
 
       it 'carries out search with correct parameters' do
         subject.call
@@ -229,7 +232,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
 
     context 'a geographical radius location search' do
       let(:search_query) { keyword }
-      let(:location_coordinates) { Geocoder::DEFAULT_STUB_COORDINATES }
+      let(:location_point_coordinates) { Geocoder::DEFAULT_STUB_COORDINATES }
       let(:location_radius) { subject.convert_radius_in_miles_to_metres(default_radius) }
 
       it 'carries out search with correct criteria' do

--- a/spec/services/vacancy_algolia_search_builder_spec.rb
+++ b/spec/services/vacancy_algolia_search_builder_spec.rb
@@ -12,53 +12,78 @@ RSpec.shared_examples 'a search in the default search replica' do
   end
 end
 
+RSpec.shared_examples 'a search using polygons' do
+  it 'sets the correct attributes' do
+    expect(subject.location_category).to eql(polygonable_location)
+    expect(subject.location_polygon).to eq(location_polygon)
+    expect(subject.location_filter).to eql({})
+  end
+end
+
 RSpec.describe VacancyAlgoliaSearchBuilder do
   subject { described_class.new(params) }
 
   let(:keyword) { 'maths teacher' }
-  let(:location) { 'SW1A 1AA' }
-  let(:location_category) { 'London' }
+  let(:point_location) { 'SW1A 1AA' }
+  let(:polygonable_location) { 'Bath' }
+  let(:polygon_coordinates) { [51.406361958644, -2.3780576677997, 51.4063596372237, -2.3787764623145] }
   let(:default_radius) { 10 }
-  let(:location_polygon) { nil }
 
-  let(:algolia_search_query) { search_query }
-  let(:algolia_search_args) do
-    {
-      aroundLatLng: location_point_coordinates,
-      aroundRadius: location_radius,
-      insidePolygon: location_polygon,
-      replica: search_replica,
-      hitsPerPage: default_hits_per_page,
-      filters: search_filter,
-      page: page
-    }
+  let!(:location_polygon) do
+    LocationPolygon.create(
+      name: polygonable_location.downcase,
+      location_type: 'cities',
+      boundary: polygon_coordinates)
   end
 
   describe '#initialize' do
-    context '#keyword' do
+    context 'keyword param' do
       let(:params) { { keyword: keyword } }
 
-      it 'adds keyword to the search query' do
-        expect(subject.search_query).to eql(keyword)
+      it 'initializes keyword attribute' do
+        expect(subject.keyword).to eql(keyword)
       end
     end
 
-    context '#location' do
-      context 'location category specified' do
-        let(:params) { { location_category: location_category } }
+    context '#initialize_location' do
+      context 'polygonable location specified' do
+        context 'by location parameter' do
+          let(:params) { { location: polygonable_location } }
 
-        it 'adds location to the search query and not the location filter' do
-          expect(subject.search_query).to eql(location_category)
-          expect(subject.location_filter).to eql({})
+          it_behaves_like 'a search using polygons'
+        end
+
+        context 'by location_category parameter' do
+          let(:params) { { location_category: polygonable_location } }
+
+          it_behaves_like 'a search using polygons'
+        end
+
+        context 'by location_category parameter and location parameter' do
+          let(:params) { { location_category: polygonable_location, location: polygonable_location } }
+
+          it_behaves_like 'a search using polygons'
+        end
+
+        context 'and polygon coordinate lookup fails (for large areas)' do
+          let(:params) { { keyword: keyword, location_category: 'North West' } }
+
+          it 'appends location to keyword' do
+            expect(subject.location_category).to eq 'North West'
+            expect(subject.location_polygon).to be nil
+            expect(subject.location_filter).to eql({})
+            expect(subject.keyword).to eql("#{keyword} North West")
+          end
         end
       end
 
-      context 'location specified' do
-        context 'no radius specified' do
-          let(:params) { { location: location } }
+      context 'non-polygonable location' do
+        context 'and no radius specified' do
+          let(:params) { { location: point_location } }
 
-          it 'carries out geographical search around a coordinate location with the default radius' do
-            expect(subject.search_query).not_to include(location)
+          it 'sets location filter around the location with the default radius' do
+            expect(subject.location_category).to be nil
+            expect(subject.location_polygon).to be nil
             expect(subject.location_filter).to eql({
               point_coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
               radius: subject.convert_radius_in_miles_to_metres(default_radius)
@@ -66,26 +91,18 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
           end
         end
 
-        context 'radius specified' do
+        context 'and radius specified' do
           let(:radius) { 30 }
-          let(:params) { { location: location, radius: radius } }
+          let(:params) { { location: point_location, radius: radius } }
 
           it 'carries out geographical search around a coordinate location with the specified radius' do
-            expect(subject.search_query).not_to include(location)
+            expect(subject.location_category).to be nil
+            expect(subject.location_polygon).to be nil
             expect(subject.location_filter).to eql({
               point_coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
               radius: subject.convert_radius_in_miles_to_metres(radius)
             })
           end
-        end
-      end
-
-      context 'location specified that is also a location category' do
-        let(:params) { { location: location_category } }
-
-        it 'adds the location to the search query' do
-          expect(subject.search_query).to eql(location_category)
-          expect(subject.location_filter).to eql({})
         end
       end
     end
@@ -94,7 +111,7 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
       let(:keyword) { nil }
       let(:jobs_sort) { '' }
       let(:params) do
-        { keyword: keyword, location: location, jobs_sort: jobs_sort }
+        { keyword: keyword, location: point_location, jobs_sort: jobs_sort }
       end
 
       describe 'default sort strategies per scenario when: no sort strategy is specified,' do
@@ -150,6 +167,76 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
     end
   end
 
+  describe '#call' do
+    let!(:expired_now) { Time.zone.now }
+    let(:sort_by) { '' }
+    let(:search_replica) { nil }
+    let(:default_hits_per_page) { 10 }
+    let(:search_filter) do
+      'listing_status:published AND '\
+      "publication_date_timestamp <= #{Time.zone.today.to_datetime.to_i} AND "\
+      "expires_at_timestamp > #{expired_now.to_datetime.to_i}"
+    end
+    let(:page) { 1 }
+
+    let(:params) do
+      {
+        keyword: keyword,
+        location: location,
+        jobs_sort: sort_by,
+        page: page
+      }
+    end
+
+    let(:vacancies) { double('vacancies').as_null_object }
+
+    let(:expected_algolia_search_args) do
+      {
+        aroundLatLng: location_point_coordinates,
+        aroundRadius: location_radius,
+        insidePolygon: location_polygon_boundary,
+        replica: search_replica,
+        hitsPerPage: default_hits_per_page,
+        filters: search_filter,
+        page: page
+      }
+    end
+
+    before do
+      travel_to(expired_now)
+      allow_any_instance_of(VacancyAlgoliaSearchBuilder)
+        .to receive(:expired_now_filter)
+        .and_return(expired_now.to_datetime.to_i)
+      mock_algolia_search(vacancies, keyword, expected_algolia_search_args)
+    end
+
+    after { travel_back }
+
+    context 'a location category search' do
+      let(:location) { polygonable_location }
+      let(:location_point_coordinates) { nil }
+      let(:location_radius) { nil }
+      let(:location_polygon_boundary) { [polygon_coordinates] }
+
+      it 'carries out search with correct parameters' do
+        subject.call
+        expect(subject.vacancies).to eql(vacancies)
+      end
+    end
+
+    context 'a geographical radius location search' do
+      let(:location) { point_location }
+      let(:location_point_coordinates) { Geocoder::DEFAULT_STUB_COORDINATES }
+      let(:location_radius) { subject.convert_radius_in_miles_to_metres(default_radius) }
+      let(:location_polygon_boundary) { nil }
+
+      it 'carries out search with correct criteria' do
+        subject.call
+        expect(subject.vacancies).to eql(vacancies)
+      end
+    end
+  end
+
   describe '#build_stats' do
     let(:params) { {} }
     let(:page) { 0 }
@@ -180,64 +267,6 @@ RSpec.describe VacancyAlgoliaSearchBuilder do
         expect(subject.build_stats(page, pages, results_per_page, total_results)).to eql(
           [51, total_results, total_results]
         )
-      end
-    end
-  end
-
-  describe '#call' do
-    let!(:expired_now) { Time.zone.now }
-    let(:sort_by) { '' }
-    let(:search_replica) { nil }
-    let(:default_hits_per_page) { 10 }
-    let(:search_filter) do
-      'listing_status:published AND '\
-      "publication_date_timestamp <= #{Time.zone.today.to_datetime.to_i} AND "\
-      "expires_at_timestamp > #{expired_now.to_datetime.to_i}"
-    end
-    let(:page) { 1 }
-
-    let(:params) do
-      {
-        keyword: keyword,
-        location: location,
-        jobs_sort: sort_by,
-        page: page
-      }
-    end
-
-    let(:vacancies) { double('vacancies').as_null_object }
-
-    before do
-      travel_to(expired_now)
-      allow_any_instance_of(VacancyAlgoliaSearchBuilder)
-        .to receive(:expired_now_filter)
-        .and_return(expired_now.to_datetime.to_i)
-      mock_algolia_search(vacancies, algolia_search_query, algolia_search_args)
-    end
-
-    after { travel_back }
-
-    context 'a location category search' do
-      let(:location) { 'Bath' }
-      let(:search_query) { "#{keyword} #{location}" }
-      let(:location_point_coordinates) { nil }
-      let(:location_radius) { nil }
-      let(:location_polygon) { [[51.406361958644, -2.3780576677997, 51.4063596372237, -2.3787764623145]] }
-
-      it 'carries out search with correct parameters' do
-        subject.call
-        expect(subject.vacancies).to eql(vacancies)
-      end
-    end
-
-    context 'a geographical radius location search' do
-      let(:search_query) { keyword }
-      let(:location_point_coordinates) { Geocoder::DEFAULT_STUB_COORDINATES }
-      let(:location_radius) { subject.convert_radius_in_miles_to_metres(default_radius) }
-
-      it 'carries out search with correct criteria' do
-        subject.call
-        expect(subject.vacancies).to eql(vacancies)
       end
     end
   end

--- a/spec/support/search_helper.rb
+++ b/spec/support/search_helper.rb
@@ -16,6 +16,7 @@ module SearchHelper
     {
       aroundLatLng: algolia_hash[:aroundLatLng] || nil,
       aroundRadius: algolia_hash[:aroundRadius] || nil,
+      insidePolygon: algolia_hash[:insidePolygon] || nil,
       replica: algolia_hash[:replica] || nil,
       hitsPerPage: algolia_hash[:hitsPerPage] || 10,
       filters: algolia_hash[:filters] ||


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-950

## Changes in this PR:

- Use LocationPolygons to construct Algolia search query for location categories.
- Rename coordinates to point coordinates within search builder, to distinguish it from polygon coordinates.
- Move import polygons task to lib/
- To test locally, you should import LocationPolygons with:

```ruby
require 'import_polygons'
ImportPolygons.new(location_type: :regions).call; ImportPolygons.new(location_type: :counties).call; ImportPolygons.new(location_type: :cities).call; ImportPolygons.new(location_type: :london_boroughs).call
...
checking_all_location_types = [LocationPolygon.regions.size, LocationPolygon.counties.size, LocationPolygon.cities.size, LocationPolygon.london_boroughs.size]
=> [9, 68, 106, 33]
```

I have not yet checked if it's definitely having the desired effect on front end - that Algolia is using the polygons appropriately, and we are no longer getting the results a text search would give. I can see that the API requests are coming through with the correct parameters.

<img width="678" alt="Screenshot 2020-08-04 at 16 53 34" src="https://user-images.githubusercontent.com/60350599/89389874-e6794a80-d6fd-11ea-8321-7a6c1abbb6a2.png">



## Next steps:

- [ ] Product signs off the search results on pre-production site.
