### PR TITLE
align UI style more closely to figma designs

### DIFF
--- a/app/components/hiring_staff/no_vacancies_component.html.haml
+++ b/app/components/hiring_staff/no_vacancies_component.html.haml
@@ -3,6 +3,8 @@
     .govuk-grid-column-full
       %h2.govuk-heading-m= t('schools.no_jobs.heading')
 
+      = link_to t('buttons.create_job'), new_organisation_job_path, class: 'govuk-button govuk-!-margin-bottom-0'
+
       %p= t('schools.no_jobs.intro')
 
     .govuk-grid-column-one-third

--- a/app/components/hiring_staff/vacancies_component.html.haml
+++ b/app/components/hiring_staff/vacancies_component.html.haml
@@ -1,12 +1,19 @@
-- if @organisation.is_a?(SchoolGroup)
-  .govuk-grid-column-one-quarter
-    = form_for @filters_form, url: organisation_managed_organisations_path, html: { method: "patch" } do |f|
-      = render 'shared/filter_group', f: f,
-        filters: { title: 'Filter results', removeButtons: true, totalCount: @filters[:managed_school_ids]&.count, items: [{ title: 'Locations', key: 'locations', search: true, attribute: :managed_school_ids, selected: @filters[:managed_school_ids], options: @school_options, value_method: :id, text_method: :name, small: true }] }
+.moj-filter-sidebar
+  - if @organisation.is_a?(SchoolGroup)
+    .govuk-grid-column-one-quarter
+      = form_for @filters_form, url: organisation_managed_organisations_path, html: { method: "patch" } do |f|
+        = render 'shared/filter_group', f: f,
+          filters: { title: 'Job Filters', removeButtons: true, totalCount: @filters[:managed_school_ids]&.count, items: [{ title: 'Locations', key: 'locations', search: true, attribute: :managed_school_ids, selected: @filters[:managed_school_ids], options: @school_options, value_method: :id, text_method: :name, small: true }] }
 
-      = f.hidden_field :jobs_type, value: @selected_type
+        = f.hidden_field :jobs_type, value: @selected_type
 
-%div{ class: grid_column_class }
+.moj-filter-layout__content{ class: grid_column_class }
+  .dashboard-header{ class: "govuk-!-margin-bottom-5" }
+    - if @organisation.is_a?(SchoolGroup)
+      .filters-information.moj-action-bar
+        %button.govuk-button.govuk-button--secondary{ class: "govuk-!-margin-bottom-0 moj-action-bar__filter", id: "toggle-filters-sidebar" }= t('buttons.hide_filters')
+        %span.govuk-body{ class: "govuk-!-margin-left-3 filters-applied-text" }= filters_applied_text
+    = link_to t("buttons.create_job"), new_organisation_job_path, class: "govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-0"
   .overflow-scroll
     .govuk-tabs
       %h2.govuk-tabs__title= t("aria_labels.content")

--- a/app/frontend/src/lib/ui/components/filterGroup.js
+++ b/app/frontend/src/lib/ui/components/filterGroup.js
@@ -1,4 +1,5 @@
 import '../../polyfill/closest.polyfill';
+import 'classlist-polyfill';
 
 export const CHECKBOX_CLASS_SELECTOR = 'govuk-checkboxes__input';
 
@@ -16,6 +17,21 @@ export const init = (groupContainerSelector, removeButtonSelector, clearButtonSe
 
   if (document.getElementById(closeButtonSelector)) {
     document.getElementById(closeButtonSelector).addEventListener('click', closeAllSectionsHandler);
+  }
+
+  const toggleButton = document.getElementById('toggle-filters-sidebar');
+
+  if (toggleButton) {
+    toggleButton.addEventListener('click', () => {
+      document.getElementsByClassName('moj-filter-sidebar')[0].classList.toggle('moj-filter-sidebar__hidden');
+      document.getElementsByClassName('moj-filter-layout__content')[0].classList.toggle('govuk-grid-column-three-quarters');
+
+      if (document.getElementsByClassName('moj-filter-sidebar')[0].classList.contains('moj-filter-sidebar__hidden')) {
+        toggleButton.innerHTML = 'Show filters';
+      } else {
+        toggleButton.innerHTML = 'Hide filters';
+      }
+    });
   }
 };
 

