### PR TITLE
Include method for deleting expired records since year start

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -91,6 +91,13 @@ class Vacancy < ApplicationRecord
     index.delete_objects(expired_records.map(&:id)) if expired_records.present?
   end
 
+  def self.remove_vacancies_that_expired_between_january_1_and_yesterday!
+    expired_records = where('expiry_time BETWEEN ? AND ?', Time.zone.now.beginning_of_year, Time.zone.yesterday.midnight)
+    expired_records.in_batches do |relation|
+      index.delete_objects(relation.map(&:id))
+    end
+  end
+
   # rubocop:disable Metrics/BlockLength
   # rubocop:disable Layout/LineLength
   algoliasearch auto_index: true, auto_remove: true, if: :listed? do


### PR DESCRIPTION
This is the method I used to clear expired records from the index which had been missed.

Because I had to play around with it a little (e.g. had to use batches) it took about 20 minutes to get it right.

It may be worth including this method in vacancy.rb to save time if we have to do this again in the future.

It also might not be worth the maintenance cost / space considerations.

Yay or nay?