### PR TITLE
Enable left side of checkbox hover box to be seen

### DIFF
--- a/app/frontend/styles/components/accordion_group.scss
+++ b/app/frontend/styles/components/accordion_group.scss
@@ -18,6 +18,7 @@
 .tv-checkbox__group {
   border: govuk-spacing(1) solid govuk-colour("light-grey");
   padding: govuk-spacing(2);
+  padding-left: 0px;
 
   .govuk-form-group {
     max-height: 194px;
@@ -28,6 +29,15 @@
   .govuk-checkboxes__item label {
     font-weight: $regular-font-weight;
     font-size: 0.9em;
+  }
+
+  .govuk-checkboxes__item {
+    margin-left: govuk-spacing(2);
+    margin-top: 2px;
+  }
+
+  .govuk-hint {
+    margin-left: govuk-spacing(2);
   }
 }
 

--- a/app/frontend/styles/components/search_input.scss
+++ b/app/frontend/styles/components/search_input.scss
@@ -1,7 +1,7 @@
 .search-input {
   background: white;
   position: relative;
-  width: 100%;
+  margin-left: govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
 
   input {


### PR DESCRIPTION

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1138

## Changes in this PR:

- See title
- I'm doing it by getting rid of the left-padding in .tv-checkbox__group, and using margins of the same size on the 2-3 child elements, so that the left part of the box-shadow is not hidden behind the padding.
- If you can think of a better way to do this, please let me know, as this is not very clean code (maintaining govuk-spacing(2) in three places)
- It is OK with Chris that there is no gap between the hover box-shadow and the light grey checkbox container.

## Screenshots of UI changes:

### Before

<img width="365" alt="Screenshot 2020-08-13 at 15 06 45" src="https://user-images.githubusercontent.com/60350599/90144983-6430fc00-dd77-11ea-9400-4076c710f479.png">

### After

<img width="365" alt="Screenshot 2020-08-13 at 15 11 51" src="https://user-images.githubusercontent.com/60350599/90145021-6bf0a080-dd77-11ea-89d6-34e8347dd06f.png">

