### PR TITLE
[TEVA-1188] Anchor page to vacancies on form submit

### DIFF
--- a/app/components/hiring_staff/vacancies_component.html.haml
+++ b/app/components/hiring_staff/vacancies_component.html.haml
@@ -21,4 +21,5 @@
           - @vacancy_types.each do |vacancy_type|
             %li.govuk-tabs__list-item{ class: selected_class(vacancy_type) }
               = vacancy_type_tab_link(vacancy_type)
-        = render "hiring_staff/organisations/vacancies_#{@selected_type}", selected_type: @selected_type, organisation: @organisation, vacancies: @vacancies, sort: @sort
+        %section.govuk-tabs__panel#vacancies-hits
+          = render "hiring_staff/organisations/vacancies_#{@selected_type}", selected_type: @selected_type, organisation: @organisation, vacancies: @vacancies, sort: @sort

--- a/app/components/hiring_staff/vacancies_component.html.haml
+++ b/app/components/hiring_staff/vacancies_component.html.haml
@@ -1,14 +1,14 @@
 .moj-filter-sidebar
   - if @organisation.is_a?(SchoolGroup)
     .govuk-grid-column-one-third
-      = form_for @filters_form, url: organisation_managed_organisations_path, html: { method: "patch", data: { 'auto-submit': true } } do |f|
+      = form_for @filters_form, url: organisation_managed_organisations_path(anchor: 'vacancies-hits'), html: { method: "patch", data: { 'auto-submit': true } } do |f|
         = render 'shared/filter_group', f: f, filters: { title: t('jobs.filters.job_filters'), remove_buttons: true, total_count: @filters[:managed_school_ids]&.count, items: [{ title: 'Locations', key: 'locations', search: true, scroll: true, attribute: :managed_school_ids, selected: @filters[:managed_school_ids], options: @organisation_options, value_method: :id, text_method: :label, selected_method: :name, small: true }] }
 
         = f.hidden_field :jobs_type, value: @selected_type
 
 .moj-filter-layout__content{ class: grid_column_class }
   - if @organisation.is_a?(SchoolGroup)
-    .dashboard-header{ class: "govuk-!-margin-bottom-5" } 
+    .dashboard-header{ class: "govuk-!-margin-bottom-5" }
       .filters-information.moj-action-bar
         %button.govuk-button.govuk-button--secondary{ class: "govuk-!-margin-bottom-0 moj-action-bar__filter", id: "toggle-filters-sidebar" }= t('buttons.hide_filters')
         %span.govuk-body{ class: "govuk-!-margin-left-3 filters-applied-text" }= filters_applied_text

--- a/app/views/hiring_staff/organisations/_vacancies_awaiting_feedback.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_awaiting_feedback.html.haml
@@ -1,4 +1,4 @@
-%section.govuk-tabs__panel
+%section.govuk-tabs__panel#vacancies-hits
   %h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
 
   - if vacancies.any?

--- a/app/views/hiring_staff/organisations/_vacancies_awaiting_feedback.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_awaiting_feedback.html.haml
@@ -1,22 +1,21 @@
-%section.govuk-tabs__panel#vacancies-hits
-  %h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
+%h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
 
-  - if vacancies.any?
-    %p.govuk-body#awaiting_feedback_intro=t("jobs.awaiting_feedback_intro")
+- if vacancies.any?
+  %p.govuk-body#awaiting_feedback_intro=t("jobs.awaiting_feedback_intro")
 
