### PR TITLE
Teva 1061 terraform postgres

### DIFF
--- a/terraform/app/modules/cloudwatch/cloudwatch.tf
+++ b/terraform/app/modules/cloudwatch/cloudwatch.tf
@@ -60,7 +60,7 @@ resource aws_iam_role_policy slack_lambda_policy {
 }
 
 resource aws_lambda_function cloudwatch_to_slack {
-  filename      = "terraform/lambda/lambda_cloudwatch_to_slack_opsgenie_payload.zip"
+  filename      = "${path.module}/../../lambda/lambda_cloudwatch_to_slack_opsgenie_payload.zip"
   function_name = "${var.project_name}-${var.environment}-cloudwatch_to_slack_opsgenie"
   role          = aws_iam_role.slack_lambda_role.arn
   handler       = "lambda_function.lambda_handler"

--- a/terraform/app/modules/paas/data.tf
+++ b/terraform/app/modules/paas/data.tf
@@ -1,0 +1,20 @@
+data cloudfoundry_org org {
+  name = "dfe-teacher-services"
+}
+
+data cloudfoundry_space space {
+  name = var.space_name
+  org  = data.cloudfoundry_org.org.id
+}
+
+data cloudfoundry_domain cloudapps_digital {
+  name = "london.cloudapps.digital"
+}
+
+data cloudfoundry_service postgres {
+  name = "postgres"
+}
+
+data cloudfoundry_service redis {
+  name = "redis"
+}

--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -1,0 +1,6 @@
+resource cloudfoundry_service_instance postgres_instance{
+  name = local.postgres_service_name
+  space = data.cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.postgres.service_plans["tiny-unencrypted-11"]
+  json_params = "{\"enable_extensions\": [\"pgcrypto\", \"fuzzystrmatch\", \"plpgsql\"]}"
+}

--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -1,6 +1,6 @@
-resource cloudfoundry_service_instance postgres_instance{
-  name = local.postgres_service_name
-  space = data.cloudfoundry_space.space.id
-  service_plan = data.cloudfoundry_service.postgres.service_plans["tiny-unencrypted-11"]
-  json_params = "{\"enable_extensions\": [\"pgcrypto\", \"fuzzystrmatch\", \"plpgsql\"]}"
+resource cloudfoundry_service_instance postgres_instance {
+  name         = local.postgres_service_name
+  space        = data.cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.postgres.service_plans["${var.postgres_service_plan}"]
+  json_params  = "{\"enable_extensions\": [\"pgcrypto\", \"fuzzystrmatch\", \"plpgsql\"]}"
 }

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -1,12 +1,15 @@
 variable environment {
 }
 
+variable postgres_service_plan {
+}
+
 variable project_name {
 }
 
-variable space_name{
+variable space_name {
 }
 
 locals {
-    postgres_service_name = "${var.project_name}-postgres-${var.environment}"
+  postgres_service_name = "${var.project_name}-postgres-${var.environment}"
 }

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -1,0 +1,12 @@
+variable environment {
+}
+
+variable project_name {
+}
+
+variable space_name{
+}
+
+locals {
+    postgres_service_name = "${var.project_name}-postgres-${var.environment}"
+}

--- a/terraform/app/modules/paas/versions.tf
+++ b/terraform/app/modules/paas/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    cloudfoundry = "~> 0.12"
+  }  
+}

--- a/terraform/app/modules/paas/versions.tf
+++ b/terraform/app/modules/paas/versions.tf
@@ -3,5 +3,5 @@ terraform {
 
   required_providers {
     cloudfoundry = "~> 0.12"
-  }  
+  }
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -13,12 +13,12 @@ For SSO authentication
 */
 
 provider cloudfoundry {
-  api_url             = var.paas_api_url
-  password            = var.paas_password != "" ? var.paas_password : null
-  sso_passcode        = var.paas_sso_passcode != "" ? var.paas_sso_passcode : null
-  store_tokens_path   = "./tokens"
-  user                = var.paas_user != "" ? var.paas_user : null
-  version             = "~> 0.12"
+  api_url           = var.paas_api_url
+  password          = var.paas_password != "" ? var.paas_password : null
+  sso_passcode      = var.paas_sso_passcode != "" ? var.paas_sso_passcode : null
+  store_tokens_path = "./tokens"
+  user              = var.paas_user != "" ? var.paas_user : null
+  version           = "~> 0.12"
 }
 
 provider statuscake {
@@ -72,9 +72,10 @@ module cloudwatch {
 module paas {
   source = "./modules/paas"
 
-  environment  = terraform.workspace
-  project_name = var.project_name
-  space_name   = var.paas_space_name
+  environment           = terraform.workspace
+  project_name          = var.project_name
+  postgres_service_plan = var.paas_postgres_service_plan
+  space_name            = var.paas_space_name
 
 }
 

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -3,14 +3,32 @@ provider aws {
   version = "~> 2.70.0"
 }
 
-provider template {
-  version = "~> 2.1.2"
+/*
+For username / password authentication:
+- user
+- password
+For SSO authentication
+- sso_passcode
+- store_tokens_path = /path/to/local/file
+*/
+
+provider cloudfoundry {
+  api_url             = var.paas_api_url
+  password            = var.paas_password != "" ? var.paas_password : null
+  sso_passcode        = var.paas_sso_passcode != "" ? var.paas_sso_passcode : null
+  store_tokens_path   = "./tokens"
+  user                = var.paas_user != "" ? var.paas_user : null
+  version             = "~> 0.12"
 }
 
 provider statuscake {
   username = var.statuscake_username
   apikey   = var.statuscake_apikey
   version  = "~> 1.0.0"
+}
+
+provider template {
+  version = "~> 2.1.2"
 }
 
 /*
@@ -28,16 +46,6 @@ terraform {
   }
 }
 
-module cloudwatch {
-  source = "./modules/cloudwatch"
-
-  environment       = terraform.workspace
-  project_name      = var.project_name
-  slack_hook_url    = var.cloudwatch_slack_hook_url
-  slack_channel     = var.cloudwatch_slack_channel
-  ops_genie_api_key = var.cloudwatch_ops_genie_api_key
-}
-
 module cloudfront {
   source = "./modules/cloudfront"
 
@@ -51,6 +59,25 @@ module cloudfront {
   domain                        = var.domain
 }
 
+module cloudwatch {
+  source = "./modules/cloudwatch"
+
+  environment       = terraform.workspace
+  project_name      = var.project_name
+  slack_hook_url    = var.cloudwatch_slack_hook_url
+  slack_channel     = var.cloudwatch_slack_channel
+  ops_genie_api_key = var.cloudwatch_ops_genie_api_key
+}
+
+module paas {
+  source = "./modules/paas"
+
+  environment  = terraform.workspace
+  project_name = var.project_name
+  space_name   = var.paas_space_name
+
+}
+
 module statuscake {
   source = "./modules/statuscake"
 
@@ -58,4 +85,3 @@ module statuscake {
   project_name      = var.project_name
   statuscake_alerts = var.statuscake_alerts
 }
-

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -50,6 +50,10 @@ variable paas_password {
   default = ""
 }
 
+variable paas_postgres_service_plan {
+  default = "tiny-unencrypted-11"
+}
+
 variable paas_space_name {
 }
 

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -42,6 +42,29 @@ variable cloudwatch_ops_genie_api_key {
   description = "The ops genie api key for sending alerts to ops genie"
 }
 
+# Gov.UK PaaS
+variable paas_api_url {
+}
+
+variable paas_password {
+  default = ""
+}
+
+variable paas_space_name {
+}
+
+variable paas_sso_passcode {
+  default = ""
+}
+
+variable paas_store_tokens_path {
+  default = ""
+}
+
+variable paas_user {
+  default = ""
+}
+
 # Statuscake
 variable statuscake_username {
   description = "The Statuscake username"

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -99,6 +99,7 @@ paas_space_name = "teaching-vacancies-staging"
 paas_user = ""
 paas_password = ""
 paas_sso_passcode = ""
+paas_postgres_service_plan = "small-11"
 
 # Statuscake
 

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -93,6 +93,13 @@ algolia_app_id = ''
 algolia_write_api_key = ''
 algolia_search_api_key = ''
 
+# Gov.UK PaaS
+paas_api_url = ""
+paas_space_name = "teaching-vacancies-staging"
+paas_user = ""
+paas_password = ""
+paas_sso_passcode = ""
+
 # Statuscake
 
 statuscake_username = ''


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1061

## Changes in this PR:

- Moved existing Terraform code for Postgres instance to a `paas` module
- Moved size of Postgres instance to a variable to support different environments
- Make path to Lambda zip for CloudWatch consistent with CloudWatch policy paths

## Next steps:

- [ ] Get service GUID of Postgres service from CF CLI by passing `--guid` flag
- [ ] Terraform import Postgres service into state file
- [ ] Grant the `SpaceDeveloper` role for the user running Terraform
- [ ] Generate a OTP passcode, and update `paas_sso_passcode` in environment .tfvars file
- [ ] Terraform apply
- [ ] Remove the `SpaceDeveloper` role for the user running Terraform
- [ ] Commit .tfvars file changes to secrets repository
