### PR TITLE
[TEVA-1125] Ensure hint and label are inline

### DIFF
--- a/app/frontend/styles/components/accordion_group.scss
+++ b/app/frontend/styles/components/accordion_group.scss
@@ -43,6 +43,10 @@
   .govuk-hint {
     margin-left: govuk-spacing(2);
   }
+
+  .govuk-checkboxes__hint {
+    margin-left: 1px;
+  }
 }
 
 .accordion-content__group .govuk-accordion__section--expanded {


### PR DESCRIPTION
This addresses the last (I pray) of the css inconsistencies between design and the subject input introduced in the move to using the checkbox component
 
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1125

## Changes in this PR:
- Ensure label and hint are inline for checkboxes
