### PR TITLE
[TEVA-1015] update vacancy review and job summary to handle multiple schools

### DIFF
--- a/app/frontend/styles/components/check_your_answers.scss
+++ b/app/frontend/styles/components/check_your_answers.scss
@@ -107,3 +107,13 @@ dt.app-check-your-answers__question > h4 {
   font-size: 19px;
   margin-left: 20px;
 }
+
+.app-check-your-answers__answer.schools-review-list {
+  .school-in-review-list {
+    margin-bottom: govuk-spacing(5);
+  }
+
+  .school-in-review-list:last-child {
+    margin-bottom: govuk-spacing(2);
+  }
+}

--- a/app/models/concerns/vacancy_job_summary_validations.rb
+++ b/app/models/concerns/vacancy_job_summary_validations.rb
@@ -9,12 +9,12 @@ module VacancyJobSummaryValidations
   def about_school_must_not_be_blank
     return if about_school.present?
     # Since vacancy is set by VacancyForm.initialize, it can be undefined here.
-    if defined?(vacancy) && vacancy&.job_location == 'central_office'
+    if job_location == 'central_office'
       organisation = 'trust'
-    elsif defined?(vacancy)
+    elsif job_location == 'at_one_school'
       organisation = 'school'
-    else
-      organisation = 'school or trust'
+    elsif job_location == 'at_multiple_schools'
+      organisation = 'schools'
     end
     errors.add(:about_school,
       I18n.t('job_summary_errors.about_school.blank',

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_location.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_location.html.haml
@@ -12,7 +12,8 @@
     %dt.app-check-your-answers__question.first-question#job_location
       %h4.govuk-heading-s= t("school_groups.job_location_heading.review.#{@vacancy.job_location}")
 
-    %dd.app-check-your-answers__answer.first-question
+    %dd.app-check-your-answers__answer.first-question.schools-review-list
       - @vacancy.organisations.each do |organisation|
-        %div{ class: 'govuk-!-font-weight-bold' }= organisation.name
-        = location(organisation)
+        .school-in-review-list
+          %div{ class: 'govuk-!-font-weight-bold' }= organisation.name
+          = full_address(organisation)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -675,6 +675,7 @@ en:
     job_location_heading:
       central_office: At head office
       at_one_school: Single school
+      at_multiple_schools: At more than one school in the trust
       review:
         central_office: Trust head office
         at_one_school: Single school

--- a/spec/form_models/job_summary_form_spec.rb
+++ b/spec/form_models/job_summary_form_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe JobSummaryForm, type: :model do
       let(:job_summary_form) { JobSummaryForm.new(about_school: nil, job_location: job_location) }
 
       context 'when about school is blank' do
-        context 'for a vacancy at a single school in a trust' do
+        context 'when vacancy job_location is at_one_school' do
           let(:job_location) { 'at_one_school' }
 
           it 'requests the user to complete the about school field' do
@@ -32,23 +32,23 @@ RSpec.describe JobSummaryForm, type: :model do
           end
         end
 
-        context 'for a vacancy at a single school NOT in a trust' do
-          let(:job_location) { nil }
-
-          it 'requests the user to complete the about school field' do
-            expect(job_summary_form.valid?).to be false
-            expect(job_summary_form.errors.messages[:about_school].first)
-              .to eq(I18n.t('job_summary_errors.about_school.blank', organisation: 'school'))
-          end
-        end
-
-        context 'for a vacancy at a school group' do
+        context 'when vacancy job_location is central_office' do
           let(:job_location) { 'central_office' }
 
           it 'requests the user to complete the about trust field' do
             expect(job_summary_form.valid?).to be false
             expect(job_summary_form.errors.messages[:about_school].first)
               .to eq(I18n.t('job_summary_errors.about_school.blank', organisation: 'trust'))
+          end
+        end
+
+        context 'when vacancy job_location is at_multiple_schools' do
+          let(:job_location) { 'at_multiple_schools' }
+
+          it 'requests the user to complete the about trust field' do
+            expect(job_summary_form.valid?).to be false
+            expect(job_summary_form.errors.messages[:about_school].first)
+              .to eq(I18n.t('job_summary_errors.about_school.blank', organisation: 'schools'))
           end
         end
       end

--- a/spec/form_models/job_summary_form_spec.rb
+++ b/spec/form_models/job_summary_form_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe JobSummaryForm, type: :model do
         context 'when vacancy job_location is at_multiple_schools' do
           let(:job_location) { 'at_multiple_schools' }
 
-          it 'requests the user to complete the about trust field' do
+          it 'requests the user to complete the about schools field' do
             expect(job_summary_form.valid?).to be false
             expect(job_summary_form.errors.messages[:about_school].first)
               .to eq(I18n.t('job_summary_errors.about_school.blank', organisation: 'schools'))

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -57,8 +57,7 @@ RSpec.describe Vacancy, type: :model do
     context 'a new record' do
       it 'should validate presence of about_school' do
         subject.about_school = ''
-        subject.valid?
-        expect(subject.errors[:about_school].first).to eq('Enter a description of the school or trust')
+        expect(subject.valid?).to be(false)
       end
       it { should validate_presence_of(:contact_email) }
       it { should validate_presence_of(:expires_on) }

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -4,6 +4,13 @@ module VacancyHelpers
     find("label[for=\"job-location-form-job-location-#{hyphenated_location}-field\"]").click
   end
 
+  def change_job_location(vacancy, location)
+    vacancy.job_location = location
+    click_header_link(I18n.t('jobs.job_location'))
+    fill_in_job_location_form_field(vacancy)
+    click_on I18n.t('buttons.update_job')
+  end
+
   def fill_in_school_form_field(school)
     find("label[for=\"schools-form-organisation-id-#{school.id}-field\"]").click
   end

--- a/spec/system/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/system/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -141,14 +141,14 @@ RSpec.describe 'Copying a vacancy' do
       within '#errors.govuk-notification--danger' do
         expect(page).to have_content(I18n.t('messages.jobs.action_required.heading'))
         expect(page).to have_content(I18n.t('messages.jobs.action_required.message'))
-        expect(page).to have_content(I18n.t('job_summary_errors.about_school.blank', organisation: 'school or trust'))
+        expect(page).to have_content(I18n.t('job_summary_errors.about_school.blank', organisation: 'school'))
       end
 
       click_on I18n.t('jobs.submit_listing.button')
       within '#errors.govuk-notification--danger' do
         expect(page).to have_content(I18n.t('messages.jobs.action_required.heading'))
         expect(page).to have_content(I18n.t('messages.jobs.action_required.message'))
-        expect(page).to have_content(I18n.t('job_summary_errors.about_school.blank', organisation: 'school or trust'))
+        expect(page).to have_content(I18n.t('job_summary_errors.about_school.blank', organisation: 'school'))
       end
 
       click_header_link(I18n.t('jobs.job_summary'))

--- a/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
@@ -25,10 +25,7 @@ RSpec.describe 'Editing a draft vacancy' do
         I18n.t('hiring_staff.organisations.readable_job_location.central_office')
       )
 
-      click_header_link(I18n.t('jobs.job_location'))
-      vacancy.job_location = 'at_one_school'
-      fill_in_job_location_form_field(vacancy)
-      click_on I18n.t('buttons.update_job')
+      change_job_location(vacancy, 'at_one_school')
 
       expect(page.current_path).to eql(organisation_job_schools_path(vacancy.id))
       fill_in_school_form_field(school_1)
@@ -39,10 +36,7 @@ RSpec.describe 'Editing a draft vacancy' do
       expect(page).to have_content(full_address(school_1))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_1.name)
 
