### PR TITLE
Fix flaky tests

### DIFF
--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     gias_data { {
       "CloseDate": nil,
       "HeadFirstName": Faker::Name.first_name,
-      "HeadLastName": Faker::Name.last_name,
+      "HeadLastName": Faker::Name.last_name.gsub("'", ''),
       "HeadPreferredJobTitle": Faker::Name.prefix.gsub('.', ''),
       "DateOfLastInspectionVisit": Faker::Date.between(from: 999.days.ago, to: 5.days.ago),
       "NumberOfPupils": Faker::Number.number(digits: 3),
@@ -22,12 +22,12 @@ FactoryBot.define do
       "ReligiousCharacter (name)": RELIGIOUS_CHARACTERS.sample,
       "SchoolCapacity": Faker::Number.number(digits: 4),
       "TelephoneNum": Faker::Number.number(digits: 11).to_s,
-      "Trusts (name)": Faker::Company.name + ' Trust'
+      "Trusts (name)": Faker::Company.name.gsub("'", '') + ' Trust'
       } }
     local_authority { Faker::Address.state_abbr }
     minimum_age { 11 }
     maximum_age { 18 }
-    name { Faker::Educator.secondary_school.strip }
+    name { Faker::Educator.secondary_school.strip.gsub("'", '') }
     northing { '1' }
     phase { :secondary }
     postcode { Faker::Address.postcode }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
         }.call
       } }
     email { Faker::Internet.email }
-    family_name { Faker::Name.last_name }
+    family_name { Faker::Name.last_name.gsub("'", '') }
     given_name { Faker::Name.first_name }
     oid { Faker::Crypto.md5 }
   end


### PR DESCRIPTION
In short, apostrophes are encoded for html pages, making feature tests
appear to fail occasionally when a school name is for example O'Reilly
School. This results in a check whether O'Reilly School (the string)
is included in a page which renders O`&#39;`Reilly School.

As these all come from the factories, we can just nip them in the bud.

For more context, see this blog post:

https://medium.com/@randallreedjr/intermittent-test-failures-with-factorygirl-faker-and-apostrophes-b47a26288fc4