### PR TITLE
Bigquery benchmark against comparable vacancies

### DIFF
--- a/bigquery/calculate-daily-vacancy-tag-time-metrics.sql
+++ b/bigquery/calculate-daily-vacancy-tag-time-metrics.sql
@@ -155,7 +155,7 @@ SELECT
   all_vacancy_in_scope_metrics.total_in_scope_live_vacancies AS total_in_scope_live_vacancies,
   all_benchmarks.benchmark_total_live_vacancies AS benchmark_total_live_vacancies,
   SAFE_DIVIDE(all_vacancy_in_scope_metrics.total_in_scope_live_vacancies,
-    all_benchmarks.benchmark_total_live_vacancies) AS total_live_vacancies_as_proportion_of_benchmark,
+    all_benchmarks.benchmark_total_live_vacancies) AS total_in_scope_live_vacancies_as_proportion_of_benchmark,
   SAFE_DIVIDE(SUM(vacancy_metrics.vacancies_published) OVER (PARTITION BY tag ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) - SUM(vacancy_metrics.vacancies_expired) OVER (PARTITION BY tag ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
     all_vacancy_metrics.total_live_vacancies) AS proportion_of_live_vacancies_with_this_tag
 FROM

--- a/bigquery/calculate-daily-vacancy-tag-time-metrics.sql
+++ b/bigquery/calculate-daily-vacancy-tag-time-metrics.sql
@@ -26,6 +26,45 @@ WITH
     vacancy.id,
     school_id,
     job_roles ),
