### PR TITLE
remove legacy event handler from old autocomplete

### DIFF
--- a/app/frontend/src/lib/ui/patterns/autocomplete.view.js
+++ b/app/frontend/src/lib/ui/patterns/autocomplete.view.js
@@ -18,7 +18,7 @@ export const create = (container, input, key) => {
     });
 
     ul.addEventListener('click', (e) => {
-      setInputValue(e.target.dataset[key]);
+      setInputValue(input, e.target.dataset[key]);
       input.dispatchEvent(new Event('change', { bubbles: true }));
     });
 
@@ -45,9 +45,6 @@ export const show = (options, container, input, key) => {
   getRenderedList(container).classList.add('autocomplete__menu--visible');
   getRenderedList(container).classList.remove('autocomplete__menu--hidden');
   input.setAttribute('aria-expanded', true);
-
-  Array.from(getCurrentOptionElementsArray(container))
-    .forEach((element) => element.addEventListener('focus', (e) => setInputValue(input, e.target.dataset[key]), true));
 };
 
 export const setInputValue = (input, value) => {


### PR DESCRIPTION
no ticket

there is a JS error on homepage when autocomplete used due to an event handle from an older iteration of autocomplete that is no longer needed an was passing incorrect args. this removes that and hence error