### PR TITLE
[TEVA-1018] Render job details notification box when there are multiple schools and create notification view component

### DIFF
--- a/app/components/notification_component.html.haml
+++ b/app/components/notification_component.html.haml
@@ -1,0 +1,9 @@
+.govuk-notification.js-dismissable{role: 'alert', tabindex: '-1', class: notification_classes}
+  - if @dismiss
+    %a.govuk-link.govuk-link--no-visited-state.dismiss-link.js-dismissable__link{ href: '#' }
+      = t('buttons.dismiss')
+  - if render_title_and_body?
+    .govuk-notification__title= content[:title]
+    .govuk-notification__body= raw content[:body]
+  - else
+    .govuk-notification__body= raw content

--- a/app/components/notification_component.rb
+++ b/app/components/notification_component.rb
@@ -1,0 +1,20 @@
+class NotificationComponent < ViewComponent::Base
+  def initialize(content:, style:, dismiss: true, background: false, alert: false)
+    @content = content
+    @style = style
+    @dismiss = style == 'danger' ? false : dismiss
+    @background = background
+    @alert = %w[danger success].include?(style) ? false : alert
+  end
+
+  def notification_classes
+    applied_class = "govuk-notification--#{@style}"
+    applied_class += ' govuk-notification__background' if @background
+    applied_class += ' alert' if @alert
+    applied_class
+  end
+
+  def render_title_and_body?
+    @content.is_a?(Hash) && @content[:title].present? && @content[:body].present?
+  end
+end

--- a/app/frontend/styles/components/flashes.scss
+++ b/app/frontend/styles/components/flashes.scss
@@ -42,10 +42,6 @@
   border-color: govuk-colour('blue');
 }
 
