### PR TITLE
Move Papertrail user-defined instances under TF

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -10,3 +10,9 @@ resource cloudfoundry_service_instance redis_instance {
   space        = data.cloudfoundry_space.space.id
   service_plan = data.cloudfoundry_service.redis.service_plans["${var.redis_service_plan}"]
 }
+
+resource cloudfoundry_user_provided_service papertrail {
+  name             = local.papertrail_service_name
+  space            = data.cloudfoundry_space.space.id
+  syslog_drain_url = var.papertrail_url
+}

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -1,6 +1,9 @@
 variable environment {
 }
 
+variable papertrail_url {
+}
+
 variable postgres_service_plan {
 }
 
@@ -14,6 +17,7 @@ variable space_name {
 }
 
 locals {
-  postgres_service_name = "${var.project_name}-postgres-${var.environment}"
-  redis_service_name    = "${var.project_name}-redis-${var.environment}"
+  papertrail_service_name = "${var.project_name}-papertrail-${var.environment}"
+  postgres_service_name   = "${var.project_name}-postgres-${var.environment}"
+  redis_service_name      = "${var.project_name}-redis-${var.environment}"
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -74,6 +74,7 @@ module paas {
 
   environment           = terraform.workspace
   project_name          = var.project_name
+  papertrail_url        = var.papertrail_url
   postgres_service_plan = var.paas_postgres_service_plan
   redis_service_plan    = var.paas_redis_service_plan
   space_name            = var.paas_space_name

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -73,6 +73,9 @@ variable paas_user {
   default = ""
 }
 
+variable papertrail_url {
+}
+
 # Statuscake
 variable statuscake_username {
   description = "The Statuscake username"

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -101,6 +101,7 @@ paas_password = ""
 paas_sso_passcode = ""
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan = "tiny-4_x
+papertrail_url = ""
 
 # Statuscake
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1146

## Changes in this PR:

- Move user-defined service connecting to Papertrail under Terraform management

## Next steps:

- [ ] Get service GUID of Papertrail service from CF CLI by passing `--guid` flag
- [ ] Terraform import Papertrail service into state file
- [ ] Grant the "SpaceDeveloper" role for the user running Terraform
- [ ] Generate a OTP passcode, and update `paas_sso_passcode` in environment .tfvars file
- [ ] Terraform apply
- [ ] Remove the "SpaceDeveloper" role for the user running Terraform
- [ ] Commit .tfvars file changes to secrets repository
