### PR TITLE
[TEVA-797] staging.tfvars fix CloudFront domain

### DIFF
--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -12,7 +12,7 @@ distribution_list = {
     offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
     offline_bucket_origin_path    = "/school-jobs-offline"
     cloudfront_origin_domain_name = "teaching-vacancies-staging.london.cloudapps.digital"
-    domain                        = "staging.teaching-vacancies.service.gov.uk"
+    domain                        = "tvs.staging.dxw.net"
   }
 }
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-797

## Changes in this PR:

- In `staging.tfvars`, revert CloudFront domain to previous value for continued DSI integration. Has been tested in staging via a local `terraform apply`, then going to https://tvs.staging.dxw.net/ and clicking the "Sign in" button.