### PR TITLE
Resurrect old nqt field

### DIFF
--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -52,10 +52,17 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
 
   def form_params
     strip_empty_checkboxes(:job_specification_form, [:working_patterns, :job_roles, :subjects])
+    append_suitable_for_nqts_to_job_roles
     params.require(:job_specification_form)
-          .permit(:state, :job_title,
+          .permit(:state, :job_title, :suitable_for_nqt,
                   job_roles: [], working_patterns: [], subjects: [])
           .merge(completed_step: current_step)
+  end
+
+  def append_suitable_for_nqts_to_job_roles
+    if params[:job_specification_form][:suitable_for_nqt] == 'yes'
+      params[:job_specification_form][:job_roles] |= [I18n.t('jobs.job_role_options.nqt_suitable')]
+    end
   end
 
   def remove_subject_fields(vacancy)

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -2,7 +2,7 @@ module VacanciesHelper
   WORD_EXCEPTIONS = ['and', 'the', 'of', 'upon'].freeze
 
   def job_role_options
-    Vacancy::JOB_ROLE_OPTIONS
+    Vacancy::JOB_ROLE_OPTIONS.reject { |job_role| job_role == I18n.t('jobs.job_role_options.nqt_suitable') }
   end
 
   def working_pattern_options

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -7,6 +7,8 @@ module VacancyJobSpecificationValidations
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
     validate :job_title_has_no_tags?, if: :job_title?
 
+    validates :suitable_for_nqt, inclusion: { in: %w[yes no] }
+
     validates :working_patterns, presence: true
   end
 

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -19,6 +19,11 @@
     %dd.app-check-your-answers__answer= @vacancy.show_job_roles.presence || t('jobs.not_defined')
 
   .app-check-your-answers__contents
+    %dt.app-check-your-answers__question#suitable_for_nqt
+      %h4.govuk-heading-s= t('jobs.suitable_for_nqt')
+    %dd.app-check-your-answers__answer= @vacancy.suitable_for_nqt&.capitalize
+
+  .app-check-your-answers__contents
     %dt.app-check-your-answers__question#subjects
       %h4.govuk-heading-s= t('jobs.subjects')
     %dd.app-check-your-answers__answer= @vacancy.show_subjects.presence || t('jobs.not_defined')

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_specification.html.haml
@@ -1,5 +1,5 @@
 = render 'hiring_staff/vacancies/section_tag', section: 'job_details'
-= render 'hiring_staff/vacancies/error_tag', attributes: [:job_title, :job_roles, :subjects, :working_patterns], section: 'job_details'
+= render 'hiring_staff/vacancies/error_tag', attributes: [:job_title, :job_roles, :suitable_for_nqt, :subjects, :working_patterns], section: 'job_details'
 
 %h2.govuk-heading-m.app-task-list__section#job_details_heading
   %span.app-task-list__section-number= edit_vacancy_section_number(:job_details, current_organisation)

--- a/app/views/hiring_staff/vacancies/job_specification/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/show.html.haml
@@ -34,13 +34,19 @@
         legend: { text: t('helpers.fieldset.job_specification_form.job_roles') },
         hint_text: t('helpers.hint.job_specification_form.job_roles')
 
+      = f.govuk_collection_radio_buttons :suitable_for_nqt,
+        %w[yes no],
+        :to_s,
+        :capitalize,
+        legend: { text: t('helpers.fieldset.job_specification_form.suitable_for_nqt_html') }
+
       = f.govuk_fieldset legend: { text: t('helpers.fieldset.job_specification_form.subjects') } do
 
         %label{ for: 'job-specification-form-subject-search' }
           %span.govuk-visually-hidden
             Subject filter
         %span.govuk-hint#job-specification-form-subjects-hint
-          =t('helpers.hint.job_specification_form.subjects_hint')
+          =t('helpers.hint.job_specification_form.subjects')
 
         %div{ class: 'govuk-!-margin-bottom-6' }
           = render 'shared/checkbox_group', search: true, f: f, attribute_name: :subjects, options: subject_options, value_method: :first, text_method: :first, hint_method: :last, small: true

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -14,6 +14,8 @@ en:
       invalid_characters: Job title must not contain any HTML tags
     job_roles:
       blank: Select a job role
+    suitable_for_nqt:
+      inclusion: Please indicate whether or not the job is suitable for NQTs
     working_patterns:
       blank: Select a working pattern
   pay_package_errors: &pay_package_errors

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,6 +330,7 @@ en:
     job_details: 'Job details'
     job_title: 'Job title'
     job_roles: 'Job role'
+    suitable_for_nqt: Is this job suitable for NQTs?
     job_role_options:
       teacher: 'Teacher'
       leadership: 'Leadership'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,6 +156,7 @@ en:
       job_specification_form:
         job_title_html: "Job title (<span class='text-red'>Required</span>)"
         job_roles: Job role
+        suitable_for_nqt_html: "Is this job suitable for NQTs? (<span class='text-red'>Required</span>)"
         subjects: Subject(s)
         working_pattern_html: "Working patterns (<span class='text-red'>Required</span>)"
       pay_package_form:
@@ -193,7 +194,7 @@ en:
           For secondary school roles include subject and, if relevant,
           level of seniority ('Subject leader for science', for example).
         job_roles: 'Select all that describe the role'
-        subjects_hint: What subject(s) will the teacher focus on?
+        subjects: What subject(s) will the teacher focus on?
         working_patterns: >-
           Select all working patterns you will consider for the role.
           Flexible working options may attract more candidates.

--- a/db/migrate/20200810112320_add_suitable_for_nqt_to_vacancies.rb
+++ b/db/migrate/20200810112320_add_suitable_for_nqt_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddSuitableForNqtToVacancies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :vacancies, :suitable_for_nqt, :string
+  end
+end

--- a/db/migrate/20200810112728_convert_nqt_job_role_to_suitable_for_nqt_on_vacancies.rb
+++ b/db/migrate/20200810112728_convert_nqt_job_role_to_suitable_for_nqt_on_vacancies.rb
@@ -1,0 +1,5 @@
+class ConvertNqtJobRoleToSuitableForNqtOnVacancies < ActiveRecord::Migration[5.2]
+  def change
+    Vacancy.where("'Suitable for NQTs' = ANY (job_roles)").update_all(suitable_for_nqt: 'yes')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_04_075056) do
+ActiveRecord::Schema.define(version: 2020_08_10_112728) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -276,6 +276,7 @@ ActiveRecord::Schema.define(version: 2020_08_04_075056) do
     t.uuid "school_group_id"
     t.string "job_location"
     t.string "readable_job_location"
