### PR TITLE
[TEVA-1165] filter side panel persistent state

### DIFF
--- a/app/frontend/src/lib/ui/components/filterGroup.js
+++ b/app/frontend/src/lib/ui/components/filterGroup.js
@@ -58,6 +58,7 @@ export const init = (groupContainerSelector, removeButtonSelector, clearButtonSe
     });
   }
   toggleFilterPanel({
+    key: 'dashboard',
     hideText: 'Hide filters',
     showText: 'Show filters',
     container: document.getElementsByClassName('moj-filter-sidebar')[0],

--- a/app/frontend/src/lib/ui/components/filterGroup.js
+++ b/app/frontend/src/lib/ui/components/filterGroup.js
@@ -7,7 +7,7 @@ export const ACCORDION_SECTION_CLASS_SELECTOR = 'govuk-accordion__section';
 export const ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR = 'govuk-accordion__section--expanded';
 export const CHECKBOX_CLASS_SELECTOR = 'govuk-checkboxes__input';
 export const CLOSED_CLASS = 'govuk-grid-column-full';
-export const OPEN_CLASS = 'govuk-grid-column-three-quarters';
+export const OPEN_CLASS = 'govuk-grid-column-two-thirds';
 export const CLOSE_ALL_TEXT = 'Close all';
 export const OPEN_ALL_TEXT = 'Open all';
 

--- a/app/frontend/src/lib/ui/components/filterGroup.js
+++ b/app/frontend/src/lib/ui/components/filterGroup.js
@@ -1,11 +1,13 @@
 import '../../polyfill/closest.polyfill';
 import '../../polyfill/from.polyfill';
 import 'classlist-polyfill';
-import toggleFilterPanel from './panel';
+import { togglePanel as toggleFilterPanel } from './panel';
 
 export const ACCORDION_SECTION_CLASS_SELECTOR = 'govuk-accordion__section';
 export const ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR = 'govuk-accordion__section--expanded';
 export const CHECKBOX_CLASS_SELECTOR = 'govuk-checkboxes__input';
+export const CLOSED_CLASS = 'govuk-grid-column-full';
+export const OPEN_CLASS = 'govuk-grid-column-three-quarters';
 export const CLOSE_ALL_TEXT = 'Close all';
 export const OPEN_ALL_TEXT = 'Open all';
 
@@ -37,34 +39,27 @@ export const init = (groupContainerSelector, removeButtonSelector, clearButtonSe
     document.getElementById(closeButtonSelector).addEventListener('click', openOrCloseAllSectionsHandler);
   }
 
-  const toggleButton = document.getElementById('toggle-filters-sidebar');
+  const content = document.getElementsByClassName('moj-filter-layout__content')[0];
 
-  if (toggleButton) {
-    toggleButton.addEventListener('click', () => {
-      document.getElementsByClassName('moj-filter-sidebar')[0].classList.toggle('moj-filter-sidebar__hidden');
-      if (document.getElementsByClassName('moj-filter-layout__content')[0].classList.contains('govuk-grid-column-two-thirds')) {
-        document.getElementsByClassName('moj-filter-layout__content')[0].classList.remove('govuk-grid-column-two-thirds');
-        document.getElementsByClassName('moj-filter-layout__content')[0].classList.add('govuk-grid-column-full');
-      } else if (document.getElementsByClassName('moj-filter-layout__content')[0].classList.contains('govuk-grid-column-full')) {
-        document.getElementsByClassName('moj-filter-layout__content')[0].classList.remove('govuk-grid-column-full');
-        document.getElementsByClassName('moj-filter-layout__content')[0].classList.add('govuk-grid-column-two-thirds');
-      }
-
-      if (document.getElementsByClassName('moj-filter-sidebar')[0].classList.contains('moj-filter-sidebar__hidden')) {
-        toggleButton.innerHTML = 'Show filters';
-      } else {
-        toggleButton.innerHTML = 'Hide filters';
-      }
-    });
-  }
   toggleFilterPanel({
-    key: 'dashboard',
+    componentKey: 'dashboard',
     hideText: 'Hide filters',
     showText: 'Show filters',
     container: document.getElementsByClassName('moj-filter-sidebar')[0],
     toggleClass: 'moj-filter-sidebar__hidden',
     toggleButton: document.getElementById('toggle-filters-sidebar'),
-    onToggleHandler: () => document.getElementsByClassName('moj-filter-layout__content')[0].classList.toggle('govuk-grid-column-three-quarters'),
+    onToggleHandler: () => {
+      content.classList.toggle(OPEN_CLASS);
+      content.classList.toggle(CLOSED_CLASS);
+    },
+    onClosedHandler: () => {
+      content.classList.remove(OPEN_CLASS);
+      content.classList.add(CLOSED_CLASS);
+    },
+    onOpenedHandler: () => {
+      content.classList.add(OPEN_CLASS);
+      content.classList.remove(CLOSED_CLASS);
+    },
   });
 
   if (document.getElementById(mobileFiltersButtonSelector)) {

--- a/app/frontend/src/lib/ui/components/filterGroup.js
+++ b/app/frontend/src/lib/ui/components/filterGroup.js
@@ -1,6 +1,7 @@
 import '../../polyfill/closest.polyfill';
 import '../../polyfill/from.polyfill';
 import 'classlist-polyfill';
+import toggleFilterPanel from './panel';
 
 export const ACCORDION_SECTION_CLASS_SELECTOR = 'govuk-accordion__section';
 export const ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR = 'govuk-accordion__section--expanded';
@@ -56,6 +57,14 @@ export const init = (groupContainerSelector, removeButtonSelector, clearButtonSe
       }
     });
   }
