### PR TITLE
Ensure form renders selected job roles

### DIFF
--- a/app/helpers/vacancies_options_helper.rb
+++ b/app/helpers/vacancies_options_helper.rb
@@ -12,7 +12,7 @@ module VacanciesOptionsHelper
 
   def job_role_options
     Vacancy::JOB_ROLE_OPTIONS.except(:nqt_suitable).map do |key, _value|
-      [I18n.t("jobs.job_role_options.#{key}"), key]
+      [I18n.t("jobs.job_role_options.#{key}"), key.to_s]
     end
   end
 

--- a/spec/helpers/vacancies_options_helper_spec.rb
+++ b/spec/helpers/vacancies_options_helper_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe VacanciesOptionsHelper, type: :helper do
     end
   end
 
+  describe '#job_role_options' do
+    it 'returns an array of vacancy job role options' do
+      expect(helper.job_role_options).to eq(
+        [
+          ['Teacher', 'teacher'],
+          ['Leadership', 'leadership'],
+          ['SEN specialist', 'sen_specialist']
+        ]
+      )
+    end
+  end
+
   describe '#job_sorting_options' do
     it 'returns an array of vacancy job sorting options' do
       expect(helper.job_sorting_options).to eq(


### PR DESCRIPTION
Array_enum returns job_roles as strings, so the options need to have string values otherwise they won't be selected in the form.
