### PR TITLE
Location category fix

### DIFF
--- a/app/form_models/vacancy_algolia_search_form.rb
+++ b/app/form_models/vacancy_algolia_search_form.rb
@@ -5,7 +5,7 @@ class VacancyAlgoliaSearchForm
 
   def initialize(params = {})
     @keyword = params[:keyword]
-    @location = params[:location]
+    @location = params[:location] || params[:location_category]
     @radius = params[:radius] || 10
     @jobs_sort = params[:jobs_sort]
     @location_category = params[:location_category]


### PR DESCRIPTION
When navigating from a location category link (teaching-jobs-in-huddersfield) for example, there is no location parameter, only a location_category parameter. 

In this instance, location should be set to the value of the location category parameter so that the form is populated with the location correctly.