### PR TITLE
Refactor vacancy.organisation to vacancy.parent_organisation

### DIFF
--- a/app/components/jobseekers/school_group_overview_component.html.haml
+++ b/app/components/jobseekers/school_group_overview_component.html.haml
@@ -7,7 +7,7 @@
         %td.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
           = t('school_groups.type')
         %td.govuk-table__cell
-          = @vacancy.organisation.group_type
+          = @vacancy.parent_organisation.group_type
       - if @vacancy.contact_email.present?
         %tr.govuk-table__row
           %td.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
@@ -16,23 +16,23 @@
             = mail_to @vacancy.contact_email, @vacancy.contact_email, class: 'govuk-link link-wrap', subject: t('jobs.contact_email_subject', job: @vacancy.job_title), body: t('jobs.contact_email_body', url: job_url(@vacancy))
 
   %h4.govuk-heading-s
-    = t('school_groups.info', school_group: @vacancy.organisation.name)
+    = t('school_groups.info', school_group: @vacancy.parent_organisation.name)
   %p= vacancy_or_organisation_description(@vacancy)
 
   %h4.govuk-heading-s
-    = t('school_groups.trust_visits', school_group: @vacancy.organisation.name)
+    = t('school_groups.trust_visits', school_group: @vacancy.parent_organisation.name)
   %p= @vacancy.school_visits
 
   %h4.govuk-heading-s
     = t('school_groups.school_group_location')
-  %p= full_address(@vacancy.organisation)
+  %p= full_address(@vacancy.parent_organisation)
 
   -# TODO: Unable to show the map as we cannot extract geolocation data from GIAS
 
-  -# - if @vacancy.organisation.geolocation
+  -# - if @vacancy.parent_organisation.geolocation
   -#   %div{ id: 'map_zoom', role: 'presentation', aria: { hidden: 'true', label: t('schools.map_aria_label') },  }
-  -#   = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.organisation.name,
-  -#                                                         lat: @vacancy.organisation.geolocation.x,
-  -#                                                         lng: @vacancy.organisation.geolocation.y }
+  -#   = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.parent_organisation.name,
+  -#                                                         lat: @vacancy.parent_organisation.geolocation.x,
+  -#                                                         lng: @vacancy.parent_organisation.geolocation.y }
 
   -#   %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}

--- a/app/components/jobseekers/school_overview_component.html.haml
+++ b/app/components/jobseekers/school_overview_component.html.haml
@@ -7,28 +7,28 @@
         %td.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
           = t('schools.type')
         %td.govuk-table__cell
-          = organisation_type(organisation: @vacancy.organisation, with_age_range: false)
+          = organisation_type(organisation: @vacancy.parent_organisation, with_age_range: false)
       %tr.govuk-table__row
         %td.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
           = t('schools.phase')
         %td.govuk-table__cell
-          = school_phase(@vacancy.organisation)
+          = school_phase(@vacancy.parent_organisation)
       %tr.govuk-table__row
         %td.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
           = t('schools.school_size')
         %td.govuk-table__cell
-          = school_size(@vacancy.organisation)
+          = school_size(@vacancy.parent_organisation)
       %tr.govuk-table__row
         %td.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
           = t('schools.age_range')
         %td.govuk-table__cell
-          = age_range(@vacancy.organisation)
+          = age_range(@vacancy.parent_organisation)
       %tr.govuk-table__row
         %td.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
           = t('schools.ofsted_report')
-        - if ofsted_report(@vacancy.organisation).present?
+        - if ofsted_report(@vacancy.parent_organisation).present?
           %td.govuk-table__cell
-            = link_to(t('schools.view_ofsted_report'), ofsted_report(@vacancy.organisation), class: 'govuk-link wordwrap', target: '_blank')
+            = link_to(t('schools.view_ofsted_report'), ofsted_report(@vacancy.parent_organisation), class: 'govuk-link wordwrap', target: '_blank')
         - else
           %td.govuk-table__cell
             = t('schools.no_information')
@@ -36,7 +36,7 @@
         %td.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
           = t('schools.website')
         %td.govuk-table__cell
-          = link_to("#{@vacancy.organisation.name} website (opens in a new window)", @vacancy.organisation.url, class: 'govuk-link link-wrap', target: '_blank')
+          = link_to("#{@vacancy.parent_organisation.name} website (opens in a new window)", @vacancy.parent_organisation.url, class: 'govuk-link link-wrap', target: '_blank')
       - if @vacancy.contact_email.present?
         %tr.govuk-table__row
           %td.govuk-table__cell{ class: "govuk-!-font-weight-bold" }
