### PR TITLE
Refactor job role options to enum

### DIFF
--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -61,7 +61,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
 
   def append_suitable_for_nqts_to_job_roles
     if params[:job_specification_form][:suitable_for_nqt] == 'yes'
-      params[:job_specification_form][:job_roles] |= [I18n.t('jobs.job_role_options.nqt_suitable')]
+      params[:job_specification_form][:job_roles] |= [:nqt_suitable]
     end
   end
 

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -2,7 +2,7 @@ module VacanciesHelper
   WORD_EXCEPTIONS = ['and', 'the', 'of', 'upon'].freeze
 
   def job_role_options
-    Vacancy::JOB_ROLE_OPTIONS.reject { |job_role| job_role == I18n.t('jobs.job_role_options.nqt_suitable') }
+    Vacancy::JOB_ROLE_OPTIONS.except(:nqt_suitable).map { |key, _value| [I18n.t("jobs.job_role_options.#{key}"), key] }
   end
 
   def working_pattern_options

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -1,12 +1,12 @@
 require 'auditor'
 
 class Vacancy < ApplicationRecord
-  JOB_ROLE_OPTIONS = [
-    I18n.t('jobs.job_role_options.teacher'),
-    I18n.t('jobs.job_role_options.leadership'),
-    I18n.t('jobs.job_role_options.sen_specialist'),
-    I18n.t('jobs.job_role_options.nqt_suitable'),
-  ].freeze
+  JOB_ROLE_OPTIONS = {
+    teacher: 0,
+    leadership: 1,
+    sen_specialist: 2,
+    nqt_suitable: 3
+  }.freeze
 
   FLEXIBLE_WORKING_PATTERN_OPTIONS = {
     'part_time' => 100,
@@ -197,6 +197,7 @@ class Vacancy < ApplicationRecord
   friendly_id :slug_candidates, use: %w[slugged history]
 
   enum status: { published: 0, draft: 1, trashed: 2 }
+  array_enum job_roles: JOB_ROLE_OPTIONS
   array_enum working_patterns: WORKING_PATTERN_OPTIONS
   enum listed_elsewhere: {
     listed_paid: 0,
@@ -332,7 +333,7 @@ class Vacancy < ApplicationRecord
   end
 
   def attributes
-    super().merge('working_patterns' => working_patterns)
+    super().merge('working_patterns' => working_patterns, 'job_roles' => job_roles)
   end
 
   def skip_update_callbacks(value = true)

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -102,7 +102,7 @@ class VacancyPresenter < BasePresenter
   end
 
   def show_job_roles
-    model.job_roles&.join(', ')
+    model.job_roles&.map { |job_role| I18n.t("jobs.job_role_options.#{job_role}") }.join(', ')
   end
 
   def show_subjects

--- a/app/views/hiring_staff/vacancies/job_specification/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/show.html.haml
@@ -29,8 +29,8 @@
 
       = f.govuk_collection_check_boxes :job_roles,
         job_role_options,
-        :itself,
-        :itself,
+        :last,
+        :first,
         legend: { text: t('helpers.fieldset.job_specification_form.job_roles') },
         hint_text: t('helpers.hint.job_specification_form.job_roles')
 

--- a/db/migrate/20200811135547_rename_job_roles_legacy_job_roles_on_vacancies.rb
+++ b/db/migrate/20200811135547_rename_job_roles_legacy_job_roles_on_vacancies.rb
@@ -1,0 +1,5 @@
+class RenameJobRolesLegacyJobRolesOnVacancies < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :vacancies, :job_roles, :legacy_job_roles
+  end
+end

--- a/db/migrate/20200811135623_add_job_roles_to_vacancies.rb
+++ b/db/migrate/20200811135623_add_job_roles_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddJobRolesToVacancies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :vacancies, :job_roles, :integer, array: true
+  end
+end

--- a/db/migrate/20200811135723_convert_legacy_job_roles_to_job_roles_on_vacancies.rb
+++ b/db/migrate/20200811135723_convert_legacy_job_roles_to_job_roles_on_vacancies.rb
@@ -1,0 +1,18 @@
+class ConvertLegacyJobRolesToJobRolesOnVacancies < ActiveRecord::Migration[5.2]
+  def change
+    Vacancy.where.not(legacy_job_roles: nil).in_batches(of: 100).each_record do |vacancy|
+      job_roles = vacancy.legacy_job_roles.map do |job_role|
+        if job_role == I18n.t('jobs.job_role_options.teacher')
+          0
+        elsif job_role == I18n.t('jobs.job_role_options.leadership')
+          1
+        elsif job_role == I18n.t('jobs.job_role_options.sen_specialist')
+          2
+        elsif job_role == I18n.t('jobs.job_role_options.nqt_suitable')
+          3
+        end
+      end
+      vacancy.update_columns(job_roles: job_roles)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_10_112728) do
+ActiveRecord::Schema.define(version: 2020_08_11_135836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -264,7 +264,7 @@ ActiveRecord::Schema.define(version: 2020_08_10_112728) do
     t.uuid "publisher_user_id"
     t.datetime "expiry_time"
     t.string "supporting_documents"
-    t.string "job_roles", array: true
+    t.string "legacy_job_roles", array: true
     t.string "salary"
     t.integer "completed_step"
     t.text "about_school"
@@ -277,6 +277,7 @@ ActiveRecord::Schema.define(version: 2020_08_10_112728) do
     t.string "job_location"
     t.string "readable_job_location"
     t.string "suitable_for_nqt"
+    t.integer "job_roles", array: true
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["expiry_time"], name: "index_vacancies_on_expiry_time"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"

--- a/lib/job_posting.rb
+++ b/lib/job_posting.rb
@@ -9,10 +9,11 @@ class JobPosting
 
   private
 
+  # rubocop:disable Metrics/AbcSize
   def map_schema_to_vacancy_fields
     {
       job_title: @schema['title'],
-      job_roles: @schema['occupationalCategory'].split(', '),
+      job_roles: @schema['occupationalCategory'].split(', ').map { |x| x.downcase.to_sym },
       salary: @schema['salary'],
       benefits: @schema['jobBenefits'],
       education: @schema['educationRequirements'],
@@ -32,6 +33,7 @@ class JobPosting
       school: school_by_urn_or_random
     }
   end
+  # rubocop:enable Metrics/AbcSize
 
   def school_by_urn_or_random
     School.find_by(urn: @schema['hiringOrganization']['identifier']) || random_school

--- a/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
+++ b/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe HiringStaff::Vacancies::JobSpecificationController, type: :contro
 
       it 'appends Suitable for NQTs to job roles' do
         subject.send(:append_suitable_for_nqts_to_job_roles)
-        expect(controller.params[:job_specification_form][:job_roles]).to eql(['Suitable for NQTs'])
+        expect(controller.params[:job_specification_form][:job_roles]).to eql([:nqt_suitable])
       end
     end
 

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     hired_status { nil }
     how_to_apply { Faker::Lorem.paragraph(sentence_count: 4) }
     job_summary { Faker::Lorem.paragraph(sentence_count: 4) }
-    job_roles { ['Teacher'] }
+    job_roles { [:teacher] }
     job_title { Faker::Lorem.sentence[1...30].strip }
     listed_elsewhere { nil }
     publish_on { Time.zone.today }

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -20,10 +20,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   context 'when editing a published vacancy' do
     let(:vacancy) do
       VacancyPresenter.new(create(:vacancy, :complete,
-                                  job_roles: [
-                                    I18n.t('jobs.job_role_options.teacher'),
-                                    I18n.t('jobs.job_role_options.sen_specialist')
-                                   ],
+                                  job_roles: [:teacher, :sen_specialist],
                                   school: school,
                                   working_patterns: ['full_time', 'part_time'],
                                   publish_on: Time.zone.today, expires_on: Time.zone.tomorrow))

--- a/spec/features/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
@@ -27,10 +27,7 @@ RSpec.feature 'Creating a vacancy' do
     let(:suitable_for_nqt) { 'no' }
     let(:vacancy) do
       VacancyPresenter.new(build(:vacancy, :complete,
-                                 job_roles: [
-                                   I18n.t('jobs.job_role_options.teacher'),
-                                   I18n.t('jobs.job_role_options.sen_specialist')
-                                  ],
+                                 job_roles: [:teacher, :sen_specialist],
                                  school: school,
                                  suitable_for_nqt: suitable_for_nqt,
                                  working_patterns: ['full_time', 'part_time'],
@@ -85,7 +82,7 @@ RSpec.feature 'Creating a vacancy' do
           fill_in_job_specification_form_fields(vacancy)
           click_on I18n.t('buttons.continue')
 
-          expect(Vacancy.last.job_roles).to include(I18n.t('jobs.job_role_options.nqt_suitable'))
+          expect(Vacancy.last.job_roles).to include('nqt_suitable')
         end
       end
 

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -85,14 +85,14 @@ RSpec.describe JobSpecificationForm, type: :model do
   context 'when all attributes are valid' do
     it 'a JobSpecificationForm can be converted to a vacancy' do
       job_specification_form = JobSpecificationForm.new(state: 'create', job_title: 'English Teacher',
-                                                        job_roles: [I18n.t('jobs.job_role_options.teacher')],
+                                                        job_roles: [:teacher],
                                                         suitable_for_nqt: 'no',
                                                         working_patterns: ['full_time'],
                                                         subjects: ['Maths'])
 
       expect(job_specification_form.valid?).to be true
       expect(job_specification_form.vacancy.job_title).to eq('English Teacher')
-      expect(job_specification_form.vacancy.job_roles).to include(I18n.t('jobs.job_role_options.teacher'))
+      expect(job_specification_form.vacancy.job_roles).to eq(['teacher'])
       expect(job_specification_form.vacancy.suitable_for_nqt).to eq('no')
       expect(job_specification_form.vacancy.working_patterns).to eq(['full_time'])
       expect(job_specification_form.vacancy.subjects).to include('Maths')

--- a/spec/lib/job_posting_spec.rb
+++ b/spec/lib/job_posting_spec.rb
@@ -5,10 +5,7 @@ RSpec.describe JobPosting do
     {
       '@type' => 'JobPosting',
       'title' => 'Teacher of English',
-      'occupationalCategory' => [
-        I18n.t('jobs.job_role_options.nqt_suitable'),
-        I18n.t('jobs.job_role_options.sen_specialist')
-      ],
+      'occupationalCategory' => 'TEACHER, SEN_SPECIALIST',
       'salary' => 'Pay scale 1 to Pay scale 2',
       'jobBenefits' => '<p>This is an exceptional opportunity to make a difference within a positive environment.</p>',
       'datePosted' => date_posted,

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -19,7 +19,7 @@ module VacancyHelpers
     end
 
     vacancy.job_roles&.each do |job_role|
-      check job_role,
+      check I18n.t("jobs.job_role_options.#{job_role}"),
             name: 'job_specification_form[job_roles][]',
             visible: false
     end


### PR DESCRIPTION
What it says on the proverbial tin...

## Why this, why now
This is being done in the interests of consistency (see working_patterns). It will also help us avoid nasty issues if we change how the data is presented at a later date. 

It will also help us filter hiring staff jobs in their dashboard easily and more performantly if we need to:
```ruby
Vacancy.with_job_roles(:nqt_suitable)
```

## Next steps
Next on the menu is the job_location field, which should undergo a similar operation before we start implementing `multiple_schools` as an option

