### PR TITLE
[TEVA-1124] Add back button to job details page

### DIFF
--- a/app/controllers/hiring_staff/vacancies/job_location_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_location_controller.rb
@@ -6,7 +6,7 @@ class HiringStaff::Vacancies::JobLocationController < HiringStaff::Vacancies::Ap
   end
 
   def show
-    attributes = @vacancy.present? ? @vacancy.attributes : (session[:vacancy_attributes] || {})
+    attributes = @vacancy.present? ? @vacancy.attributes : (session[:vacancy_attributes]&.symbolize_keys || {})
     @form = JobLocationForm.new(attributes)
   end
 

--- a/app/views/hiring_staff/vacancies/job_specification/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/show.html.haml
@@ -7,6 +7,8 @@
 
 - if @vacancy.present? && @vacancy&.state != 'create'
   = render 'hiring_staff/vacancies/vacancy_form_partials/cancel_and_return_link'
+- else
+  = link_to t('buttons.back'), @previous_step_path, class: 'govuk-back-link'
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/hiring_staff/vacancies/school/show.html.haml
+++ b/app/views/hiring_staff/vacancies/school/show.html.haml
@@ -27,7 +27,7 @@
         :address,
         legend: { text: t('helpers.fieldset.school_form.job_location_html') }
 
-      = render 'hiring_staff/vacancies/vacancy_form_partials/submit', f: f
+      = render 'hiring_staff/vacancies/vacancy_form_partials/continue_or_update_submit', f: f
 
   .govuk-grid-column-one-third
     = render(HiringStaff::SidebarComponent.new(vacancy: @vacancy))

--- a/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
+++ b/spec/controllers/hiring_staff/vacancies/job_specification_controller_spec.rb
@@ -80,4 +80,47 @@ RSpec.describe HiringStaff::Vacancies::JobSpecificationController, type: :contro
       end
     end
   end
+
+  describe '#set_up_previous_step_path' do
+    before do
+      allow(session).to receive(:[]).with(:vacancy_attributes).and_return(vacancy_attributes)
+    end
+
+    context 'when current organisation is a School' do
+      let(:vacancy_attributes) { {} }
+
+      before do
+        allow(controller).to receive_message_chain(:current_organisation, :is_a?).with(School).and_return(true)
+      end
+
+      it 'sets the previous step path to the dashboard page' do
+        subject.send(:set_up_previous_step_path)
+        expect(controller.instance_variable_get(:@previous_step_path)).to eql(organisation_path)
+      end
+    end
+
+    context 'when current organisation is a SchoolGroup' do
+      before do
+        allow(controller).to receive_message_chain(:current_organisation, :is_a?).with(School).and_return(false)
+      end
+
+      context 'when job_location is at_one_school' do
+        let(:vacancy_attributes) { { 'job_location' => 'at_one_school' } }
+
+        it 'sets the previous step path to schools page' do
+          subject.send(:set_up_previous_step_path)
+          expect(controller.instance_variable_get(:@previous_step_path)).to eql(school_organisation_job_path)
+        end
+      end
+
+      context 'when job_location is central_office' do
+        let(:vacancy_attributes) { { 'job_location' => 'central_office' } }
+
+        it 'sets the previous step path to job_location page' do
+          subject.send(:set_up_previous_step_path)
+          expect(controller.instance_variable_get(:@previous_step_path)).to eql(job_location_organisation_job_path)
+        end
+      end
+    end
+  end
 end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_as_a_school_group_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_as_a_school_group_spec.rb
@@ -68,33 +68,68 @@ RSpec.feature 'Creating a vacancy' do
     end
 
     describe '#job_location' do
-      scenario 'redirects to job details when submitted successfully but vacancy is not created' do
-        visit new_organisation_job_path
+      context 'when no school is selected' do
+        scenario 'displays error message and vacancy is not created' do
+          visit new_organisation_job_path
 
-        expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 8))
-        within('h2.govuk-heading-l') do
-          expect(page).to have_content(I18n.t('jobs.job_location'))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 8))
+          within('h2.govuk-heading-l') do
+            expect(page).to have_content(I18n.t('jobs.job_location'))
+          end
+
+          fill_in_job_location_form_field(vacancy)
+          click_on I18n.t('buttons.continue')
+
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 8))
+          within('h2.govuk-heading-l') do
+            expect(page).to have_content(I18n.t('jobs.job_location'))
+          end
+
+          expect(Vacancy.count).to eql(0)
+
+          click_on I18n.t('buttons.continue')
+
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 8))
+          within('h2.govuk-heading-l') do
+            expect(page).to have_content(I18n.t('jobs.job_location'))
+          end
+          within('div.govuk-error-summary') do
+            expect(page).to have_content(I18n.t('school_errors.organisation_id.blank'))
+          end
+
+          expect(Vacancy.count).to eql(0)
         end
+      end
 
-        fill_in_job_location_form_field(vacancy)
-        click_on I18n.t('buttons.continue')
+      context 'when a school is selected' do
+        scenario 'redirects to job details when submitted successfully but vacancy is not created' do
+          visit new_organisation_job_path
 
-        expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 8))
-        within('h2.govuk-heading-l') do
-          expect(page).to have_content(I18n.t('jobs.job_location'))
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 8))
+          within('h2.govuk-heading-l') do
+            expect(page).to have_content(I18n.t('jobs.job_location'))
+          end
+
+          fill_in_job_location_form_field(vacancy)
+          click_on I18n.t('buttons.continue')
+
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 1, total: 8))
+          within('h2.govuk-heading-l') do
+            expect(page).to have_content(I18n.t('jobs.job_location'))
+          end
+
+          expect(Vacancy.count).to eql(0)
+
+          fill_in_school_form_field(school)
+          click_on I18n.t('buttons.continue')
+
+          expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 8))
+          within('h2.govuk-heading-l') do
+            expect(page).to have_content(I18n.t('jobs.job_details'))
+          end
+
+          expect(Vacancy.count).to eql(0)
         end
-
-        expect(Vacancy.count).to eql(0)
-
-        fill_in_school_form_field(school)
-        click_on I18n.t('buttons.continue')
-
-        expect(page).to have_content(I18n.t('jobs.current_step', step: 2, total: 8))
-        within('h2.govuk-heading-l') do
-          expect(page).to have_content(I18n.t('jobs.job_details'))
-        end
-
-        expect(Vacancy.count).to eql(0)
       end
     end
 


### PR DESCRIPTION
This PR adds a back button to the job details page. This link changes based on the options selected in the previous step.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1124

## Changes in this PR
- Fix bug where no school being selected would result in a page not found error
- Remove save and return later link from schools page
- Add back link to job details page
