### PR TITLE
Do not show scrolls when unneeded on checkbox container

### DIFF
--- a/app/frontend/styles/components/accordion_group.scss
+++ b/app/frontend/styles/components/accordion_group.scss
@@ -21,7 +21,7 @@
 
   .govuk-form-group {
     max-height: 194px;
-    overflow: scroll;
+    overflow: auto;
     margin-bottom: govuk-spacing(1);
   }
 


### PR DESCRIPTION
Remove visual clutter which does not exist in TVS Design System.

This causes the horizontal and vertical scrolls not to be shown when there is no overflowing content.

We wrap text to the following line, so horizontal scroll can never be used anyway.

## Screenshots of UI changes:

### Before

<img width="287" alt="Screenshot 2020-08-13 at 12 27 37" src="https://user-images.githubusercontent.com/60350599/90130791-f5e23e80-dd62-11ea-8b38-4191634f79cc.png">
<img width="591" alt="Screenshot 2020-08-13 at 12 28 13" src="https://user-images.githubusercontent.com/60350599/90130793-f67ad500-dd62-11ea-93c6-6a59476c4d71.png">

### After

<img width="225" alt="Screenshot 2020-08-13 at 12 44 12" src="https://user-images.githubusercontent.com/60350599/90130835-085c7800-dd63-11ea-81c5-3ce350b3d93a.png">
<img width="568" alt="Screenshot 2020-08-13 at 12 44 24" src="https://user-images.githubusercontent.com/60350599/90130836-098da500-dd63-11ea-865b-b5186d48c02e.png">
