### PR TITLE
Disable the radius input if the input value does not contain a number

### DIFF
--- a/app/frontend/src/search/ui/input/location.js
+++ b/app/frontend/src/search/ui/input/location.js
@@ -1,8 +1,10 @@
-import { enableRadiusSelect } from './radius';
+import { enableRadiusSelect, disableRadiusSelect } from './radius';
 
 export const onChange = (value) => {
   if (/\d/.test(value)) {
     enableRadiusSelect();
+  } else {
+    disableRadiusSelect();
   }
 };
 

--- a/app/frontend/src/search/ui/input/location.test.js
+++ b/app/frontend/src/search/ui/input/location.test.js
@@ -11,7 +11,7 @@ describe('location search box', () => {
   describe('onChange (input)', () => {
     test('disables the radius input if the input value does not contain a number', () => {
       onChange('london');
-      expect(disableRadiusSelect).not.toHaveBeenCalled();
+      expect(disableRadiusSelect).toHaveBeenCalledTimes(1);
     });
 
     test('enables the radius input if the input value does contain a number', () => {


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1140

## Changes in this PR:

We already show the radius whenever the location input contains a number (i.e. is probably a postcode).

This PR changes a test and JS, so that when the location input has *no* number, we *dis*able the location input. 