-      click_header_link(I18n.t('jobs.job_location'))
-      vacancy.job_location = 'at_one_school'
-      fill_in_job_location_form_field(vacancy)
-      click_on I18n.t('buttons.update_job')
+      change_job_location(vacancy, 'at_one_school')
 
       expect(page.current_path).to eql(organisation_job_schools_path(vacancy.id))
       fill_in_school_form_field(school_2)
@@ -53,10 +47,7 @@ RSpec.describe 'Editing a draft vacancy' do
       expect(page).to have_content(full_address(school_2))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_2.name)
 
-      click_header_link(I18n.t('jobs.job_location'))
-      vacancy.job_location = 'at_multiple_schools'
-      fill_in_job_location_form_field(vacancy)
-      click_on I18n.t('buttons.update_job')
+      change_job_location(vacancy, 'at_multiple_schools')
 
       expect(page.current_path).to eql(organisation_job_schools_path(vacancy.id))
       check school_1.name, name: 'schools_form[organisation_ids][]', visible: false
@@ -67,10 +58,7 @@ RSpec.describe 'Editing a draft vacancy' do
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql('More than one school (2)')
 
-      click_header_link(I18n.t('jobs.job_location'))
-      vacancy.job_location = 'central_office'
-      fill_in_job_location_form_field(vacancy)
-      click_on I18n.t('buttons.update_job')
+      change_job_location(vacancy, 'central_office')
 
       expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))

--- a/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Editing a draft vacancy' do
       visit organisation_job_review_path(vacancy.id)
 
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
-      expect(page).to have_content(location(school_group))
+      expect(page).to have_content(full_address(school_group))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
         I18n.t('hiring_staff.organisations.readable_job_location.central_office')
       )
@@ -36,7 +36,7 @@ RSpec.describe 'Editing a draft vacancy' do
 
       expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
-      expect(page).to have_content(location(school_1))
+      expect(page).to have_content(full_address(school_1))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_1.name)
 
       click_header_link(I18n.t('jobs.job_location'))
@@ -50,7 +50,7 @@ RSpec.describe 'Editing a draft vacancy' do
 
       expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