-    %table.govuk-table.vacancies#awaiting_feedback{ class: "govuk-!-margin-top-4" }
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header.job-title-table-header= table_header_sort_by(t("jobs.job_title"), "awaiting_feedback", column: "job_title", sort: sort)
-          - if organisation.is_a?(SchoolGroup)
-            %th.govuk-table__header= table_header_sort_by(t("jobs.location"), "awaiting_feedback", column: "readable_job_location", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.publish_on"), "awaiting_feedback", column: "publish_on", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.expired_on"), "awaiting_feedback", column: "expires_on", sort: sort)
-          %th.govuk-table__header{ class: "govuk-!-width-one-quarter" }= t("jobs.job_filled")
-          %th.govuk-table__header{ class: "govuk-!-width-one-quarter" }= t("jobs.listed_elsewhere")
-          %th.govuk-table__header= t("jobs.actions")
-      %tbody.govuk-table__body
-        - vacancies.each do |vacancy|
-          = render "hiring_staff/organisations/vacancy_awaiting_feedback", vacancy: vacancy, organisation: organisation
-  - else
-    %p.govuk-body= t("jobs.no_awaiting_feedback")
+  %table.govuk-table.vacancies#awaiting_feedback{ class: "govuk-!-margin-top-4" }
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header.job-title-table-header= table_header_sort_by(t("jobs.job_title"), "awaiting_feedback", column: "job_title", sort: sort)
+        - if organisation.is_a?(SchoolGroup)
+          %th.govuk-table__header= table_header_sort_by(t("jobs.location"), "awaiting_feedback", column: "readable_job_location", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.publish_on"), "awaiting_feedback", column: "publish_on", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.expired_on"), "awaiting_feedback", column: "expires_on", sort: sort)
+        %th.govuk-table__header{ class: "govuk-!-width-one-quarter" }= t("jobs.job_filled")
+        %th.govuk-table__header{ class: "govuk-!-width-one-quarter" }= t("jobs.listed_elsewhere")
+        %th.govuk-table__header= t("jobs.actions")
+    %tbody.govuk-table__body
+      - vacancies.each do |vacancy|
+        = render "hiring_staff/organisations/vacancy_awaiting_feedback", vacancy: vacancy, organisation: organisation
+- else
+  %p.govuk-body= t("jobs.no_awaiting_feedback")

--- a/app/views/hiring_staff/organisations/_vacancies_draft.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_draft.html.haml
@@ -1,18 +1,17 @@
-%section.govuk-tabs__panel#vacancies-hits
-  %h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
+%h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
 
-  - if vacancies.any?
-    %table.govuk-table.vacancies{ class: "govuk-!-margin-top-4" }
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header= table_header_sort_by(t("jobs.job_title"), "draft", column: "job_title", sort: sort)
-          - if organisation.is_a?(SchoolGroup)
-            %th.govuk-table__header= table_header_sort_by(t("jobs.location"), "draft", column: "readable_job_location", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.draft.time_created"), "draft", column: "created_at", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.draft.time_updated"), "draft", column: "updated_at", sort: sort)
-          %th.govuk-table__header{ colspan: 2 }= t("jobs.actions")
-      %tbody.govuk-table__body
-        - vacancies.each do |vacancy|
-          = render "hiring_staff/organisations/vacancy_draft", vacancy: vacancy, organisation: organisation
-  - else
-    %p.govuk-body= t("jobs.no_draft_jobs")
+- if vacancies.any?
+  %table.govuk-table.vacancies{ class: "govuk-!-margin-top-4" }
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header= table_header_sort_by(t("jobs.job_title"), "draft", column: "job_title", sort: sort)
+        - if organisation.is_a?(SchoolGroup)
+          %th.govuk-table__header= table_header_sort_by(t("jobs.location"), "draft", column: "readable_job_location", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.draft.time_created"), "draft", column: "created_at", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.draft.time_updated"), "draft", column: "updated_at", sort: sort)
+        %th.govuk-table__header{ colspan: 2 }= t("jobs.actions")
+    %tbody.govuk-table__body
+      - vacancies.each do |vacancy|
+        = render "hiring_staff/organisations/vacancy_draft", vacancy: vacancy, organisation: organisation
+- else
+  %p.govuk-body= t("jobs.no_draft_jobs")

--- a/app/views/hiring_staff/organisations/_vacancies_draft.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_draft.html.haml
@@ -1,4 +1,4 @@
-%section.govuk-tabs__panel
+%section.govuk-tabs__panel#vacancies-hits
   %h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
 
   - if vacancies.any?

--- a/app/views/hiring_staff/organisations/_vacancies_expired.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_expired.html.haml
@@ -1,19 +1,18 @@
-%section.govuk-tabs__panel#vacancies-hits
-  %h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
+%h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
 
