### PR TITLE
Fix school/trust overview heading

### DIFF
--- a/app/components/jobseekers/school_group_overview_component.html.haml
+++ b/app/components/jobseekers/school_group_overview_component.html.haml
@@ -1,6 +1,6 @@
 %section#school-overview.govuk-tabs__panel.no-border-override
   %h3.govuk-heading-l
-    = t('school_groups.trust_overview')
+    = @vacancy.overview_heading
   %table.govuk-table
     %tbody.govuk-table__body
       %tr.govuk-table__row

--- a/app/components/jobseekers/school_overview_component.html.haml
+++ b/app/components/jobseekers/school_overview_component.html.haml
@@ -1,6 +1,6 @@
 %section#school-overview.govuk-tabs__panel.no-border-override
   %h3.govuk-heading-l
-    = t('schools.school_overview')
+    = @vacancy.overview_heading
   %table.govuk-table
     %tbody.govuk-table__body
       %tr.govuk-table__row

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -342,6 +342,11 @@ class Vacancy < ApplicationRecord
     self.documents.each { |document| DocumentDelete.new(document).delete }
   end
 
+  def overview_heading
+    type = self.job_location == 'central_office' ? 'trust' : 'school'
+    I18n.t('jobs.organisation_overview', organisation_type: type.capitalize)
+  end
+
   private
 
   def expires_at

--- a/app/views/shared/vacancy/_jobseeker_view.html.haml
+++ b/app/views/shared/vacancy/_jobseeker_view.html.haml
@@ -24,10 +24,7 @@
             = t('jobs.job_details')
         %li.govuk-tabs__list-item
           %a.govuk-tabs__tab.tab-links-override{ href: "#school-overview" }
-            - if @vacancy.school_group
-              = t('school_groups.trust_overview')
-            - else
-              = t('schools.school_overview')
+            = @vacancy.overview_heading
 
       = render(Jobseekers::VacancyDetailsComponent.new(vacancy: @vacancy))
       = render(Jobseekers::SchoolGroupOverviewComponent.new(vacancy: @vacancy))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,6 +282,7 @@ en:
       remaining: '%{days_remaining} days remaining to apply'
       today: 'Deadline is today'
       tomorrow: 'Deadline is tomorrow'
+    organisation_overview: '%{organisation_type} overview'
     school_type: 'School type'
     trust_type: 'Trust type'
     publish_on: 'Date listed'
@@ -581,7 +582,6 @@ en:
       We'll only use this to tell you about opportunities to take part in user research that helps us improve
       Department for Education services.
   schools:
-    school_overview: 'School overview'
     address: 'Address'
     school_location: 'School location'
     phase: 'Education phase'
@@ -638,7 +638,6 @@ en:
     group_type: Group type
     info: 'About %{school_group}'
     school_group_location: 'Head office location'
-    trust_overview: Trust overview
     trust_visits: 'Arrange a visit to %{school_group}'
     type: 'Trust type'
     uid: Unique identifier (UID)

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -478,4 +478,32 @@ RSpec.describe Vacancy, type: :model do
       end
     end
   end
+
+  describe '#overview_heading' do
+    context 'a vacancy at a trust head office' do
+      subject { build(:vacancy, :with_school_group) }
+
+      it 'enables translation to generate a TRUST overview heading' do
+        expect(subject.overview_heading).to eq('Trust overview')
+      end
+    end
+
+    context 'a vacancy at a single school' do
+      subject { build(:vacancy) }
+
+      context 'at a trust' do
+        it 'enables translation to generate a SCHOOL overview heading' do
+          expect(subject.overview_heading).to eq('School overview')
+        end
+      end
+
+      context 'NOT at a trust' do
+        subject { build(:vacancy, :with_school_group_at_school) }
+
+        it 'enables translation to generate a SCHOOL overview heading' do
+          expect(subject.overview_heading).to eq('School overview')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
By moving logic from views to vacancy model.

## Jira ticket URL

None - this seemed small so I just went for it.

## Changes in this PR:

- Fix bug. See screenshots. We want to show a school overview for vacancies at 1 school in a trust. This was inconsistently implemented.
- Move the logic to a method on the vacancy model. Where should this method live? I avoided using a helper or presenter as I know we want to eventually get rid of these. The method is used in three places, not in any particular view component.

## Screenshots of UI changes:

### Before
<img width="355" alt="Screenshot 2020-08-12 at 12 28 15" src="https://user-images.githubusercontent.com/60350599/90018779-5c088c00-dca5-11ea-8d38-72644414a20c.png">

### After
<img width="355" alt="Screenshot 2020-08-12 at 12 33 39" src="https://user-images.githubusercontent.com/60350599/90018782-5ca12280-dca5-11ea-9c69-b76f97121e59.png">