+  vacancies_in_scope AS (
+  SELECT
+    vacancy.id,
+    MIN(vacancy.publish_on) AS publish_on,
+    MIN(vacancy.expires_on) AS expires_on,
+    vacancy.school_id,
+    vacancy.job_roles AS job_roles,
+    vacancy.category AS category,
+    COUNT(document.id) AS number_of_documents
+  FROM
+    `teacher-vacancy-service.production_dataset.vacancies_in_scope` AS vacancy
+  LEFT JOIN
+    `teacher-vacancy-service.production_dataset.feb20_document` AS document
+  ON
+    document.vacancy_id=vacancy.id
+  WHERE
+    (status NOT IN ("trashed",
+        "deleted",
+        "draft"))
+  GROUP BY
+    vacancy.id,
+    school_id,
+    job_roles,
+    category),
+  scraped_vacancies_in_scope AS (
+  SELECT
+    scraped_vacancy.scraped_url AS url,
+    MIN(scraped_vacancy.publish_on) AS publish_on,
+    MIN(scraped_vacancy.expires_on) AS expires_on,
+    scraped_vacancy.school_id,
+    scraped_vacancy.vacancy_category AS category,
+    scraped_vacancy.source AS source
+  FROM
+    `teacher-vacancy-service.production_dataset.scraped_vacancies_in_scope` AS scraped_vacancy
+  GROUP BY
+    url,
+    school_id,
+    category,
+    source ),
   all_vacancy_metrics AS (
   SELECT
     dates.date AS date,
@@ -36,6 +75,32 @@ WITH
     dates
   CROSS JOIN
     vacancies
+  GROUP BY
+    date ),
+  all_vacancy_in_scope_metrics AS (
+  SELECT
+    dates.date AS date,
+    COUNTIF(publish_on=date) AS vacancies_in_scope_published,
+    COUNTIF(expires_on=date) AS vacancies_in_scope_expired,
+    SUM(COUNTIF(publish_on=date)) OVER (ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) - SUM(COUNTIF(expires_on=date)) OVER (ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS total_in_scope_live_vacancies
+  FROM
+    dates
+  CROSS JOIN
+    vacancies_in_scope
+  GROUP BY
+    date ),
+  all_benchmarks AS (
+  SELECT
+    dates.date AS date,
+    COUNTIF(publish_on=date) AS benchmark_total_vacancies_published,
+    COUNTIF(expires_on=date) AS benchmark_total_vacancies_expired,
+    SUM(COUNTIF(publish_on=date)) OVER (ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) - SUM(COUNTIF(expires_on=date)) OVER (ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS benchmark_total_live_vacancies
+  FROM
+    dates
+  CROSS JOIN
+    scraped_vacancies_in_scope
+  WHERE
+    scraped_vacancies_in_scope.source="TES"
   GROUP BY
     date ),
   vacancy_metrics AS ( (
@@ -83,9 +148,16 @@ SELECT
   vacancy_metrics.tag AS tag,
   vacancy_metrics.vacancies_published AS vacancies_published_with_this_tag_on_this_date,
   all_vacancy_metrics.vacancies_published AS total_vacancies_published_on_this_date,
+  all_vacancy_in_scope_metrics.vacancies_in_scope_published AS total_in_scope_vacancies_published_on_this_date,
+  all_benchmarks.benchmark_total_vacancies_published AS benchmark_total_vacancies_published_on_this_date,
   SUM(vacancy_metrics.vacancies_published) OVER (PARTITION BY tag ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) - SUM(vacancy_metrics.vacancies_expired) OVER (PARTITION BY tag ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS live_vacancies_with_this_tag,
   all_vacancy_metrics.total_live_vacancies AS total_live_vacancies,
-  SAFE_DIVIDE(SUM(vacancy_metrics.vacancies_published) OVER (PARTITION BY tag ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) - SUM(vacancy_metrics.vacancies_expired) OVER (PARTITION BY tag ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),all_vacancy_metrics.total_live_vacancies) AS proportion_of_live_vacancies_with_this_tag
+  all_vacancy_in_scope_metrics.total_in_scope_live_vacancies AS total_in_scope_live_vacancies,
+  all_benchmarks.benchmark_total_live_vacancies AS benchmark_total_live_vacancies,
+  SAFE_DIVIDE(all_vacancy_in_scope_metrics.total_in_scope_live_vacancies,
+    all_benchmarks.benchmark_total_live_vacancies) AS total_live_vacancies_as_proportion_of_benchmark,
+  SAFE_DIVIDE(SUM(vacancy_metrics.vacancies_published) OVER (PARTITION BY tag ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) - SUM(vacancy_metrics.vacancies_expired) OVER (PARTITION BY tag ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+    all_vacancy_metrics.total_live_vacancies) AS proportion_of_live_vacancies_with_this_tag
 FROM
   dates
 LEFT JOIN
@@ -94,6 +166,14 @@ USING
   (date)
 LEFT JOIN
   all_vacancy_metrics
+USING
+  (date)
+LEFT JOIN
+  all_benchmarks
+USING
+  (date)
+LEFT JOIN
+  all_vacancy_in_scope_metrics
 USING
   (date)
 ORDER BY

--- a/bigquery/vacancies-in-scope.sql
+++ b/bigquery/vacancies-in-scope.sql
@@ -1,0 +1,36 @@
+  # Filters the feb20_vacancies table into the vacancies_in_scope view by excluding vacancies from out of scope statuses or roles
+SELECT
+  *
+FROM (
+  SELECT
+    vacancy.*,
+  IF
+    (LOWER(job_title) LIKE '%head%'
+      OR LOWER(job_title) LIKE '%ordinat%'
+      OR LOWER(job_title) LIKE '%principal%',
+      "leadership",
+    IF
+      ((job_title LIKE '%TA%'
+          OR job_title LIKE '%TAs%'
+          OR LOWER(job_title) LIKE '% assistant%' #picks up teaching assistant, learning support assistant etc.
+          OR LOWER(job_title) LIKE '%intervention %')
+        AND LOWER(job_title) NOT LIKE '%admin%'
+        AND LOWER(job_title) NOT LIKE '%account%'
+        AND LOWER(job_title) NOT LIKE '%marketing%'
+        AND LOWER(job_title) NOT LIKE '%admission%'
+        AND LOWER(job_title) NOT LIKE '%care%',
+        "teaching_assistant",
+      IF
+        (LOWER(job_title) LIKE '%teacher%'
+          OR LOWER(job_title) LIKE '%lecturer%',
+          "teacher",
+          NULL))) AS category
+  FROM
+    `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
+  WHERE
+    vacancy.status NOT IN ("trashed",
+      "draft",
+      "deleted"))
+WHERE
+  category IN ("teacher",
+    "leadership") #i.e. not null or teaching_assistant


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1067

## Changes in this PR:

- Adds 'in scope' view of vacancy table in BigQuery that excludes non-teaching/leadership roles and unpublished roles.
- Calculates number of live vacancies and vacancies published on an alternative jobs board as a benchmark.
- Compares the two as a proportion