@@ -46,22 +46,22 @@
 
   - if @vacancy.about_school.present?
     %h4.govuk-heading-s
-      = t('schools.info', organisation: @vacancy.organisation.name)
+      = t('schools.info', organisation: @vacancy.parent_organisation.name)
     %p= vacancy_or_organisation_description(@vacancy)
 
   - if @vacancy.school_visits.present?
     %h4.govuk-heading-s
-      = t('jobs.school_visits_heading', school: @vacancy.organisation.name)
+      = t('jobs.school_visits_heading', school: @vacancy.parent_organisation.name)
     %p= @vacancy.school_visits
 
   %h4.govuk-heading-s
     = t('schools.school_location')
-  %p= full_address(@vacancy.organisation)
+  %p= full_address(@vacancy.parent_organisation)
 
-  - if @vacancy.organisation.geolocation
+  - if @vacancy.parent_organisation.geolocation
     %div{ id: 'map_zoom', role: 'presentation', aria: { hidden: 'true', label: t('schools.map_aria_label') },  }
-    = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.organisation.name,
-                                                          lat: @vacancy.organisation.geolocation.x,
-                                                          lng: @vacancy.organisation.geolocation.y }
+    = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.parent_organisation.name,
+                                                          lat: @vacancy.parent_organisation.geolocation.x,
+                                                          lng: @vacancy.parent_organisation.geolocation.y }
 
     %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}

--- a/app/components/jobseekers/vacancy_summary_component.html.haml
+++ b/app/components/jobseekers/vacancy_summary_component.html.haml
@@ -1,16 +1,16 @@
 %li.vacancy{ 'role': 'listitem', 'tab-index': '0'}
   %h2.govuk-heading-m.mb0= link_to @vacancy.job_title, job_path(@vacancy), class: 'govuk-link view-vacancy-link'
-  %p.govuk-body= location(@vacancy.organisation)
+  %p.govuk-body= location(@vacancy.parent_organisation)
   %dl
     %dt= t('jobs.salary')
     %dd.double
       = @vacancy.salary
-    - if @vacancy.organisation.is_a?(School)
+    - if @vacancy.parent_organisation.is_a?(School)
       %dt= t('jobs.school_type')
     - else
       %dt= t('jobs.trust_type')
     %dd.double
-      = organisation_type(organisation: @vacancy.organisation, with_age_range: true)
+      = organisation_type(organisation: @vacancy.parent_organisation, with_age_range: true)
     - if @vacancy.working_patterns?
       %dt= t('jobs.working_patterns')
       %dd.double

--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -43,7 +43,7 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
     if job_location == 'at_one_school'
       school_name
     elsif job_location == 'at_multiple_schools'
-      I18n.t('hiring_staff.organisations.readable_job_location.at_multiple_schools', count: schools_count)
+      I18n.t('hiring_staff.organisations.readable_job_location.at_multiple_schools_with_count', count: schools_count)
     elsif job_location == 'central_office'
       I18n.t('hiring_staff.organisations.readable_job_location.central_office')
     end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -99,4 +99,27 @@ module VacanciesHelper
   def vacancy_or_organisation_description(vacancy)
     vacancy.about_school.presence || vacancy.organisation.description.presence
   end
+
+  def vacancy_about_school_label_organisation(vacancy)
+    vacancy.organisations.many? ? 'the schools' : vacancy.organisation.name
+  end
+
+  def vacancy_about_school_hint_text(vacancy)
+    return I18n.t('helpers.hint.job_summary_form.about_schools') if vacancy.organisations.many?
+    return I18n.t('helpers.hint.job_summary_form.about_organisation', organisation: 'Trust') if
+      vacancy.organisation.is_a?(SchoolGroup)
+    I18n.t('helpers.hint.job_summary_form.about_organisation', organisation: 'School')
+  end
+
+  def vacancy_about_school_value(vacancy)
+    return '' if vacancy.organisations.many?
+    vacancy_or_organisation_description(vacancy)
+  end
+
+  def vacancy_job_location(vacancy)
+    organisation = vacancy.parent_organisation
+    return "#{I18n.t('hiring_staff.organisations.readable_job_location.at_multiple_schools')}, #{organisation.name}" if
+      vacancy&.job_location == 'at_multiple_schools'
+    [organisation.name, organisation.town, organisation.county].compact.join(', ')
+  end
 end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -348,6 +348,10 @@ class Vacancy < ApplicationRecord
     self.documents.each { |document| DocumentDelete.new(document).delete }
   end
 
