### PR TITLE
Match crawled vacancies to school groups and filter by scope

### DIFF
--- a/bigquery/scraped-vacancies-in-scope.sql
+++ b/bigquery/scraped-vacancies-in-scope.sql
@@ -1,0 +1,24 @@
+  # Filters the scraped_vacancies view into the scraped_vacancies_in_scope view by excluding vacancies from out of scope schools or where we don't know which school posted the vacancy
+SELECT
+  scraped_vacancies.*
+FROM
+  `teacher-vacancy-service.production_dataset.scraped_vacancies` AS scraped_vacancies
+LEFT JOIN
+  `teacher-vacancy-service.production_dataset.feb20_school` AS school
+ON
+  scraped_vacancies.school_id=school.id
+LEFT JOIN
+  `teacher-vacancy-service.production_dataset.feb20_detailedschooltype` AS detailed_school_type
+ON
+  detailed_school_type.id=school.detailed_school_type_id
+WHERE
+  scraped
+  AND NOT expired_before_scrape
+  AND (CAST(detailed_school_type.code AS NUMERIC) IN ( #exclude schools recorded in our database which have an out of scope establishment type
+    SELECT
+      code
+    FROM
+      `teacher-vacancy-service.production_dataset.STATIC_establishment_types_in_scope`)
+    OR detailed_school_type.code IS NULL)
+  AND vacancy_category IN ("teacher","leadership") #i.e. not null or teaching_assistant
+  AND (school_id IS NOT NULL OR school_group_id IS NOT NULL)


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1067

## Changes in this PR:

- Match crawled vacancies to school groups advertising them (e.g. MATs) where possible
- Adds new table of crawled vacancies which only includes vacancies that (a) have been crawled (b) are being advertised by an in scope school type or by a MAT (i.e. not an agency) (c) are for a teaching or leadership role in a school and (d) have been matched successfully to a school or MAT