### PR TITLE
Update webpack-dev-server to 3.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "stylelint-config-standard": "^20.0.0",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10",
-    "webpack-dev-server": "^3.10.1"
+    "webpack-dev-server": "^3.11.0"
   },
   "scripts": {
     "server": "rails s -b 'ssl://localhost:3000?key=config/localhost/https/local.key&cert=config/localhost/https/local.crt'",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10478,7 +10478,7 @@ webpack-dev-middleware@^3.7.2:
     range-parser "^1.2.1"
     webpack-log "^2.0.0"
 
-webpack-dev-server@^3.10.1:
+webpack-dev-server@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz#8f154a3bce1bcfd1cc618ef4e703278855e7ff8c"
   integrity sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==


### PR DESCRIPTION
This fixed errors in local development experienced by Connor and David, where Webpacker could not compile due to 'Webpacker can't find application.css'.

Please checkout the branch and successfully run the server before approving.

I updated package.json because although we use yarn, (a) this PR is not about deleting package.json, and (b) I would rather have an up-to-date package.json than an out of date package.json.