+  def parent_organisation
+    self.organisations.many? ? self.organisations.first.school_groups.first : self.organisation
+  end
+
   private
 
   def expires_at

--- a/app/views/hiring_staff/vacancies/_show.html.haml
+++ b/app/views/hiring_staff/vacancies/_show.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title_prefix do
-  #{@vacancy.job_title} - #{@vacancy.organisation_name}
+  #{@vacancy.job_title} - #{@vacancy.parent_organisation.name}
 
 .vacancy
 
@@ -18,7 +18,7 @@
           .og_image= image_pack_tag 'og_image.jpg'
           .og_text
             .og_url= t('app.title')
-            .og_title #{@vacancy.job_title} - #{@vacancy.organisation_name}
+            .og_title #{@vacancy.job_title} - #{@vacancy.parent_organisation.name}
             .og_description= truncate(strip_tags(@vacancy.job_summary), length: 76, separator: ' ')
         .og-caption
           Your job listing will appear on Facebook in a format similar to the above.

--- a/app/views/hiring_staff/vacancies/application_details/show.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/show.html.haml
@@ -22,8 +22,8 @@
         required: true
 
       = f.govuk_text_area :school_visits,
-        label: { text: t("helpers.fieldset.application_details_form.#{organisation_type_basic(@vacancy.organisation)}_visits"), size: 's' },
-        hint_text: t("helpers.hint.application_details_form.#{organisation_type_basic(@vacancy.organisation)}_visits"),
+        label: { text: t("helpers.fieldset.application_details_form.#{organisation_type_basic(@vacancy.parent_organisation)}_visits"), size: 's' },
+        hint_text: t("helpers.hint.application_details_form.#{organisation_type_basic(@vacancy.parent_organisation)}_visits"),
         rows: 10
 
       = f.govuk_text_area :how_to_apply,

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_application_details.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_application_details.html.haml
@@ -14,11 +14,11 @@
     %dd.app-check-your-answers__answer.first-question
       =mail_to 'Job contact email', @vacancy.contact_email, class: 'govuk-link', 'aria-label': t('jobs.aria_labels.contact_email_link', email: @vacancy.contact_email)
 
-  - organisation = @vacancy.organisation.is_a?(SchoolGroup) ? 'trust_visits' : 'school_visits'
+  - organisation = @vacancy.parent_organisation.is_a?(SchoolGroup) ? 'trust_visits' : 'school_visits'
 
   .app-check-your-answers__contents
     %dt.app-check-your-answers__question#school_visits
-      %h4.govuk-heading-s= t("jobs.#{organisation_type_basic(@vacancy.organisation)}_visits")
+      %h4.govuk-heading-s= t("jobs.#{organisation_type_basic(@vacancy.parent_organisation)}_visits")
     %dd.app-check-your-answers__answer= @vacancy.school_visits.presence || t('jobs.not_defined')
 
   .app-check-your-answers__contents

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_location.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_location.html.haml
@@ -13,5 +13,6 @@
       %h4.govuk-heading-s= t("school_groups.job_location_heading.review.#{@vacancy.job_location}")
 
     %dd.app-check-your-answers__answer.first-question
-      %div{ class: 'govuk-!-font-weight-bold' }= @vacancy.organisation.name
-      = location(@vacancy.organisation)
+      - @vacancy.organisations.each do |organisation|
+        %div{ class: 'govuk-!-font-weight-bold' }= organisation.name
+        = location(organisation)

--- a/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_summary.html.haml
+++ b/app/views/hiring_staff/vacancies/edit_vacancy_sections/_edit_job_summary.html.haml
@@ -15,5 +15,5 @@
 
   .app-check-your-answers__contents
     %dt.app-check-your-answers__question#about_school
-      %h4.govuk-heading-s= t('jobs.about_school', school: @vacancy.organisation.name)
+      %h4.govuk-heading-s= t('jobs.about_school', school: vacancy_about_school_label_organisation(@vacancy))
     %dd.app-check-your-answers__answer= @vacancy.about_school

--- a/app/views/hiring_staff/vacancies/job_summary/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_summary/show.html.haml
@@ -23,9 +23,9 @@
         required: true
 
       = f.govuk_text_area :about_school,
