### PR TITLE
Refactor search inputs into partials and remove aria-describedby

### DIFF
--- a/app/views/pages/home/_search.html.haml
+++ b/app/views/pages/home/_search.html.haml
@@ -2,33 +2,9 @@
 
 = form_for @jobs_search_form, as: 'jobs_search_form', url: jobs_path(anchor: 'vacancy-results'), html: { method: 'get' } do |f|
 
-  = f.govuk_text_field :keyword,
-    label: { text: t('jobs.filters.keyword'), size: 's' },
-    placeholder: t('jobs.filters.keyword_hint')
-
-  = f.govuk_text_field :location,
-    label: { text: t('jobs.filters.location'), size: 's' },
-    placeholder: t('jobs.filters.location_hint'),
-    class: 'govuk-input js-location-finder__input',
-    form_group_classes: 'js-location-finder location-search',
-    'autocomplete': 'off',
-    'aria-expanded': 'false',
-    'aria-owns': 'location_listbox',
-    'aria-autocomplete': 'list',
-    'aria-describedby': 'js-location-finder__error',
-    'role': 'combobox',
-    'data-coordinates': @vacancies_search&.point_coordinates
-
-  = f.govuk_collection_select :radius,
-    radius_filter_options,
-    :last,
-    :first,
-    label: { text: t('jobs.filters.within_radius'), size: 's' },
-    html_options: { class: 'govuk-!-width-full' },
-    form_group_classes: 'location-radius-select location-radius-select-inline-block'
-
-  .js-location-finder__link.govuk-body-s
-    or
-    = link_to t('jobs.filters.use_current_location'), '#', id: 'current-location', class: 'govuk-link govuk-link--no-visited-state'
+  = render 'shared/search/keyword', f: f
+  = render 'shared/search/location', f: f
+  = render 'shared/search/radius', f: f, filters: false
+  = render 'shared/search/current_location'
 
   = f.govuk_submit t('buttons.search'), classes: "govuk-button govuk-button--start govuk-!-margin-0"

--- a/app/views/shared/search/_current_location.html.haml
+++ b/app/views/shared/search/_current_location.html.haml
@@ -1,0 +1,3 @@
+.js-location-finder__link.govuk-body-s
+  or
+  = link_to t('jobs.filters.use_current_location'), '#', id: 'current-location', class: 'govuk-link govuk-link--no-visited-state'

--- a/app/views/shared/search/_keyword.html.haml
+++ b/app/views/shared/search/_keyword.html.haml
@@ -1,0 +1,3 @@
+= f.govuk_text_field :keyword,
+  label: { text: t('jobs.filters.keyword'), size: 's' },
+  placeholder: t('jobs.filters.keyword_hint')

--- a/app/views/shared/search/_location.html.haml
+++ b/app/views/shared/search/_location.html.haml
@@ -1,0 +1,11 @@
+= f.govuk_text_field :location,
+  label: { text: t('jobs.filters.location'), size: 's' },
+  placeholder: t('jobs.filters.location_hint'),
+  class: 'govuk-input js-location-finder__input',
+  form_group_classes: 'js-location-finder location-search',
+  'autocomplete': 'off',
+  'aria-expanded': 'false',
+  'aria-owns': 'location_listbox',
+  'aria-autocomplete': 'list',
+  'role': 'combobox',
+  'data-coordinates': @vacancies_search&.point_coordinates

--- a/app/views/shared/search/_radius.html.haml
+++ b/app/views/shared/search/_radius.html.haml
@@ -1,0 +1,7 @@
+= f.govuk_collection_select :radius,
+  radius_filter_options,
+  :last,
+  :first,
+  label: { text: t('jobs.filters.within_radius'), size: 's' },
+  html_options: { class: 'govuk-!-width-full' },
+  form_group_classes: "#{filters ? 'govuk-inset-text' : ''} location-radius-select location-radius-select-block"

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -3,36 +3,10 @@
 
   = form_for @jobs_search_form, as: 'jobs_search_form', url: jobs_path(anchor: 'vacancy-results'), method: :get, html: { class: 'filters-form', role: 'search', aria: { label: 'Search criteria' } } do |f|
 
-    = f.govuk_text_field :keyword,
-      label: { text: t('jobs.filters.keyword'), size: 's' },
-      placeholder: t('jobs.filters.keyword_hint'),
-      value: @vacancies_search.keyword
+    = render 'shared/search/keyword', f: f
+    = render 'shared/search/location', f: f
+    = render 'shared/search/current_location'
+    = render 'shared/search/radius', f: f, filters: true
 
-    = f.govuk_text_field :location,
-      label: { text: t('jobs.filters.location'), size: 's' },
-      placeholder: t('jobs.filters.location_hint'),
-      class: 'govuk-input js-location-finder__input',
-      form_group_classes: 'js-location-finder location-search',
-      'autocomplete': 'off',
-      'aria-expanded': 'false',
-      'aria-owns': 'location_listbox',
-      'aria-autocomplete': 'list',
-      'aria-describedby': 'js-location-finder__error',
-      'role': 'combobox',
-      'data-coordinates': @vacancies_search&.point_coordinates
-
-    .js-location-finder__link.govuk-body-s
-      or
-      = link_to t('jobs.filters.use_current_location'), '#', id: 'current-location', class: 'govuk-link govuk-link--no-visited-state'
-
-    = f.govuk_collection_select :radius,
-      radius_filter_options,
-      :last,
-      :first,
-      label: { text: t('jobs.filters.within_radius'), size: 's' },
-      html_options: { class: 'govuk-!-width-full' },
-      form_group_classes: 'govuk-inset-text location-radius-select location-radius-select-block'
-
-    = f.hidden_field :jobs_sort, value: @vacancies_search.sort_by
-
+    = f.hidden_field :jobs_sort, value: @vacancies_search&.sort_by
     = f.govuk_submit t('buttons.search'), classes: 'govuk-button mb0 govuk-!-width-full'


### PR DESCRIPTION
This PR addresses TEVA-1141 in the sense that the automated accessibility score will be higher, but I don't think that means it is necessarily a good thing to do.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1141

## Changes in this PR
- Refactor search form inputs into shared partials
- Remove aria-describedby attribute because the error element is added by JS and not present in the template