+    t.string "suitable_for_nqt"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["expiry_time"], name: "index_vacancies_on_expiry_time"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"

--- a/lib/job_posting.rb
+++ b/lib/job_posting.rb
@@ -26,6 +26,9 @@ class JobPosting
       expires_on: expires_on_or_future,
       job_summary: @schema['description'],
       about_school: @schema['hiringOrganization']['description'],
+      suitable_for_nqt: @schema['occupationalCategory']
+        .split(', ')
+        .include?(I18n.t('jobs.job_role_options.nqt_suitable')) ? 'yes' : 'no',
       school: school_by_urn_or_random
     }
   end

--- a/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
+++ b/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
@@ -52,4 +52,32 @@ RSpec.describe HiringStaff::Vacancies::JobSpecificationController, type: :contro
       end
     end
   end
+
+  describe '#append_suitable_for_nqts_to_job_roles' do
+    let(:params) do
+      { job_specification_form: { suitable_for_nqt: suitable_for_nqt, job_roles: [] } }
+    end
+
+    before do
+      allow(controller).to receive(:params).and_return(params)
+    end
+
+    context 'when suitable for nqts is yes' do
+      let(:suitable_for_nqt) { 'yes' }
+
+      it 'appends Suitable for NQTs to job roles' do
+        subject.send(:append_suitable_for_nqts_to_job_roles)
+        expect(controller.params[:job_specification_form][:job_roles]).to eql(['Suitable for NQTs'])
+      end
+    end
+
+    context 'when suitable for nqts is no' do
+      let(:suitable_for_nqt) { 'no' }
+
+      it 'does not append Suitable for NQTs to job roles' do
+        subject.send(:append_suitable_for_nqts_to_job_roles)
+        expect(controller.params[:job_specification_form][:job_roles]).to be_blank
+      end
+    end
+  end
 end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
     status { :published }
     subjects { SUBJECT_OPTIONS.sample(2).map(&:first).sort! }
     supporting_documents { 'yes' }