-        label: { text: t('helpers.fieldset.job_summary_form.about_organisation_html', organisation: @vacancy.organisation.name), size: 's' },
-        hint_text: t('helpers.hint.job_summary_form.about_organisation', organisation: organisation_type_basic(@vacancy.organisation).capitalize ),
-        value: @vacancy.about_school.presence || @vacancy.organisation.description.presence.to_s,
+        label: { text: t('helpers.fieldset.job_summary_form.about_organisation_html', organisation: vacancy_about_school_label_organisation(@vacancy)), size: 's' },
+        hint_text: vacancy_about_school_hint_text(@vacancy),
+        value: vacancy_about_school_value(@vacancy),
         rows: 10,
         required: true
 

--- a/app/views/shared/vacancy/_jobseeker_view.html.haml
+++ b/app/views/shared/vacancy/_jobseeker_view.html.haml
@@ -7,7 +7,7 @@
   %h1.govuk-heading-xl{ class: 'govuk-!-margin-bottom-2' }
     = @vacancy.job_title
   %h2.govuk-caption-l.job-caption{ class: 'govuk-!-margin-top-0' }
-    = location(@vacancy.organisation, job_location: @vacancy.job_location)
+    = vacancy_job_location(@vacancy)
 
 .govuk-grid-row
 
@@ -24,7 +24,7 @@
             = t('jobs.job_details')
         %li.govuk-tabs__list-item
           %a.govuk-tabs__tab.tab-links-override{ href: "#school-overview" }
-            - if @vacancy.organisation.is_a?(SchoolGroup)
+            - if @vacancy.parent_organisation.is_a?(SchoolGroup)
               = t('school_groups.trust_overview')
             - else
               = t('schools.school_overview')

--- a/app/views/vacancies/_school_details.html.haml
+++ b/app/views/vacancies/_school_details.html.haml
@@ -1,16 +1,16 @@
 %dl.school--details
   %dt= t('schools.address')
-  %dd= full_address(@vacancy.organisation)
+  %dd= full_address(@vacancy.parent_organisation)
 
-  - if school_phase(@vacancy.organisation).present?
+  - if school_phase(@vacancy.parent_organisation).present?
     %dt= t('schools.phase')
-    %dd= school_phase(@vacancy.organisation)
+    %dd= school_phase(@vacancy.parent_organisation)
 
-  - if @vacancy.organisation.school_type.present?
+  - if @vacancy.parent_organisation.school_type.present?
     %dt= t('schools.type')
-    %dd= @vacancy.organisation.school_type.label
+    %dd= @vacancy.parent_organisation.school_type.label
 
-  - if @vacancy.organisation.url.present?
+  - if @vacancy.parent_organisation.url.present?
     %dt= t('schools.website')
     %dd
-      = link_to("#{@vacancy.organisation.name} website (opens in a new window)", @vacancy.organisation.url, class: 'govuk-link wordwrap', target: '_blank')
+      = link_to("#{@vacancy.parent_organisation.name} website (opens in a new window)", @vacancy.parent_organisation.url, class: 'govuk-link wordwrap', target: '_blank')

--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title_prefix do
-  #{@vacancy.job_title} - #{@vacancy.organisation_name}
+  #{@vacancy.job_title} - #{@vacancy.parent_organisation.name}
 
 - content_for :page_description do
   = strip_tags(@vacancy.job_summary)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,7 +59,8 @@ en:
         edit:
           title: Change description
       readable_job_location:
-        at_multiple_schools: More than one school (%{count})
+        at_multiple_schools: More than one school
+        at_multiple_schools_with_count: More than one school (%{count})
         central_office: Trust head office
     temp_login:
       heading: Temporary login
@@ -228,7 +229,11 @@ en:
         job_summary: >-
           Give a brief summary of the job that job seekers can quickly scan.
           This will be the first thing they see on the listing or in search engine results
-        about_organisation: "This will appear next to the job details under '%{organisation} overview'. Feel free to adapt this text"
+        about_organisation: >-
+          This will appear next to the job details under '%{organisation} overview'. Feel free to adapt this text
+        about_schools: >-
+          Give a brief summary of the schools where the jobseeker would be teaching and any relevant information about
+          the trust
       organisation_form:
         description: Jobseekers will see this description of the school in the job listing
   organisation:


### PR DESCRIPTION
This PR refactors the frequent usage of `vacancy.organisation`.

If a vacancy has many organisations, then the parent organisation is the school group, otherwise it is the organisation