### PR TITLE
Refactor queries to use vacancies_published view

### DIFF
--- a/bigquery/calculate-daily-vacancy-tag-time-metrics.sql
+++ b/bigquery/calculate-daily-vacancy-tag-time-metrics.sql
@@ -12,15 +12,11 @@ WITH
     vacancy.job_roles AS job_roles,
     COUNT(document.id) AS number_of_documents
   FROM
-    `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
+    `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
   LEFT JOIN
     `teacher-vacancy-service.production_dataset.feb20_document` AS document
   ON
     document.vacancy_id=vacancy.id
-  WHERE
-    (status NOT IN ("trashed",
-        "deleted",
-        "draft"))
   GROUP BY
     vacancy.id,
     job_roles ),
@@ -38,10 +34,6 @@ WITH
     `teacher-vacancy-service.production_dataset.feb20_document` AS document
   ON
     document.vacancy_id=vacancy.id
-  WHERE
-    (status NOT IN ("trashed",
-        "deleted",
-        "draft"))
   GROUP BY
     vacancy.id,
     job_roles,

--- a/bigquery/calculated-daily-time-metrics-by-RSC-region.sql
+++ b/bigquery/calculated-daily-time-metrics-by-RSC-region.sql
@@ -27,11 +27,7 @@ WITH
     publish_on,
     expires_on
   FROM
-    `teacher-vacancy-service.production_dataset.feb20_vacancy`
-  WHERE
-    (status NOT IN ("trashed",
-        "deleted",
-        "draft")) ),
+    `teacher-vacancy-service.production_dataset.vacancies_published` ),
   metrics AS (
   SELECT
     date,

--- a/bigquery/calculated-daily-time-metrics.sql
+++ b/bigquery/calculated-daily-time-metrics.sql
@@ -27,15 +27,11 @@ WITH
     vacancy.expires_on,
     COUNT(document.id) AS number_of_documents
   FROM
-    `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
+    `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
   LEFT JOIN
     `teacher-vacancy-service.production_dataset.feb20_document` AS document
   ON
     document.vacancy_id=vacancy.id
-  WHERE
-    (status NOT IN ("trashed",
-        "deleted",
-        "draft"))
   GROUP BY
     vacancy.id,
     publish_on,

--- a/bigquery/schools_joined_with_metrics.sql
+++ b/bigquery/schools_joined_with_metrics.sql
@@ -29,7 +29,7 @@ WITH
     #count this as vacancies which have been published and have not yet expired
     MAX(publish_on) AS date_last_published
   FROM
-    `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
+    `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
   LEFT JOIN
     `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
   ON
@@ -38,9 +38,6 @@ WITH
     `teacher-vacancy-service.production_dataset.school` AS school
   ON
     organisationvacancy.organisation_id=school.id
-  WHERE
-    vacancy.status != "trashed" #exclude deleted vacancies from the counts above
-    AND vacancy.status != "draft" #exclude vacancies which have not (yet) been published from the counts above
   GROUP BY
     urn)
 SELECT

--- a/bigquery/vacancies-published.sql
+++ b/bigquery/vacancies-published.sql
@@ -19,12 +19,9 @@ WITH
         #use the first day of the month containing publish_on to represent the month (standard in data studio)
         DATE_TRUNC(publish_on,YEAR) AS year #use the first day of the year containing publish_on to represent the year (standard in data studio)
       FROM
-        `teacher-vacancy-service.production_dataset.feb20_vacancy`
+        `teacher-vacancy-service.production_dataset.vacancies_published`
       WHERE
-        status NOT IN ("trashed",
-          "deleted",
-          "draft") #excludes vacancies which were never published, or which were published and then subsequently deleted
-        AND publish_on IS NOT NULL #also excludes vacancies which were never published (to be safe)
+        publish_on IS NOT NULL #also excludes vacancies which were never published (to be safe)
         AND publish_on <= CURRENT_DATE() ) #excludes vacancies which have been published but are not yet visible on the site because their publication date is in the future
     GROUP BY
       month,

--- a/bigquery/vacancy-feedback-metrics-by-month.sql
+++ b/bigquery/vacancy-feedback-metrics-by-month.sql
@@ -30,11 +30,7 @@ FROM (
         "listed_dont_know")) AS exclusive_hires_upperbound,
     COUNTIF(listed_elsewhere IN ("not_listed")) AS exclusive_listings
   FROM
-    `teacher-vacancy-service.production_dataset.feb20_vacancy`
-  WHERE
-    status NOT IN ("trashed",
-      "deleted",
-      "draft")
+    `teacher-vacancy-service.production_dataset.vacancies_published`
   GROUP BY
     month)
 WHERE

--- a/bigquery/views/vacancies_in_scope.sql
+++ b/bigquery/views/vacancies_in_scope.sql
@@ -1,0 +1,8 @@
+  # Filters the vacancies_published view into the vacancies_in_scope view by excluding vacancies from out of scope roles
+SELECT
+  *
+FROM
+  `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
+WHERE
+  category IN ("teacher",
+    "leadership") #i.e. not null or teaching_assistant

--- a/bigquery/views/vacancies_published.sql
+++ b/bigquery/views/vacancies_published.sql
@@ -1,0 +1,30 @@
+  # Filters the feb20_vacancies table into the vacancies_published view by excluding vacancies from out of scope statuses or roles
+SELECT
+  vacancy.*,
+IF
+  (LOWER(job_title) LIKE '%head%'
+    OR LOWER(job_title) LIKE '%ordinat%'
+    OR LOWER(job_title) LIKE '%principal%',
+    "leadership",
+  IF
+    ((job_title LIKE '%TA%'
+        OR job_title LIKE '%TAs%'
+        OR LOWER(job_title) LIKE '% assistant%' #picks up teaching assistant, learning support assistant etc.
+        OR LOWER(job_title) LIKE '%intervention %')
+      AND LOWER(job_title) NOT LIKE '%admin%'
+      AND LOWER(job_title) NOT LIKE '%account%'
+      AND LOWER(job_title) NOT LIKE '%marketing%'
+      AND LOWER(job_title) NOT LIKE '%admission%'
+      AND LOWER(job_title) NOT LIKE '%care%',
+      "teaching_assistant",
+    IF
+      (LOWER(job_title) LIKE '%teacher%'
+        OR LOWER(job_title) LIKE '%lecturer%',
+        "teacher",
+        NULL))) AS category #categorises each vacancy as leadership,teaching_assistant,teacher or NULL
+FROM
+  `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
+WHERE
+  vacancy.status NOT IN ("trashed",
+    "draft",
+    "deleted")

--- a/bigquery/working-patterns-monthly.sql
+++ b/bigquery/working-patterns-monthly.sql
@@ -32,13 +32,9 @@ FROM (
   FROM
     UNNEST(GENERATE_DATE_ARRAY('2018-08-01',DATE_TRUNC(CURRENT_DATE(),MONTH),INTERVAL 1 MONTH)) AS month
   LEFT JOIN
-    `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
+    `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
   ON
     DATE_TRUNC(vacancy.publish_on,MONTH)=month
-  WHERE
-    status != "draft"
-    AND status != "trashed"
-    AND status != "deleted"
   GROUP BY
     month )
 ORDER BY


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1064

## Changes in this PR:

- Add new vacancies_published and vacancies_in_scope views of the feb20_vacancy table.
- Refactor SQL that filters the vacancy table out of individual queries into these views.
- Gives access to a 'vacancy category' field in lots of places that will be important to allow us to normalise (exclusive) hire / savings extrapolations by vacancy category.