+    suitable_for_nqt { 'no' }
     working_patterns { ['full_time'] }
 
     trait :with_school_group do

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
     context 'when the vacancy is now invalid' do
       before do
         vacancy.about_school = nil
+        vacancy.suitable_for_nqt = nil
         vacancy.save(validate: false)
       end
 
@@ -42,6 +43,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
           expect(page).to have_content(I18n.t('messages.jobs.action_required.heading'))
           expect(page).to have_content(I18n.t('messages.jobs.action_required.message'))
           expect(page).to have_content(I18n.t('job_summary_errors.about_school.blank'))
+          expect(page).to have_content(I18n.t('job_specification_errors.suitable_for_nqt.inclusion'))
         end
       end
     end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'Creating a vacancy' do
   end
 
   context 'creating a new vacancy' do
+    let(:suitable_for_nqt) { 'no' }
     let(:vacancy) do
       VacancyPresenter.new(build(:vacancy, :complete,
                                  job_roles: [
@@ -31,6 +32,7 @@ RSpec.feature 'Creating a vacancy' do
                                    I18n.t('jobs.job_role_options.sen_specialist')
                                   ],
                                  school: school,
+                                 suitable_for_nqt: suitable_for_nqt,
                                  working_patterns: ['full_time', 'part_time'],
                                  publish_on: Time.zone.today))
     end
@@ -71,6 +73,19 @@ RSpec.feature 'Creating a vacancy' do
         expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 7))
         within('h2.govuk-heading-l') do
           expect(page).to have_content(I18n.t('jobs.pay_package'))
+        end
+      end
+
+      context 'when job is selected as suitable for NQTs' do
+        let(:suitable_for_nqt) { 'yes' }
+
+        scenario 'Suitable for NQTs is appended to the job roles' do
+          visit new_organisation_job_path
+
+          fill_in_job_specification_form_fields(vacancy)
+          click_on I18n.t('buttons.continue')
+
+          expect(Vacancy.last.job_roles).to include(I18n.t('jobs.job_role_options.nqt_suitable'))
         end
       end
 

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -4,6 +4,16 @@ RSpec.describe JobSpecificationForm, type: :model do
   subject { JobSpecificationForm.new({}) }
 
   context 'validations' do
+    describe '#suitable_for_nqt' do
+      let(:job_specification) { JobSpecificationForm.new(suitable_for_nqt: nil) }
+
+      it 'requests an entry in the field' do
+        expect(job_specification.valid?).to be false
+        expect(job_specification.errors.messages[:suitable_for_nqt][0])
+          .to eq('Please indicate whether or not the job is suitable for NQTs')
+      end
+    end
+
     describe '#working_patterns' do
       let(:job_specification) { JobSpecificationForm.new(working_patterns: nil) }
 
@@ -76,12 +86,14 @@ RSpec.describe JobSpecificationForm, type: :model do
     it 'a JobSpecificationForm can be converted to a vacancy' do
       job_specification_form = JobSpecificationForm.new(state: 'create', job_title: 'English Teacher',
                                                         job_roles: [I18n.t('jobs.job_role_options.teacher')],
+                                                        suitable_for_nqt: 'no',
                                                         working_patterns: ['full_time'],
                                                         subjects: ['Maths'])
 
       expect(job_specification_form.valid?).to be true
       expect(job_specification_form.vacancy.job_title).to eq('English Teacher')
       expect(job_specification_form.vacancy.job_roles).to include(I18n.t('jobs.job_role_options.teacher'))
+      expect(job_specification_form.vacancy.suitable_for_nqt).to eq('no')
       expect(job_specification_form.vacancy.working_patterns).to eq(['full_time'])
       expect(job_specification_form.vacancy.subjects).to include('Maths')
     end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -24,6 +24,8 @@ module VacancyHelpers
             visible: false
     end
 
+    find("label[for='job-specification-form-suitable-for-nqt-#{vacancy.suitable_for_nqt}-field']").click
+
     vacancy.subjects&.each do |subject|
       check subject,
             name: 'job_specification_form[subjects][]',


### PR DESCRIPTION
This PR adds an extra question to the Job details page.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1045

## Changes in this PR
- Add suitable for nqt column
- Add question to job details page
- Append `'Suitable for NQTs'` to `job_roles` if `suitable_for_nqt` is `true` (this is nasty but unavoidable in order to retain consistency between the data model and what jobseekers see/search/filter on)
