### PR TITLE
Show age range in search snippet for vacancies at single schools

### DIFF
--- a/app/components/jobseekers/school_overview_component.html.haml
+++ b/app/components/jobseekers/school_overview_component.html.haml
@@ -7,7 +7,7 @@
         %td.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
           = t('schools.type')
         %td.govuk-table__cell
-          = organisation_type(@vacancy.school)
+          = organisation_type(organisation: @vacancy.school, with_age_range: false)
       %tr.govuk-table__row
         %td.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
           = t('schools.phase')

--- a/app/components/jobseekers/vacancy_summary_component.html.haml
+++ b/app/components/jobseekers/vacancy_summary_component.html.haml
@@ -10,7 +10,7 @@
     - else
       %dt= t('jobs.trust_type')
     %dd.double
-      = organisation_type(@vacancy.school_or_school_group)
+      = organisation_type(organisation: @vacancy.school_or_school_group, with_age_range: true)
     - if @vacancy.working_patterns?
       %dt= t('jobs.working_patterns')
       %dd.double

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -11,15 +11,9 @@ module OrganisationHelper
 
   def organisation_type(organisation: organisation, with_age_range: false)
     return organisation.group_type unless organisation.is_a?(School)
-    school_type = school_type_and_religious_character(organisation)
-    school_type.push age_range_or_nil(organisation) if with_age_range
-    school_type.reject(&:blank?).join(', ')
-  end
-
-  def school_type_and_religious_character(school)
-    school_type = [school.school_type.label.singularize]
-    school_type.push school.gias_data['ReligiousCharacter (name)'] if school.has_religious_character?
-    school_type
+    school_type_details = [organisation.school_type.label.singularize, organisation.religious_character]
+    school_type_details.push age_range(organisation) if with_age_range
+    school_type_details.reject(&:blank?).reject { |str| str == I18n.t('schools.not_given') }.join(', ')
   end
 
   def organisation_type_basic(organisation)
@@ -41,11 +35,8 @@ module OrganisationHelper
   end
 
   def age_range(school)
-    age_range_or_nil(school) || I18n.t('schools.not_given')
-  end
-
-  def age_range_or_nil(school)
-    "#{school.minimum_age} to #{school.maximum_age}" if school.minimum_age? && school.maximum_age?
+    return I18n.t('schools.not_given') unless school.minimum_age? && school.maximum_age?
+    "#{school.minimum_age} to #{school.maximum_age}"
   end
 
   def edit_vacancy_section_number(section, organisation)

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -38,9 +38,10 @@ class School < ApplicationRecord
     set_geolocation_from_easting_and_northing
   end
 
-  def has_religious_character?
-    return false if !self.respond_to?(:gias_data) || self.gias_data == nil
-    ['None', 'Does not apply', nil].exclude?(self.gias_data['ReligiousCharacter (name)'])
+  def religious_character
+    return if !self.respond_to?(:gias_data) || self.gias_data == nil
+    return if ['None', 'Does not apply'].include?(self.gias_data['ReligiousCharacter (name)'])
+    self.gias_data['ReligiousCharacter (name)']
   end
 
   private

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -146,7 +146,7 @@ class Vacancy < ApplicationRecord
         detailed_school_type: school.detailed_school_type&.label,
         local_authority: school.local_authority,
         phase: school.phase,
-        religious_character: school.gias_data['ReligiousCharacter (name)'],
+        religious_character: school.religious_character,
         region: school.region&.name,
         school_type: school.school_type&.label&.singularize,
         town: school.town } if school.present?

--- a/spec/components/jobseekers/school_group_overview_component_spec.rb
+++ b/spec/components/jobseekers/school_group_overview_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Jobseekers::SchoolGroupOverviewComponent, type: :component do
   end
 
   it 'renders the trust type' do
-    expect(rendered_component).to include(organisation_type(vacancy.school_group))
+    expect(rendered_component).to include(organisation_type(organisation: vacancy.school_group))
   end
 
   it 'renders the trust email' do

--- a/spec/components/jobseekers/school_overview_component_spec.rb
+++ b/spec/components/jobseekers/school_overview_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Jobseekers::SchoolOverviewComponent, type: :component do
   end
 
   it 'renders the school type' do
-    expect(rendered_component).to include(organisation_type(vacancy.school))
+    expect(rendered_component).to include(organisation_type(organisation: vacancy.school))
   end
 
   it 'renders the education phase' do

--- a/spec/components/jobseekers/school_overview_component_spec.rb
+++ b/spec/components/jobseekers/school_overview_component_spec.rb
@@ -27,9 +27,18 @@ RSpec.describe Jobseekers::SchoolOverviewComponent, type: :component do
     end
   end
 
-  it 'renders the school type' do
-    expect(rendered_component).to include(organisation_type(organisation: vacancy.school))
+  context 'rendering the school type' do
+    it 'renders the school type' do
+      expect(rendered_component).to include(organisation_type(organisation: vacancy.school,
+        with_age_range: false))
+    end
+
+    it 'does not render the age range as part of the school type' do
+      expect(rendered_component).not_to include(organisation_type(organisation: vacancy.school,
+        with_age_range: true))
+    end
   end
+
 
   it 'renders the education phase' do
     expect(rendered_component).to include(vacancy.school.phase.titleize)

--- a/spec/components/jobseekers/vacancy_summary_component_spec.rb
+++ b/spec/components/jobseekers/vacancy_summary_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
     end
 
     it 'renders the school type' do
-      expect(rendered_component).to include(organisation_type(vacancy.school))
+      expect(rendered_component).to include(organisation_type(organisation: vacancy.school, with_age_range: true))
     end
 
     it 'renders the working pattern' do