-  - if vacancies.any?
-    %table.govuk-table.vacancies{ class: "govuk-!-margin-top-4" }
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header= table_header_sort_by(t("jobs.job_title"), "expired", column: "job_title", sort: sort)
-          - if organisation.is_a?(SchoolGroup)
-            %th.govuk-table__header= table_header_sort_by(t("jobs.location"), "expired", column: "readable_job_location", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.publish_on"), "expired", column: "publish_on", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.expired_on"), "expired", column: "expires_on", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.page_views"), "expired", column: "total_pageviews", sort: sort)
-          %th.govuk-table__header{ colspan: 2 }= t("jobs.actions")
-      %tbody.govuk-table__body
-        - vacancies.each do |vacancy|
-          = render "hiring_staff/organisations/vacancy_expired", vacancy: vacancy, organisation: organisation
-  - else
-    %p.govuk-body= t("jobs.no_expired_jobs")
+- if vacancies.any?
+  %table.govuk-table.vacancies{ class: "govuk-!-margin-top-4" }
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header= table_header_sort_by(t("jobs.job_title"), "expired", column: "job_title", sort: sort)
+        - if organisation.is_a?(SchoolGroup)
+          %th.govuk-table__header= table_header_sort_by(t("jobs.location"), "expired", column: "readable_job_location", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.publish_on"), "expired", column: "publish_on", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.expired_on"), "expired", column: "expires_on", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.page_views"), "expired", column: "total_pageviews", sort: sort)
+        %th.govuk-table__header{ colspan: 2 }= t("jobs.actions")
+    %tbody.govuk-table__body
+      - vacancies.each do |vacancy|
+        = render "hiring_staff/organisations/vacancy_expired", vacancy: vacancy, organisation: organisation
+- else
+  %p.govuk-body= t("jobs.no_expired_jobs")

--- a/app/views/hiring_staff/organisations/_vacancies_expired.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_expired.html.haml
@@ -1,4 +1,4 @@
-%section.govuk-tabs__panel
+%section.govuk-tabs__panel#vacancies-hits
   %h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
 
   - if vacancies.any?

--- a/app/views/hiring_staff/organisations/_vacancies_pending.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_pending.html.haml
@@ -1,18 +1,17 @@
-%section.govuk-tabs__panel#vacancies-hits
-  %h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
+%h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
 
-  - if vacancies.any?
-    %table.govuk-table.vacancies{ class: "govuk-!-margin-top-4" }
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header= table_header_sort_by(t("jobs.job_title"), "pending", column: "job_title", sort: sort)
-          - if organisation.is_a?(SchoolGroup)
-            %th.govuk-table__header= table_header_sort_by(t("jobs.location"), "pending", column: "readable_job_location", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.date_to_be_posted"), "pending", column: "publish_on", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.expires_on"), "pending", column: "expires_on", sort: sort)
-          %th.govuk-table__header{ colspan: 3 }= t("jobs.actions")
-        %tbody.govuk-table__body
-          - vacancies.each do |vacancy|
-            = render "hiring_staff/organisations/vacancy_pending", vacancy: vacancy, organisation: organisation
-  - else
-    %p.govuk-body= t("jobs.no_pending_jobs")
+- if vacancies.any?
+  %table.govuk-table.vacancies{ class: "govuk-!-margin-top-4" }
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header= table_header_sort_by(t("jobs.job_title"), "pending", column: "job_title", sort: sort)
+        - if organisation.is_a?(SchoolGroup)
+          %th.govuk-table__header= table_header_sort_by(t("jobs.location"), "pending", column: "readable_job_location", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.date_to_be_posted"), "pending", column: "publish_on", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.expires_on"), "pending", column: "expires_on", sort: sort)
+        %th.govuk-table__header{ colspan: 3 }= t("jobs.actions")
+      %tbody.govuk-table__body
+        - vacancies.each do |vacancy|
+          = render "hiring_staff/organisations/vacancy_pending", vacancy: vacancy, organisation: organisation
+- else
+  %p.govuk-body= t("jobs.no_pending_jobs")

--- a/app/views/hiring_staff/organisations/_vacancies_pending.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_pending.html.haml
@@ -1,4 +1,4 @@
-%section.govuk-tabs__panel
+%section.govuk-tabs__panel#vacancies-hits
   %h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
 
   - if vacancies.any?

--- a/app/views/hiring_staff/organisations/_vacancies_published.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_published.html.haml
@@ -1,19 +1,18 @@
-%section.govuk-tabs__panel#vacancies-hits
-  %h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
+%h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
 
