### PR TITLE
resolve serialize-javascript to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
       "<rootDir>/app/frontend/src/lib/polyfill/*",
       "<rootDir>/app/frontend/src/loader.js"
     ]
+  },
+  "resolutions": {
+    "serialize-javascript": "^3.1.0"
   }
 }


### PR DESCRIPTION
Follow up to #1867 

version < 3.1.0 was flagged [as a CVE](https://github.com/advisories/GHSA-hxcc-f52p-wc94).