@@ -71,7 +71,7 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
     end
 
     it 'renders the trust type' do
-      expect(rendered_component).to include(organisation_type(vacancy.school_group))
+      expect(rendered_component).to include(organisation_type(organisation: vacancy.school_group))
     end
 
     it 'renders the working pattern' do

--- a/spec/components/jobseekers/vacancy_summary_component_spec.rb
+++ b/spec/components/jobseekers/vacancy_summary_component_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
-  context 'when vacancy organisation is a school' do
+  let(:vacancy_presenter) { VacancyPresenter.new(vacancy) }
+
+  before { render_inline(described_class.new(vacancy: vacancy_presenter)) }
+
+  context 'when vacancy is at a school that is not in a trust' do
     let(:school) { create(:school) }
     let(:vacancy) { create(:vacancy, school: school) }
-    let(:vacancy_presenter) { VacancyPresenter.new(vacancy) }
-
-    before { render_inline(described_class.new(vacancy: vacancy_presenter)) }
 
     it 'renders the title' do
       expect(rendered_component).to include(vacancy_presenter.job_title)
@@ -47,20 +48,17 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
     end
   end
 
-  context 'when vacancy organisation is a school_group' do
-    let(:school_group) { create(:school_group) }
-    let(:vacancy) { create(:vacancy, school_group: school_group, school: nil) }
-    let(:vacancy_presenter) { VacancyPresenter.new(vacancy) }
+  context 'when vacancy is at a single school in a trust' do
+    let(:vacancy) { create(:vacancy, :with_school_group_at_school) }
 
-    before { render_inline(described_class.new(vacancy: vacancy_presenter)) }
-
-    it 'renders the title' do
-      expect(rendered_component).to include(vacancy_presenter.job_title)
+    it 'renders the trust type' do
+      expect(rendered_component)
+        .to include(organisation_type(organisation: vacancy.school, with_age_range: true))
     end
+  end
 
-    it 'renders the salary' do
-      expect(rendered_component).to include(vacancy_presenter.salary)
-    end
+  context 'when vacancy is at central office in a trust' do
+    let(:vacancy) { create(:vacancy, :with_school_group) }
 
     it 'renders the address' do
       assert_includes rendered_component, location(vacancy.school_group)
@@ -72,24 +70,6 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
 
     it 'renders the trust type' do
       expect(rendered_component).to include(organisation_type(organisation: vacancy.school_group))
-    end
-
-    it 'renders the working pattern' do
-      expect(rendered_component).to include(vacancy_presenter.working_patterns)
-    end
-
-    context 'when expiry time is nil' do
-      let(:vacancy) { create(:vacancy, school_group: school_group, expiry_time: nil) }
-
-      it 'renders the date it expires on but not the time' do
-        expect(rendered_component).to include(format_date(vacancy.expires_on))
-      end
-    end
-
-    context 'when expiry time is not nil' do
-      it 'renders the date and time it expires at' do
-        expect(rendered_component).to include(expiry_date_and_time(vacancy))
-      end
     end
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -25,6 +25,8 @@ FactoryBot.define do
       "Trusts (name)": Faker::Company.name + ' Trust'
       } }
     local_authority { Faker::Address.state_abbr }
+    minimum_age { 11 }
+    maximum_age { 18 }
     name { Faker::Educator.secondary_school.strip }
     northing { '1' }
     phase { :secondary }

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -7,24 +7,30 @@ RSpec.describe School, type: :model do
   it { should have_many(:school_group_memberships) }
   it { should have_many(:school_groups) }
 
-  describe '#has_religious_character?' do
-    before do
-      subject.gias_data = {}.to_json
+  describe '#religious_character' do
+    let(:religious_character) { 'Roman Catholic' }
+    let(:gias_data) { { 'ReligiousCharacter (name)' => religious_character } }
+
+    before { allow(subject).to receive(:gias_data).and_return gias_data }
+
+    it 'returns religious character' do
+      expect(subject.religious_character).to eq 'Roman Catholic'
     end
 
-    it 'returns false when the school has no gias_data' do
-      subject.gias_data = nil
-      expect(subject.has_religious_character?).to be false
+    context 'when the school has no religious character' do
+      let(:religious_character) { 'Does not apply' }
+
+      it 'returns nil' do
+        expect(subject.religious_character).to eq nil
+      end
     end
 
-    it 'returns false when the school has no religious_character' do
-      allow(subject.gias_data).to receive(:[]).with('ReligiousCharacter (name)').and_return 'Does not apply'
-      expect(subject.has_religious_character?).to be false
-    end
+    context 'when the school has no gias_data' do
+      let(:gias_data) { nil }
 
-    it 'returns true when the school has a religious character' do
-      allow(subject.gias_data).to receive(:[]).with('ReligiousCharacter (name)').and_return 'Roman Catholic'
-      expect(subject.has_religious_character?).to be true
+      it 'returns nil' do
+        expect(subject.religious_character).to eq nil
+      end
     end
   end
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe School, type: :model do
     let(:religious_character) { 'Roman Catholic' }
     let(:gias_data) { { 'ReligiousCharacter (name)' => religious_character } }
 
-    before { allow(subject).to receive(:gias_data).and_return gias_data }
+    subject { build(:school, gias_data: gias_data) }
 
     it 'returns religious character' do
       expect(subject.religious_character).to eq 'Roman Catholic'


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1088

## Changes in this PR:

- Display age range alongside school type and religious character, but only in search snippets. For a singular school in a trust, school type is displayed with religious character and age range (i.e. it here behaves like non-trust vacancies, as desired).
- Removed redundant test examples for vacancy summary view component to save time running test suite
- Refactor: changed out `School#has_religious_character?` for `School#religious_character`