-  - if vacancies.any?
-    %table.govuk-table.vacancies{ class: "govuk-!-margin-top-4" }
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header= table_header_sort_by(t("jobs.job_title"), "published", column: "job_title", sort: sort)
-          - if organisation.is_a?(SchoolGroup)
-            %th.govuk-table__header= table_header_sort_by(t("jobs.location"), "published", column: "readable_job_location", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.publish_on"), "published", column: "publish_on", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.expires_on"), "published", column: "expires_on", sort: sort)
-          %th.govuk-table__header= table_header_sort_by(t("jobs.page_views"), "published", column: "total_pageviews", sort: sort)
-          %th.govuk-table__header{ colspan: 3 }= t("jobs.actions")
-      %tbody.govuk-table__body
-        - vacancies.each do |vacancy|
-          = render "hiring_staff/organisations/vacancy_published", vacancy: vacancy, organisation: organisation
-  - else
-    %p.govuk-body= t("jobs.no_published_jobs")
+- if vacancies.any?
+  %table.govuk-table.vacancies{ class: "govuk-!-margin-top-4" }
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header= table_header_sort_by(t("jobs.job_title"), "published", column: "job_title", sort: sort)
+        - if organisation.is_a?(SchoolGroup)
+          %th.govuk-table__header= table_header_sort_by(t("jobs.location"), "published", column: "readable_job_location", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.publish_on"), "published", column: "publish_on", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.expires_on"), "published", column: "expires_on", sort: sort)
+        %th.govuk-table__header= table_header_sort_by(t("jobs.page_views"), "published", column: "total_pageviews", sort: sort)
+        %th.govuk-table__header{ colspan: 3 }= t("jobs.actions")
+    %tbody.govuk-table__body
+      - vacancies.each do |vacancy|
+        = render "hiring_staff/organisations/vacancy_published", vacancy: vacancy, organisation: organisation
+- else
+  %p.govuk-body= t("jobs.no_published_jobs")

--- a/app/views/hiring_staff/organisations/_vacancies_published.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancies_published.html.haml
@@ -1,4 +1,4 @@
-%section.govuk-tabs__panel
+%section.govuk-tabs__panel#vacancies-hits
   %h2.govuk-heading-m= t("jobs.#{selected_type}_jobs_with_count", count: vacancies.count)
 
   - if vacancies.any?

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,7 +32,7 @@
     = render partial: 'shared/google_tag_manager_body'
     :javascript
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    %a.govuk-skip-link{ href: "#main-content" } Skip to main content
+    = render 'shared/skip_links'
     %header.govuk-header{ "data-module": "govuk-header", role: "banner" }
       .govuk-header__container.govuk-width-container
         .govuk-header__logo

--- a/app/views/shared/_skip_links.html.haml
+++ b/app/views/shared/_skip_links.html.haml
@@ -1,0 +1,3 @@
+%a.govuk-skip-link{ href: "#main-content" } Skip to main content
+- if params[:jobs_search_form]
+  %a.govuk-skip-link{ href: "#vacancies-hits" } Skip to search results

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -1,4 +1,4 @@
-= form_for @jobs_search_form, as: 'jobs_search_form', url: jobs_path(anchor: 'vacancy-results'), method: :get, html: { data: { 'auto-submit': true }, class: 'filters-form', role: 'search', aria: { label: 'Search criteria' } } do |f|
+= form_for @jobs_search_form, as: 'jobs_search_form', url: jobs_path(anchor: 'vacancies-hits'), method: :get, html: { data: { 'auto-submit': true }, class: 'filters-form', role: 'search', aria: { label: 'Search criteria' } } do |f|
   %aside.filter-vacancies{ class: "govuk-!-margin-bottom-3" }
     %h2.govuk-heading-m= t('jobs.filters.title')
 

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -1,4 +1,4 @@
-= form_for @jobs_search_form, as: 'jobs_search_form', url: jobs_path(anchor: 'vacancies-hits'), method: :get, html: { data: { 'auto-submit': true }, class: 'filters-form', role: 'search', aria: { label: 'Search criteria' } } do |f|
+= form_for @jobs_search_form, as: 'jobs_search_form', url: jobs_path, method: :get, html: { data: { 'auto-submit': true }, class: 'filters-form', role: 'search', aria: { label: 'Search criteria' } } do |f|
   %aside.filter-vacancies{ class: "govuk-!-margin-bottom-3" }
     %h2.govuk-heading-m= t('jobs.filters.title')
 


### PR DESCRIPTION
This PR anchors both the job results page and the dashboard to the job results.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1188

## Changes in this PR:
- Form submit url is anchored to `#vacancies-hits` elements