-.govuk-notification--notice__background {
-  background-color: rgba($color: govuk-colour('blue'), $alpha: 0.1);
-}
-
 .govuk-notification--success {
   background-image: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" fill="%2300703c" width="25" height="25" viewBox="0 0 25 25"><path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" ></path></svg>');
   background-position: top 20px left 15px;
@@ -66,6 +62,18 @@
   .govuk-notification__list a {
     color: govuk-colour('red');
   }
+}
+
+.govuk-notification--notice.govuk-notification__background {
+  background-color: rgba($color: govuk-colour('blue'), $alpha: 0.1);
+}
+
+.govuk-notification--success.govuk-notification__background {
+  background-color: rgba($color: govuk-colour('green'), $alpha: 0.1);
+}
+
+.govuk-notification--danger.govuk-notification__background {
+  background-color: rgba($color: govuk-colour('red'), $alpha: 0.1);
 }
 
 .alert {

--- a/app/views/hiring_staff/sign_in/email/sessions/choose_organisation.html.haml
+++ b/app/views/hiring_staff/sign_in/email/sessions/choose_organisation.html.haml
@@ -3,12 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     - if @reason_for_failing_sign_in
-      .govuk-notification.govuk-notification--notice{ aria: { labelledby: "govuk-notification__title" }, role: "alert", tabindex: "-1" }
-        %h2.govuk-notification__title
-          =t('hiring_staff.temp_login.choose_organisation.denial.title')
-        .govuk-notification__body
-          =t("hiring_staff.temp_login.choose_organisation.denial.#{@reason_for_failing_sign_in}_html",
-            try_again: (link_to 'try again', new_identifications_path, class: 'govuk-link'))
+      = render(NotificationComponent.new(content: { title: t('hiring_staff.temp_login.choose_organisation.denial.title'), body: t("hiring_staff.temp_login.choose_organisation.denial.#{@reason_for_failing_sign_in}_html", try_again: link_to('try again', new_identifications_path, class: 'govuk-link')) }, style: 'notice', background: true, dismiss: false))
     - else
       %h1.govuk-heading-l= t('hiring_staff.temp_login.choose_organisation.heading')
 

--- a/app/views/hiring_staff/sign_in/email/sessions/new.html.haml
+++ b/app/views/hiring_staff/sign_in/email/sessions/new.html.haml
@@ -1,11 +1,7 @@
 - content_for :page_title_prefix, t('sign_in.title')
 
 .govuk-grid-row
-  .govuk-notification.govuk-notification--danger{ aria: { labelledby: "govuk-notification__title" }, role: "alert", tabindex: "-1" }
-    %h2.govuk-notification__title
-      =t('hiring_staff.temp_login.heading')
-    .govuk-notification__body
-      =t('hiring_staff.temp_login.please_use_email')
+  = render(NotificationComponent.new(content: { title: t('hiring_staff.temp_login.heading'), body: t('hiring_staff.temp_login.please_use_email') }, style: 'danger'))
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-l= t('sign_in.title')
     %p= t('pages.home.signin.description')

--- a/app/views/hiring_staff/vacancies/_error_tag.html.haml
+++ b/app/views/hiring_staff/vacancies/_error_tag.html.haml
@@ -1,4 +1,4 @@
 - attributes.each do |attribute|
   - if @vacancy.errors.messages.keys.include?(attribute)
-    %strong.govuk-tag.action-required-tag{ class: "action-required--#{section}" }= t('jobs.notification_labels.action_required')
+    %strong.govuk-tag.action-required-tag{ class: "action-required--#{section}" }= t('jobs.notifications.labels.action_required')
     - break

--- a/app/views/hiring_staff/vacancies/_section_tag.html.haml
+++ b/app/views/hiring_staff/vacancies/_section_tag.html.haml
@@ -1,2 +1,2 @@
 - if new_sections(@vacancy).include?(section)
-  %strong.govuk-tag.notification-tag{ class: "new--#{section}" }= t('jobs.notification_labels.new')
+  %strong.govuk-tag.notification-tag{ class: "new--#{section}" }= t('jobs.notifications.labels.new')

--- a/app/views/nqt_job_alerts/new.html.haml
+++ b/app/views/nqt_job_alerts/new.html.haml
@@ -32,7 +32,6 @@
 
       = recaptcha_v3(action: 'subscription')
 
-      .govuk-notification.govuk-notification--notice.govuk-notification--notice__background.alert
-        .govuk-notification__body= t('nqt_job_alerts.intro.unsubscribe')
+      = render(NotificationComponent.new(content: t('nqt_job_alerts.intro.unsubscribe'), style: 'notice', background: true, alert: true))
 
       = f.govuk_submit t('buttons.subscribe'), classes: 'nqt-job-alert-subscribe-gtm'

--- a/app/views/shared/_flash_messages.html.haml
+++ b/app/views/shared/_flash_messages.html.haml
@@ -1,11 +1,2 @@
 - flash.each do |style, message|
-  .govuk-notification.js-dismissable{role: 'alert', tabindex: '-1', class: "govuk-notification--#{style}"}
-    - unless style == 'danger'
-      %a.govuk-link.govuk-link--no-visited-state.dismiss-link.js-dismissable__link{ href: '#' }
-        = t('buttons.dismiss')
-
-    - if message.is_a?(Hash) && message.key?(:title) && message.key?(:body)
-      .govuk-notification__title= message[:title]
-      .govuk-notification__body= raw message[:body]
-    - else
-      .govuk-notification__body= raw message
+  = render(NotificationComponent.new(content: message, style: style))

--- a/app/views/shared/vacancy/_jobseeker_view.html.haml
+++ b/app/views/shared/vacancy/_jobseeker_view.html.haml
@@ -15,6 +15,9 @@
 
   .govuk-grid-column-two-thirds
 
+    - if @vacancy.organisations.many?
+      = render(NotificationComponent.new(content: t('jobs.notifications.content.multi_school_job_notification_html'), style: 'notice', background: true, dismiss: false, alert: true))
+
     .govuk-tabs{"data-module": "govuk-tabs"}
       %h2.govuk-tabs__title
         = t('jobs.key_info')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -261,9 +261,12 @@ en:
         zero: Showing all jobs
         one: 1 filter applied
         other: '%{count} filters applied'
-    notification_labels:
-      new: new
-      action_required: action required
+    notifications:
+      content:
+        multi_school_job_notification_html: This teaching role is at <span class="govuk-!-font-weight-bold">more than one school in the trust</span>. You can find out more in Schools overview.
+      labels:
+        action_required: action required
+        new: new
     heading: 'Find a job in teaching'
     location_description: >-
       Find teaching jobs in %{location} on Teaching Vacancies, the free national job site for teachers,

--- a/spec/components/notification_component_spec.rb
+++ b/spec/components/notification_component_spec.rb
@@ -6,108 +6,116 @@ RSpec.describe NotificationComponent, type: :component do
   let(:dismiss) { true }
   let(:background) { false }
   let(:alert) { false }
-  let!(:inline_component) { render_inline(NotificationComponent.new(content: content, style: style, dismiss: dismiss, background: background, alert: alert)) }
-
-  context 'when content is a string' do
-    it 'renders content in the body' do
-      expect(inline_component.css('.govuk-notification__body').to_html).to include(content)
-    end
+  let!(:inline_component) do
+    render_inline(NotificationComponent.new(
+                    content: content,
+                    style: style,
+                    dismiss: dismiss,
+                    background: background,
+                    alert: alert,
+                  ))
   end
 
-  context 'when content is a hash' do
-    let(:content) { { title: 'Title', body: 'This is the body' } }
-
-    it 'renders the title' do
-      expect(inline_component.css('.govuk-notification__title').to_html).to include(content[:title])
-    end
-
-    it 'renders the body' do
-      expect(inline_component.css('.govuk-notification__body').to_html).to include(content[:body])
-    end
-  end
-
-  context 'when dismiss is true' do
-    it 'renders the dismiss link' do
-      expect(inline_component.css('.dismiss-link').to_html).to include(I18n.t('buttons.dismiss'))
-    end
-  end
-
-  context 'when dismiss is false' do
-    let(:dismiss) { false }
-
-    it 'does not render the dismiss link' do
-      expect(rendered_component).to_not include(I18n.t('buttons.dismiss'))
-    end
-  end
-
-  context 'when style is notice' do
-    it 'applies correct style' do
-      expect(inline_component.css('.govuk-notification--notice')).to_not be_blank
-    end
-  end
-
-  context 'when style is success' do
-    let(:style) { 'success' }
-
-    it 'applies correct style' do
-      expect(inline_component.css('.govuk-notification--success')).to_not be_blank
-    end
-  end
-
-  context 'when style is danger' do
-    let(:style) { 'danger' }
-
-    it 'does not render the dismiss link' do
-      expect(rendered_component).to_not include(I18n.t('buttons.dismiss'))
-    end
-
-    it 'applies correct style' do
-      expect(inline_component.css('.govuk-notification--danger')).to_not be_blank
-    end
-  end
-
-  context 'when background is true' do
-    let(:background) { true }
-
-    it 'applies the background style' do
-      expect(inline_component.css('.govuk-notification__background')).to_not be_blank
-    end
-  end
-
-  context 'when background is false' do
-    it 'does not apply the background style' do
-      expect(inline_component.css('.govuk-notification__background')).to be_blank
-    end
-  end
-
-  context 'when style is success' do
-    let(:style) { 'success' }
-
-    it 'does not apply the alert style' do
-      expect(inline_component.css('.alert')).to be_blank
-    end
-  end
-
-  context 'when style is danger' do
-    let(:style) { 'danger' }
-
-    it 'does not apply the alert style' do
-      expect(inline_component.css('.alert')).to be_blank
-    end
-  end
-
-  context 'when style is notice' do
-    context 'when alert is true' do
-      let(:alert) { true }
-
-      it 'applies the alert style' do
-        expect(inline_component.css('.alert')).to_not be_blank
+  describe '#content' do
+    context 'when content is a string' do
+      it 'renders content in the body' do
+        expect(inline_component.css('.govuk-notification__body').to_html).to include('This is content')
       end
     end
 
-    context 'when alert is false' do
-      it 'does not apply the alert style' do
+    context 'when content is a hash' do
+      let(:content) { { title: 'Title', body: 'This is the body' } }
+
+      it 'renders the title' do
+        expect(inline_component.css('.govuk-notification__title').to_html).to include('Title')
+      end
+
+      it 'renders the body' do
+        expect(inline_component.css('.govuk-notification__body').to_html).to include('This is the body')
+      end
+    end
+  end
+
+  describe '#dismiss' do
+    context 'when dismiss is true' do
+      it 'renders the dismiss link' do
+        expect(inline_component.css('.dismiss-link').to_html).to include(I18n.t('buttons.dismiss'))
+      end
+    end
+
+    context 'when dismiss is false' do
+      let(:dismiss) { false }
+
+      it 'does not render the dismiss link' do
+        expect(rendered_component).to_not include(I18n.t('buttons.dismiss'))
+      end
+    end
+  end
+
+  describe '#style' do
+    context 'when style is notice' do
+      it 'applies correct class' do
+        expect(inline_component.css('.govuk-notification--notice')).to_not be_blank
+      end
+
+      context 'when alert is true' do
+        let(:alert) { true }
+
+        it 'applies the alert class' do
+          expect(inline_component.css('.alert')).to_not be_blank
+        end
+      end
+
+      context 'when alert is false' do
+        it 'does not apply the alert class' do
+          expect(inline_component.css('.alert')).to be_blank
+        end
+      end
+    end
+
+    context 'when style is success' do
+      let(:style) { 'success' }
+      let(:alert) { true }
+
+      it 'applies correct class' do
+        expect(inline_component.css('.govuk-notification--success')).to_not be_blank
+      end
+
+      it 'does not apply the alert class' do
         expect(inline_component.css('.alert')).to be_blank
+      end
+    end
+
+    context 'when style is danger' do
+      let(:style) { 'danger' }
+      let(:alert) { true }
+
+      it 'does not render the dismiss link' do
+        expect(rendered_component).to_not include(I18n.t('buttons.dismiss'))
+      end
+
+      it 'applies correct class' do
+        expect(inline_component.css('.govuk-notification--danger')).to_not be_blank
+      end
+
+      it 'does not apply the alert class' do
+        expect(inline_component.css('.alert')).to be_blank
+      end
+    end
+  end
+
+  describe '#background' do
+    context 'when background is true' do
+      let(:background) { true }
+
+      it 'applies the background class' do
+        expect(inline_component.css('.govuk-notification__background')).to_not be_blank
+      end
+    end
+
+    context 'when background is false' do
+      it 'does not apply the background class' do
+        expect(inline_component.css('.govuk-notification__background')).to be_blank
       end
     end
   end

--- a/spec/components/notification_component_spec.rb
+++ b/spec/components/notification_component_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe NotificationComponent, type: :component do
+  let(:content) { 'This is content' }
+  let(:style) { 'notice' }
+  let(:dismiss) { true }
+  let(:background) { false }
+  let(:alert) { false }
+  let!(:inline_component) { render_inline(NotificationComponent.new(content: content, style: style, dismiss: dismiss, background: background, alert: alert)) }
+
+  context 'when content is a string' do
+    it 'renders content in the body' do
+      expect(inline_component.css('.govuk-notification__body').to_html).to include(content)
+    end
+  end
+
+  context 'when content is a hash' do
+    let(:content) { { title: 'Title', body: 'This is the body' } }
+
+    it 'renders the title' do
+      expect(inline_component.css('.govuk-notification__title').to_html).to include(content[:title])
+    end
+
+    it 'renders the body' do
+      expect(inline_component.css('.govuk-notification__body').to_html).to include(content[:body])
+    end
+  end
+
+  context 'when dismiss is true' do
+    it 'renders the dismiss link' do
+      expect(inline_component.css('.dismiss-link').to_html).to include(I18n.t('buttons.dismiss'))
+    end
+  end
+
+  context 'when dismiss is false' do
+    let(:dismiss) { false }
+
+    it 'does not render the dismiss link' do
+      expect(rendered_component).to_not include(I18n.t('buttons.dismiss'))
+    end
+  end
+
+  context 'when style is notice' do
+    it 'applies correct style' do
+      expect(inline_component.css('.govuk-notification--notice')).to_not be_blank
+    end
+  end
+
+  context 'when style is success' do
+    let(:style) { 'success' }
+
+    it 'applies correct style' do
+      expect(inline_component.css('.govuk-notification--success')).to_not be_blank
+    end
+  end
+
+  context 'when style is danger' do
+    let(:style) { 'danger' }
+
+    it 'does not render the dismiss link' do
+      expect(rendered_component).to_not include(I18n.t('buttons.dismiss'))
+    end
+
+    it 'applies correct style' do
+      expect(inline_component.css('.govuk-notification--danger')).to_not be_blank
+    end
+  end
+
+  context 'when background is true' do
+    let(:background) { true }
+
+    it 'applies the background style' do
+      expect(inline_component.css('.govuk-notification__background')).to_not be_blank
+    end
+  end
+
+  context 'when background is false' do
+    it 'does not apply the background style' do
+      expect(inline_component.css('.govuk-notification__background')).to be_blank
+    end
+  end
+
+  context 'when style is success' do
+    let(:style) { 'success' }
+
+    it 'does not apply the alert style' do
+      expect(inline_component.css('.alert')).to be_blank
+    end
+  end
+
+  context 'when style is danger' do
+    let(:style) { 'danger' }
+
+    it 'does not apply the alert style' do
+      expect(inline_component.css('.alert')).to be_blank
+    end
+  end
+
+  context 'when style is notice' do
+    context 'when alert is true' do
+      let(:alert) { true }
+
+      it 'applies the alert style' do
+        expect(inline_component.css('.alert')).to_not be_blank
+      end
+    end
+
+    context 'when alert is false' do
+      it 'does not apply the alert style' do
+        expect(inline_component.css('.alert')).to be_blank
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1018

## Changes in this PR:

- Created view component for notification boxes
- Added new css selectors for notification box style-dependent background colours
- Render component if vacancy is associated with many organisations
- Added translations and changed old translations to fit into new structure

## Screenshots of UI changes:

### Before

![Screenshot 2020-09-02 at 16 55 20](https://user-images.githubusercontent.com/30624173/92006852-23f0e800-ed3d-11ea-9d3d-29f63a00cb7a.png)

### After

![Screenshot 2020-09-02 at 16 56 58](https://user-images.githubusercontent.com/30624173/92007043-5864a400-ed3d-11ea-81ee-b2729f37a9ce.png)

