### PR TITLE
Fix nqt job alerts

### DIFF
--- a/app/services/vacancy_algolia_alert_builder.rb
+++ b/app/services/vacancy_algolia_alert_builder.rb
@@ -49,7 +49,7 @@ class VacancyAlgoliaAlertBuilder < VacancyAlgoliaSearchBuilder
       |working_pattern| "working_patterns:#{working_pattern}"
     }&.join(' OR ')
 
-    job_roles = "job_roles:'#{I18n.t('jobs.job_role_options.nqt_suitable')}'" if
+    job_roles = "job_roles:'#{I18n.t('jobs.job_role_options.nqt_suitable')}' OR job_roles:nqt_suitable" if
       subscription_hash[:newly_qualified_teacher] == 'true'
 
     phases = subscription_hash[:phases]&.map {

--- a/spec/services/vacancy_algolia_alert_builder_spec.rb
+++ b/spec/services/vacancy_algolia_alert_builder_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
 
         it 'adds NQT filter' do
           expect(subject.filter_array).to include(
-            "(job_roles:'#{I18n.t('jobs.job_role_options.nqt_suitable')}')"
+            "(job_roles:'#{I18n.t('jobs.job_role_options.nqt_suitable')}' OR job_roles:nqt_suitable)"
           )
         end
 
@@ -96,7 +96,7 @@ RSpec.describe VacancyAlgoliaAlertBuilder do
         "publication_date_timestamp <= #{date_today.to_i} AND expires_at_timestamp > #{expired_now.to_datetime.to_i})"\
         " AND (publication_date_timestamp >= #{date_today.to_i} AND publication_date_timestamp <="\
         " #{date_today.to_i}) AND (working_patterns:full_time OR working_patterns:part_time) AND "\
-        "(job_roles:'#{I18n.t('jobs.job_role_options.nqt_suitable')}') AND "\
+        "(job_roles:'#{I18n.t('jobs.job_role_options.nqt_suitable')}' OR job_roles:nqt_suitable) AND "\
         '(school.phase:secondary OR school.phase:primary)'
       end
 


### PR DESCRIPTION
Refactoring job_roles from an array of strings to an array_enum means the job alerts builder needed to be updated (otherwise newly indexed vacancies that should match would not be returned)