### PR TITLE
Fix BigQuery data feed

### DIFF
--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -23,6 +23,7 @@ class ExportTablesToBigQuery
     geolocation
     gias_data
     job_summary
+    legacy_job_roles
     qualifications
     supporting_documents
   ].freeze
@@ -31,12 +32,13 @@ class ExportTablesToBigQuery
   ENUM_ATTRIBUTES = {
     'frequency' => :string,
     'hired_status' => :string,
+    'job_roles' => :string,
     'listed_elsewhere' => :string,
     'phase' => :string,
     'search_criteria' => :string,
     'status' => :string,
-    'visit_purpose' => :string,
     'user_participation_response' => :string,
+    'visit_purpose' => :string,
     'working_patterns' => :string,
   }.freeze
 
@@ -71,10 +73,10 @@ class ExportTablesToBigQuery
     tables.each do |table|
       bigquery_load(table.constantize)
     rescue StandardError => e
-      binding.pry
-      # If any table causes an uncaught error, no data from any table is sent.
+      # If any table causes an uncaught error, no data from any later table is sent.
       # Therefore we should catch errors, skip the failing tables, and alert the
       # team (devs + PA) to any failing tables.
+      # This handles the error catching, but not the alerting to the team.
       Rails.logger.error({ bigquery_export: 'error', status: 'handled', table: table, message: e })
     end
     Rails.logger.info({ bigquery_export: 'finished' }.to_json)


### PR DESCRIPTION
There were two errors similar to previous BigQuery data feed errors.

Firstly, legacy_job_roles (formerly 'job_roles') was being rejected by BigQuery when it was a list of length 1. We do not need this legacy data so I excluded the column from the feed.

Secondly, job_roles (a new enum column) evaluates to a string because of Rails helper methods, while the column type is integer. BigQuery quite rightly rejects any attempt to put a string into an integer column. This problem applies to several other columns already, so I just had to add 'job_roles' to the ENUM_ATTIBUTES constant.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1172
