### PR TITLE
WIP: [TEVA-1008] change vacancy form title for multi school job

### DIFF
--- a/app/controllers/hiring_staff/vacancies/job_location_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_location_controller.rb
@@ -50,7 +50,7 @@ class HiringStaff::Vacancies::JobLocationController < HiringStaff::Vacancies::Ap
     vacancy_id = @vacancy&.persisted? ? @vacancy.id : session_vacancy_id
     if @form.job_location == 'at_one_school'
       vacancy_id.present? ? organisation_job_school_path(vacancy_id) : school_organisation_job_path
-    elsif @form.job_location == 'central_office'
+    elsif %w(central_office at_multiple_schools).include?(@form.job_location)
       vacancy_id.present? ?
         organisation_job_job_specification_path(vacancy_id) : job_specification_organisation_job_path
     end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -42,15 +42,26 @@ module VacanciesHelper
 
   def page_title(vacancy)
     return I18n.t('jobs.copy_job_title', job_title: vacancy.job_title) if vacancy.state == 'copy'
-    return I18n.t('jobs.create_a_job_title', organisation: vacancy.school_or_school_group&.name.presence || '') if
+    return I18n.t('jobs.create_a_job_title', organisation: page_title_job_location(vacancy.location)) if
       %w(create review).include?(vacancy.state)
     I18n.t('jobs.edit_job_title', job_title: vacancy.job_title)
   end
 
+  def page_title_job_location(location)
+    binding.pry
+    if location == 'at_one_school'
+      vacancy.school_or_school_group&.name.presence
+    elsif location == 'central_office'
+      vacancy.school_or_school_group&.name.presence
+    else
+      'multiple schools'
+    end
+  end
+
   def page_title_no_vacancy
-    return I18n.t('jobs.create_a_job_title', organisation: session[:vacancy_attributes]['readable_job_location']) if
-      session[:vacancy_attributes].present? && session[:vacancy_attributes]['school_id'].present? &&
-      session[:vacancy_attributes]['job_location'] == 'at_one_school'
+    binding.pry
+    return I18n.t('jobs.create_a_job_title', organisation: page_title_job_location(session[:vacancy_attributes]['job_location'])) if
+      session[:vacancy_attributes].present? && (session[:vacancy_attributes]['school_id'].present? || session[:vacancy_attributes]['job_location'] == 'at_multiple_schools')
     I18n.t('jobs.create_a_job_title', organisation: current_organisation.name)
   end
 

--- a/spec/helpers/vacancies_options_helper_spec.rb
+++ b/spec/helpers/vacancies_options_helper_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe VacanciesOptionsHelper, type: :helper do
     before do
       allow(MultiSchoolJobsFeature).to receive(:enabled?).and_return(:multi_school_jobs_enabled?)
     end
+    
     context 'when MultiSchoolJobsFeature is enabled' do
       let (:multi_school_jobs_enabled?) { true }
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1008

## Changes in this PR:

-It's not currently working as it is, but I was in the process trying to of change the page title to display 'Create a job listing for multiple schools' when hiring staff select the 'At more than one school in the trust' option. 