+  toggleFilterPanel({
+    hideText: 'Hide filters',
+    showText: 'Show filters',
+    container: document.getElementsByClassName('moj-filter-sidebar')[0],
+    toggleClass: 'moj-filter-sidebar__hidden',
+    toggleButton: document.getElementById('toggle-filters-sidebar'),
+    onToggleHandler: () => document.getElementsByClassName('moj-filter-layout__content')[0].classList.toggle('govuk-grid-column-three-quarters'),
+  });
 
   if (document.getElementById(mobileFiltersButtonSelector)) {
     document.getElementById(mobileFiltersButtonSelector).addEventListener('click', () => {

--- a/app/frontend/src/lib/ui/components/panel.js
+++ b/app/frontend/src/lib/ui/components/panel.js
@@ -2,29 +2,30 @@ import 'classlist-polyfill';
 
 const LOCALSTORAGE_COMPONENT_KEY = 'panel';
 
-export const panelToggle = (options) => {
+export const togglePanel = (options) => {
   if (!localStorage.getItem(LOCALSTORAGE_COMPONENT_KEY)) {
     localStorage.setItem(LOCALSTORAGE_COMPONENT_KEY, '{}');
   }
 
   if (options.toggleButton) {
-    isInitialStateOpen(options.key) ? openPanel(options.container, options.toggleClass) : closePanel(options.container, options.toggleClass);
+    panel.isInitialStateOpen(options.componentKey) ? panel.openPanel(options) : panel.closePanel(options);
+
     toggleButtonText(options);
 
     options.toggleButton.addEventListener('click', () => {
       options.container.classList.toggle(options.toggleClass);
       options.onToggleHandler();
       toggleButtonText(options);
-      setState(options.container, options.toggleClass, options.key);
+      setState(options.container, options.toggleClass, options.componentKey);
     });
   }
 };
 
-export const isInitialStateOpen = (key) => JSON.parse(localStorage.getItem(LOCALSTORAGE_COMPONENT_KEY))[key] === 'open';
+export const isInitialStateOpen = (componentKey) => JSON.parse(localStorage.getItem(LOCALSTORAGE_COMPONENT_KEY))[componentKey] === 'open';
 
-export const setState = (container, toggleClass, key) => localStorage.setItem(
+export const setState = (container, toggleClass, componentKey) => localStorage.setItem(
   LOCALSTORAGE_COMPONENT_KEY,
-  JSON.stringify({ [key]: isPanelClosed(container, toggleClass) ? 'closed' : 'open' })
+  JSON.stringify({ [componentKey]: isPanelClosed(container, toggleClass) ? 'closed' : 'open' }),
 );
 
 export const toggleButtonText = ({
@@ -40,8 +41,20 @@ export const toggleButtonText = ({
 
 export const isPanelClosed = (container, toggleClass) => container.classList.contains(toggleClass);
 
-export const openPanel = (container, toggleClass) => container.classList.remove(toggleClass);
+export const openPanel = ({ container, toggleClass, onOpenedHandler }) => {
+  container.classList.remove(toggleClass);
+  onOpenedHandler();
+};
 
-export const closePanel = (container, toggleClass) => container.classList.add(toggleClass);
+export const closePanel = ({ container, toggleClass, onClosedHandler }) => {
+  container.classList.add(toggleClass);
+  onClosedHandler();
+};
 
-export default panelToggle;
+const panel = {
+  isInitialStateOpen,
+  openPanel,
+  closePanel,
+};
+
+export default panel;

--- a/app/frontend/src/lib/ui/components/panel.js
+++ b/app/frontend/src/lib/ui/components/panel.js
@@ -1,14 +1,31 @@
 import 'classlist-polyfill';
 
+const LOCALSTORAGE_COMPONENT_KEY = 'panel';
+
 export const panelToggle = (options) => {
+  if (!localStorage.getItem(LOCALSTORAGE_COMPONENT_KEY)) {
+    localStorage.setItem(LOCALSTORAGE_COMPONENT_KEY, '{}');
+  }
+
   if (options.toggleButton) {
+    isInitialStateOpen(options.key) ? openPanel(options.container, options.toggleClass) : closePanel(options.container, options.toggleClass);
+    toggleButtonText(options);
+
     options.toggleButton.addEventListener('click', () => {
       options.container.classList.toggle(options.toggleClass);
       options.onToggleHandler();
       toggleButtonText(options);
+      setState(options.container, options.toggleClass, options.key);
     });
   }
 };
+
+export const isInitialStateOpen = (key) => JSON.parse(localStorage.getItem(LOCALSTORAGE_COMPONENT_KEY))[key] === 'open';
+
+export const setState = (container, toggleClass, key) => localStorage.setItem(
+  LOCALSTORAGE_COMPONENT_KEY,
+  JSON.stringify({ [key]: isPanelClosed(container, toggleClass) ? 'closed' : 'open' })
+);
 
 export const toggleButtonText = ({
   toggleClass,
@@ -16,8 +33,15 @@ export const toggleButtonText = ({
   container,
   hideText,
   showText,
-}) => toggleButton.innerHTML = isPanelClosed(container, toggleClass) ? showText : hideText;
+}) => {
+  toggleButton.innerHTML = isPanelClosed(container, toggleClass) ? showText : hideText;
+  return true;
+};
 
 export const isPanelClosed = (container, toggleClass) => container.classList.contains(toggleClass);
+
+export const openPanel = (container, toggleClass) => container.classList.remove(toggleClass);
+
+export const closePanel = (container, toggleClass) => container.classList.add(toggleClass);
 
 export default panelToggle;

--- a/app/frontend/src/lib/ui/components/panel.js
+++ b/app/frontend/src/lib/ui/components/panel.js
@@ -1,0 +1,23 @@
+import 'classlist-polyfill';
+
+export const panelToggle = (options) => {
+  if (options.toggleButton) {
+    options.toggleButton.addEventListener('click', () => {
+      options.container.classList.toggle(options.toggleClass);
+      options.onToggleHandler();
+      toggleButtonText(options);
+    });
+  }
+};
+
+export const toggleButtonText = ({
+  toggleClass,
+  toggleButton,
+  container,
+  hideText,
+  showText,
+}) => toggleButton.innerHTML = isPanelClosed(container, toggleClass) ? showText : hideText;
+
+export const isPanelClosed = (container, toggleClass) => container.classList.contains(toggleClass);
+
+export default panelToggle;

--- a/app/frontend/src/lib/ui/components/panel.test.js
+++ b/app/frontend/src/lib/ui/components/panel.test.js
@@ -1,0 +1,55 @@
+import { toggleButtonText, isPanelClosed, panelToggle } from './panel';
+
+describe('panel', () => {
+  document.body.innerHTML = '<div id="panel-container"></div><button id="toggle-button">original text</button>';
+
+  const HIDE_BUTTON_TEXT = 'Hide panel';
+  const SHOW_BUTTON_TEXT = 'Show panel';
+  const CLOSED_CLASS = 'closed';
+  const container = document.getElementById('panel-container');
+  const button = document.getElementById('toggle-button');
+  const options = {
+    container,
+    toggleButton: button,
+    hideText: HIDE_BUTTON_TEXT,
+    showText: SHOW_BUTTON_TEXT,
+    toggleClass: CLOSED_CLASS,
+    onToggleHandler: jest.fn(),
+  };
+
+  describe('toggleButtonText', () => {
+    test('changes button text to show panel state when panel is hidden', () => {
+      toggleButtonText(options);
+      expect(button.innerHTML).toBe(HIDE_BUTTON_TEXT);
+    });
+
+    test('changes button text to hide panel state when panel is visible', () => {
+      container.classList.toggle(CLOSED_CLASS);
+      toggleButtonText(options);
+      expect(button.innerHTML).toBe(SHOW_BUTTON_TEXT);
+    });
+  });
+
+  describe('isPanelClosed', () => {
+    test('changes button text to show panel state when panel is hidden', () => {
+      expect(isPanelClosed(container, CLOSED_CLASS)).toBe(true);
+    });
+  });
+
+  describe('panelToggle', () => {
+    test('calls toggle handler when button is clicked', () => {
+      const toggleMock = jest.spyOn(options, 'onToggleHandler');
+      panelToggle(options);
+      options.toggleButton.dispatchEvent(new Event('click'));
+      expect(toggleMock).toHaveBeenCalled();
+    });
+
+    test('toggles supplied class when button is clicked', () => {
+      options.toggleButton.dispatchEvent(new Event('click'));
+      expect(container.classList.contains(CLOSED_CLASS)).toBe(true);
+
+      options.toggleButton.dispatchEvent(new Event('click'));
+      expect(container.classList.contains(CLOSED_CLASS)).toBe(false);
+    });
+  });
+});

--- a/app/frontend/src/lib/ui/components/panel.test.js
+++ b/app/frontend/src/lib/ui/components/panel.test.js
@@ -26,12 +26,12 @@ describe('panel', () => {
   });
 
   describe('toggleButtonText', () => {
-    test('changes button text to show panel state when panel is hidden', () => {
+    test('changes button text to hide panel text when panel is visible', () => {
       toggleButtonText(options);
       expect(button.innerHTML).toBe(HIDE_BUTTON_TEXT);
     });
 
-    test('changes button text to hide panel state when panel is visible', () => {
+    test('changes button text to show panel text when panel is hidden', () => {
       container.classList.toggle(CLOSED_CLASS);
       toggleButtonText(options);
       expect(button.innerHTML).toBe(SHOW_BUTTON_TEXT);

--- a/app/frontend/src/lib/ui/components/panel.test.js
+++ b/app/frontend/src/lib/ui/components/panel.test.js
@@ -1,4 +1,4 @@
-import { toggleButtonText, isPanelClosed, panelToggle } from './panel';
+import panel, { toggleButtonText, isPanelClosed, togglePanel } from './panel';
 
 describe('panel', () => {
   document.body.innerHTML = '<div id="panel-container"></div><button id="toggle-button">original text</button>';
@@ -8,14 +8,22 @@ describe('panel', () => {
   const CLOSED_CLASS = 'closed';
   const container = document.getElementById('panel-container');
   const button = document.getElementById('toggle-button');
-  const options = {
-    container,
-    toggleButton: button,
-    hideText: HIDE_BUTTON_TEXT,
-    showText: SHOW_BUTTON_TEXT,
-    toggleClass: CLOSED_CLASS,
-    onToggleHandler: jest.fn(),
-  };
+  let options = null;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    options = {
+      container,
+      toggleButton: button,
+      hideText: HIDE_BUTTON_TEXT,
+      showText: SHOW_BUTTON_TEXT,
+      toggleClass: CLOSED_CLASS,
+      onToggleHandler: jest.fn(),
+      onClosedHandler: jest.fn(),
+      onOpenedHandler: jest.fn(),
+    };
+  });
 
   describe('toggleButtonText', () => {
     test('changes button text to show panel state when panel is hidden', () => {
@@ -36,10 +44,10 @@ describe('panel', () => {
     });
   });
 
-  describe('panelToggle', () => {
+  describe('togglePanel', () => {
     test('calls toggle handler when button is clicked', () => {
       const toggleMock = jest.spyOn(options, 'onToggleHandler');
-      panelToggle(options);
+      togglePanel(options);
       options.toggleButton.dispatchEvent(new Event('click'));
       expect(toggleMock).toHaveBeenCalled();
     });
@@ -50,6 +58,20 @@ describe('panel', () => {
 
       options.toggleButton.dispatchEvent(new Event('click'));
       expect(container.classList.contains(CLOSED_CLASS)).toBe(false);
+    });
+
+    test('sets the correct initial state of the panel', () => {
+      panel.isInitialStateOpen = jest.fn(() => true);
+      panel.openPanel = jest.fn();
+      const openPanelMock = jest.spyOn(panel, 'openPanel');
+      togglePanel(options);
+      expect(openPanelMock).toHaveBeenCalledWith(options);
+
+      panel.isInitialStateOpen = jest.fn(() => false);
+      panel.closePanel = jest.fn();
+      const closePanelMock = jest.spyOn(panel, 'closePanel');
+      togglePanel(options);
+      expect(closePanelMock).toHaveBeenCalledWith(options);
     });
   });
 });


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-1165

- refactor open close/panel into separate script so is not coupled to filters specifically
- add tests for new panel component
- add persistence to open/closed state using local storage for each page load
- integrated with changes in master to do with column widths

Test Coverage

![Screenshot 2020-08-26 at 18 46 28](https://user-images.githubusercontent.com/1792451/91338253-91949580-e7cc-11ea-8a72-ebdc49c19981.png)