-      expect(page).to have_content(location(school_2))
+      expect(page).to have_content(full_address(school_2))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_2.name)
 
       click_header_link(I18n.t('jobs.job_location'))
@@ -74,7 +74,7 @@ RSpec.describe 'Editing a draft vacancy' do
 
       expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
-      expect(page).to have_content(location(school_group))
+      expect(page).to have_content(full_address(school_group))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
         I18n.t('hiring_staff.organisations.readable_job_location.central_office')
       )

--- a/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Editing a published vacancy' do
 
       expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t('school_groups.job_location_heading.review.at_one_school'))
-      expect(page).to have_content(location(school_1))
+      expect(page).to have_content(full_address(school_1))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_1.name)
 
       click_header_link(I18n.t('jobs.job_location'))
@@ -50,7 +50,7 @@ RSpec.describe 'Editing a published vacancy' do
 
       expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t('school_groups.job_location_heading.review.at_one_school'))
-      expect(page).to have_content(location(school_2))
+      expect(page).to have_content(full_address(school_2))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_2.name)
 
       click_header_link(I18n.t('jobs.job_location'))

--- a/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
@@ -25,10 +25,7 @@ RSpec.describe 'Editing a published vacancy' do
         I18n.t('hiring_staff.organisations.readable_job_location.central_office')
       )
 
-      click_header_link(I18n.t('jobs.job_location'))
-      vacancy.job_location = 'at_one_school'
-      fill_in_job_location_form_field(vacancy)
-      click_on I18n.t('buttons.update_job')
+      change_job_location(vacancy, 'at_one_school')
 
       expect(page.current_path).to eql(organisation_job_schools_path(vacancy.id))
       fill_in_school_form_field(school_1)
@@ -39,10 +36,7 @@ RSpec.describe 'Editing a published vacancy' do
       expect(page).to have_content(full_address(school_1))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_1.name)
 
-      click_header_link(I18n.t('jobs.job_location'))
-      vacancy.job_location = 'at_one_school'
-      fill_in_job_location_form_field(vacancy)
-      click_on I18n.t('buttons.update_job')
+      change_job_location(vacancy, 'at_one_school')
 
       expect(page.current_path).to eql(organisation_job_schools_path(vacancy.id))
       fill_in_school_form_field(school_2)
@@ -53,10 +47,7 @@ RSpec.describe 'Editing a published vacancy' do
       expect(page).to have_content(full_address(school_2))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_2.name)
 
-      click_header_link(I18n.t('jobs.job_location'))
-      vacancy.job_location = 'at_multiple_schools'
-      fill_in_job_location_form_field(vacancy)
-      click_on I18n.t('buttons.update_job')
+      change_job_location(vacancy, 'at_multiple_schools')
 
       expect(page.current_path).to eql(organisation_job_schools_path(vacancy.id))
       check school_1.name, name: 'schools_form[organisation_ids][]', visible: false
@@ -67,10 +58,7 @@ RSpec.describe 'Editing a published vacancy' do
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.review.#{vacancy.job_location}"))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql('More than one school (2)')
 
-      click_header_link(I18n.t('jobs.job_location'))
-      vacancy.job_location = 'central_office'
-      fill_in_job_location_form_field(vacancy)
-      click_on I18n.t('buttons.update_job')
+      change_job_location(vacancy, 'central_office')
 
       expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t('school_groups.job_location_heading.review.central_office'))


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-1014
https://dfedigital.atlassian.net/browse/TEVA-1015

## Changes in this PR:

- Changes to the job summary section to ensure that 'About the schools' is displayed as a field's label and the hint text is different when the job is at multiple schools

- Changes to validation error messages so an appropriate message is displayed when the job is at multiple schools

- Changes to the 'Review the job listing' page to ensure that multiple schools can be displayed in the job location section and to make sure that that 'About the schools' is displayed in the relevant section when the job is associated with multiple schools

- Job Summary about school section (when job is at multiple schools)

<img width="977" alt="Screenshot 2020-08-27 at 17 07 20" src="https://user-images.githubusercontent.com/30624173/91467254-40e27280-e888-11ea-97ba-8fa495eca252.png">

- Review page job location

<img width="891" alt="Screenshot 2020-08-27 at 17 07 31" src="https://user-images.githubusercontent.com/30624173/91467323-5788c980-e888-11ea-8368-0613ea1cbefb.png">

- Review page job summary 

<img width="865" alt="Screenshot 2020-08-27 at 17 07 42" src="https://user-images.githubusercontent.com/30624173/91467366-61aac800-e888-11ea-9a82-c4b703caba55.png">

- Error message

<img width="921" alt="Screenshot 2020-08-27 at 17 12 40" src="https://user-images.githubusercontent.com/30624173/91467492-8d2db280-e888-11ea-9740-4b716acca77d.png">

- Not sure about some of the variable names. Any suggestions for changes are welcome