### PR TITLE
Prevent noisy-logging jobs running outside production

### DIFF
--- a/app/jobs/export_dsi_users_to_big_query_job.rb
+++ b/app/jobs/export_dsi_users_to_big_query_job.rb
@@ -5,7 +5,9 @@ class ExportDsiUsersToBigQueryJob < ApplicationJob
   queue_as :export_users
 
   def perform
-    ExportDsiUsersToBigQuery.new.run!
-    ExportDsiApproversToBigQuery.new.run!
+    if Rails.env.production?
+      ExportDsiUsersToBigQuery.new.run!
+      ExportDsiApproversToBigQuery.new.run!
+    end
   end
 end

--- a/app/jobs/update_schools_data_from_source_job.rb
+++ b/app/jobs/update_schools_data_from_source_job.rb
@@ -4,6 +4,6 @@ class UpdateSchoolsDataFromSourceJob < ApplicationJob
   queue_as :import_school_data
 
   def perform
-    UpdateSchoolData.new.run!
+    UpdateSchoolData.new.run! if Rails.env.production?
   end
 end

--- a/spec/jobs/update_schools_data_from_source_job_spec.rb
+++ b/spec/jobs/update_schools_data_from_source_job_spec.rb
@@ -13,11 +13,23 @@ RSpec.describe UpdateSchoolsDataFromSourceJob, type: :job do
     expect(job.queue_name).to eq('import_school_data')
   end
 
-  it 'executes perform' do
-    update_school_data = double(:mock)
-    expect(UpdateSchoolData).to receive(:new).and_return(update_school_data)
-    expect(update_school_data).to receive(:run!)
+  context 'when in the production environment' do
+    before { allow(Rails.env).to receive(:production?).and_return(true) }
 
-    perform_enqueued_jobs { job }
+    it 'executes perform' do
+      update_school_data = double(:mock)
+      expect(UpdateSchoolData).to receive(:new).and_return(update_school_data)
+      expect(update_school_data).to receive(:run!)
+
+      perform_enqueued_jobs { job }
+    end
+  end
+
+  context 'when in non-production environments' do
+    it 'does not execute perform' do
+      expect(UpdateSchoolData).not_to receive(:new)
+
+      perform_enqueued_jobs { job }
+    end
   end
 end


### PR DESCRIPTION
Hoping to merge at half-completed because the logging noise might cost us money.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1228

## Changes in this PR:

- Address 2 of 4 of the noisy-logging errors listed in the ticket.
- Do this by checking environment before running jobs.

## Next steps:

- [ ] Quieten more errors
