### PR TITLE
Move Redis service to TF module with var for plan size

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -4,3 +4,9 @@ resource cloudfoundry_service_instance postgres_instance {
   service_plan = data.cloudfoundry_service.postgres.service_plans["${var.postgres_service_plan}"]
   json_params  = "{\"enable_extensions\": [\"pgcrypto\", \"fuzzystrmatch\", \"plpgsql\"]}"
 }
+
+resource cloudfoundry_service_instance redis_instance {
+  name         = local.redis_service_name
+  space        = data.cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.redis.service_plans["${var.redis_service_plan}"]
+}

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -7,9 +7,13 @@ variable postgres_service_plan {
 variable project_name {
 }
 
+variable redis_service_plan {
+}
+
 variable space_name {
 }
 
 locals {
   postgres_service_name = "${var.project_name}-postgres-${var.environment}"
+  redis_service_name    = "${var.project_name}-redis-${var.environment}"
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -75,8 +75,8 @@ module paas {
   environment           = terraform.workspace
   project_name          = var.project_name
   postgres_service_plan = var.paas_postgres_service_plan
+  redis_service_plan    = var.paas_redis_service_plan
   space_name            = var.paas_space_name
-
 }
 
 module statuscake {

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -54,6 +54,10 @@ variable paas_postgres_service_plan {
   default = "tiny-unencrypted-11"
 }
 
+variable paas_redis_service_plan {
+  default = "tiny-4_x"
+}
+
 variable paas_space_name {
 }
 

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -100,6 +100,7 @@ paas_user = ""
 paas_password = ""
 paas_sso_passcode = ""
 paas_postgres_service_plan = "small-11"
+paas_redis_service_plan = "tiny-4_x
 
 # Statuscake
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1137

## Changes in this PR:

- Moved existing Terraform code for Redis instance to a `paas` module
- Moved size of Redis instance to a variable to support different environments

## Next steps:

- [x] Get service GUID of Redis service from CF CLI by passing `--guid` flag
- [x] Terraform import Redis service into state file
- [x] Grant the `SpaceDeveloper` role for the user running Terraform
- [x] Generate a OTP passcode, and update `paas_sso_passcode` in environment .tfvars file
- [x] Terraform apply
- [ ] Remove the `SpaceDeveloper` role for the user running Terraform
- [x] Commit .tfvars file changes to secrets repository
