### PR TITLE
Initialise empty jobs search form on home page load

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,7 @@ class PagesController < ApplicationController
   include HighVoltage::StaticPage
 
   def home
-    @jobs_search_form = VacancyAlgoliaSearchForm.new(params)
+    @jobs_search_form = VacancyAlgoliaSearchForm.new
   end
 
   def invalid_page


### PR DESCRIPTION
Resolves https://rollbar.com/dfe/teacher-vacancies/items/1988/

## Changes in this PR
- Don't pass params to search form on home page load