--- a/app/frontend/src/lib/ui/components/filterGroup.scss
+++ b/app/frontend/src/lib/ui/components/filterGroup.scss
@@ -1,18 +1,41 @@
-.moj-filter {
+.filter-group__container {
+  border-bottom: 1px solid #b1b4b6;
+}
 
+.js-enabled .filters-submit {
+  display: none;
+}
+
+.moj-filter-sidebar {
+  &.moj-filter-sidebar__hidden {
+    display: none;
+  }
+}
+
+.moj-filter {
   box-shadow: none;
 
-  .moj-filter__header {
+  .moj-filter__selected .govuk-link {
+    border: none;
     background: none;
-    border: 1px solid govuk-colour("white");
-    padding: 0;
-    border-bottom: 2px solid govuk-colour("light-grey");
-    margin-bottom: govuk-spacing(2);
+    color: $govuk-link-colour;
     font-size: 1rem;
+    text-decoration: underline;
+    padding: 0;
   }
 
-  .moj-filter__heading-action .govuk-link {
-    font-size: 1rem;
+  .moj-filter__header {
+
+    padding: 8px govuk-spacing(2);
+
+    &.search-filters {
+      background: none;
+      border: 1px solid govuk-colour("white");
+      padding: 0;
+      border-bottom: 2px solid #b1b4b6;
+      margin-bottom: govuk-spacing(2);
+      font-size: 1rem;
+    }
   }
 
   .moj-filter__content {

--- a/app/frontend/styles/components/accordion_group.scss
+++ b/app/frontend/styles/components/accordion_group.scss
@@ -20,7 +20,7 @@
   padding: govuk-spacing(2);
 
   .govuk-form-group {
-    max-height: 214px;
+    max-height: 194px;
     overflow: scroll;
     margin-bottom: govuk-spacing(1);
   }
@@ -41,9 +41,8 @@
   border-bottom: 3px solid govuk-colour("light-grey");
 }
 
-.govuk-accordion__section-content {
-  padding: 0;
-
+.js-enabled .govuk-accordion__section-content {
+  padding: 0 0 govuk-spacing(2) 0;
 }
 
 .govuk-accordion__controls {
@@ -62,7 +61,7 @@
 }
 
 .govuk-accordion__section-button {
-  font-size: 1rem;
+  font-size: 1.2rem;
   padding: 0 0 govuk-spacing(1) 0;
 }
 

--- a/app/frontend/styles/components/hiring-staff.scss
+++ b/app/frontend/styles/components/hiring-staff.scss
@@ -25,10 +25,14 @@ body.hiring-staff {
     float: right;
     margin-bottom: 0;
   }
-}
 
-.filters-information {
-  display: inline-block;
+  .filters-information {
+    display: inline-block;
+
+    .filters-applied-text {
+      line-height: 2em;
+    }
+  }
 }
 
 .button-link {

--- a/app/views/hiring_staff/organisations/show.html.haml
+++ b/app/views/hiring_staff/organisations/show.html.haml
@@ -11,9 +11,6 @@
         = link_to t('sign_in.organisation.change'), auth_dfe_callback_path, class: 'govuk-link'
 
   .govuk-grid-column-full
-    .dashboard-header.govuk-grid-row
-      = link_to t("buttons.create_job"), new_organisation_job_path, class: "govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-0"
-
     .govuk-grid-row{ class: "govuk-!-margin-top-6" }
       = render(HiringStaff::VacanciesComponent.new(organisation: @organisation, sort: @sort, selected_type: @selected_type, filters: @filters, filters_form: @managed_organisations_form))
       = render(HiringStaff::NoVacanciesComponent.new(organisation: @organisation))

--- a/app/views/shared/_filter_group.html.haml
+++ b/app/views/shared/_filter_group.html.haml
@@ -2,9 +2,10 @@
 -#
 -# = render 'shared/filter_group', f: <FormBuilder form>,
 -#   filters: {
--#     :title => <String>,
--#     :removeButtons => <Boolean>,
--#     :totalCount => <Integer>,
+-#     title: <String>,
+-#     removeButtons: <Boolean>,
+-#     totalCount: <Integer>,
+-#     closeAll: <Boolean>,
 -#     :items => [
 -#       { :options => <Array>, :title => <String>, :search => <Boolean>, :key => <String> }
 -#     ]
@@ -17,8 +18,9 @@
         %span.moj-filter__heading-title
           %h2.govuk-heading-s
             = filters[:title]
-        %a.govuk-link.govuk-link--no-visited-state{ href: '', id: 'close-all-groups' }
-          = t('shared.filter_group.close_all_filter_groups')
+        - if filters[:closeAll]
+          %button.govuk-link.govuk-link--no-visited-state{ id: 'close-all-groups' }
+            = t('shared.filter_group.close_all_filter_groups')
 
     - if filters[:totalCount] > 0 && filters[:removeButtons]
       .moj-filter__content
@@ -26,7 +28,7 @@
           .selected-filters__heading{ class: 'govuk-!-margin-bottom-2' }
             .govuk-body{ class: 'govuk-!-margin-bottom-0' }
               = t('shared.filter_group.current_selected_filters')
-            %a.govuk-link.govuk-link--no-visited-state{ href: '', id: 'clear-filters-button' }
+            %button.govuk-link.govuk-link--no-visited-state{ id: 'clear-filters-button' }
               = t('shared.filter_group.clear_all_filters')
 
           - filters[:items].each do |group|
@@ -38,14 +40,14 @@
                 - if group[:selected].include? tag.id
                   %li
                     %button.moj-filter__tag{ data: { group: group[:key], key: tag.id } }
+                      %i.fa.fa-close
                       %span.govuk-visually-hidden
                         = t('shared.filter_group.remove_filter_hidden')
                       = tag.name
-                      %i.fa.fa-close
 
-= f.govuk_submit t('buttons.apply_filters'), classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-2"
+= f.govuk_submit t('buttons.apply_filters'), classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-2 filters-submit"
 
-.accordion-group.govuk-accordion{ id: 'accordion-default', data: { module: "govuk-accordion"} }
+.accordion-group.govuk-accordion{ id: 'accordion-default', data: { module: "govuk-accordion" } }
 
   - filters[:items].each_with_index do |group, index|
     .govuk-accordion__section.accordion-content__group.filter-group__container

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@ministryofjustice/frontend": "^0.0.19-alpha",
     "@rails/webpacker": "4.2.2",
     "axios": "^0.19.2",
+    "classlist-polyfill": "^1.2.0",
     "clipboard": "^2.0.4",
     "govuk-frontend": "3.4.0",
     "jquery": "^3.5.0",

--- a/spec/features/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
+++ b/spec/features/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
@@ -49,6 +49,7 @@ RSpec.feature 'Hiring staff can filter vacancies in their dashboard' do
         visit jobs_with_type_organisation_path(:published)
 
         expect(page).to_not have_css('.moj-filter__tag')
+        expect(page).to have_content('Showing all jobs')
 
         expect(page).to have_content(school_group_vacancy.job_title)
         expect(page).to have_content(school_1_vacancy.job_title)
@@ -63,7 +64,8 @@ RSpec.feature 'Hiring staff can filter vacancies in their dashboard' do
           check 'Happy Rainbows School (1)', name: 'managed_organisations_form[managed_school_ids][]', visible: false
           click_on I18n.t('buttons.apply_filters')
 
-          expect(page).to have_css('.moj-filter__tag'), count: 1
+          expect(page).to have_css('.moj-filter__tag', count: 1)
+          expect(page).to have_content('1 filter applied')
 
           expect(page).to_not have_content(school_group_vacancy.job_title)
           expect(page).to have_content(school_1_vacancy.job_title)
@@ -78,6 +80,7 @@ RSpec.feature 'Hiring staff can filter vacancies in their dashboard' do
         visit jobs_with_type_organisation_path(:draft)
 
         expect(page).to_not have_css('.moj-filter__tag')
+        expect(page).to have_content('Showing all jobs')
 
         expect(page).to_not have_content(school_group_vacancy.job_title)
         expect(page).to_not have_content(school_1_vacancy.job_title)
@@ -94,7 +97,8 @@ RSpec.feature 'Hiring staff can filter vacancies in their dashboard' do
     scenario 'it shows filtered published vacancies' do
       visit organisation_path
 
-      expect(page).to have_css('.moj-filter__tag'), count: 1
+      expect(page).to have_css('.moj-filter__tag', count: 1)
+      expect(page).to have_content('1 filter applied')
 
       expect(page).to have_content(school_group_vacancy.job_title)
       expect(page).to_not have_content(school_1_vacancy.job_title)
@@ -110,7 +114,8 @@ RSpec.feature 'Hiring staff can filter vacancies in their dashboard' do
     scenario 'it shows filtered published vacancies' do
       visit organisation_path
 
-      expect(page).to have_css('.moj-filter__tag'), count: 2
+      expect(page).to have_css('.moj-filter__tag', count: 2)
+      expect(page).to have_content('2 filters applied')
 
       expect(page).to_not have_content(school_group_vacancy.job_title)
       expect(page).to have_content(school_1_vacancy.job_title)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2591,6 +2591,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classlist-polyfill@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz#935bc2dfd9458a876b279617514638bcaa964a2e"
+  integrity sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4=
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"


### PR DESCRIPTION
this updates task to include resolutions to a few misunderstandings about figma designs
including the UI to hide/show the filter sidebar with was removed in subsequent PR. the search filters styling is left in component for use when this arises

https://dfedigital.atlassian.net/browse/TEVA-1123

![Screenshot 2020-08-12 at 08 40 05](https://user-images.githubusercontent.com/1792451/89988444-76c40c00-dc77-11ea-80ed-e56e08ed9527.png)
![Screenshot 2020-08-12 at 08 39 54](https://user-images.githubusercontent.com/1792451/89988461-7cb9ed00-dc77-11ea-92f2-d440afc7d65e.png)

