### PR TITLE
Remove padding change which breaks GOV.UK grid

### DIFF
--- a/app/components/hiring_staff/vacancies_component.rb
+++ b/app/components/hiring_staff/vacancies_component.rb
@@ -23,7 +23,7 @@ class HiringStaff::VacanciesComponent < ViewComponent::Base
   end
 
   def grid_column_class
-    @organisation.is_a?(SchoolGroup) ? 'govuk-grid-column-two-thirds govuk-!-padding-right-0' : 'govuk-grid-column-full'
+    @organisation.is_a?(SchoolGroup) ? 'govuk-grid-column-two-thirds' : 'govuk-grid-column-full'
   end
 
   def filters_applied_text


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1236

## Changes in this PR:

- As per PR title. This change prevents elements from spilling out of the grid container.

## Screenshots of UI changes:

### Before

The screenshots of the broken grid are in the Jira ticket

### After

#### School dashboard
<img width="1440" alt="Screenshot 2020-09-01 at 10 45 40" src="https://user-images.githubusercontent.com/60350599/91834969-a8117580-ec40-11ea-9baf-6a2daa51ee80.png">

#### Trust dashboard with filters sidebar open/closed
<img width="1440" alt="Screenshot 2020-09-01 at 10 44 41" src="https://user-images.githubusercontent.com/60350599/91834974-a9db3900-ec40-11ea-8340-29eeeca16a58.png">
<img width="1440" alt="Screenshot 2020-09-01 at 10 45 04" src="https://user-images.githubusercontent.com/60350599/91834979-ab0c6600-ec40-11ea-9374-18450c83abce.png">

