### PR TITLE
Use parent_organisation across the application

### DIFF
--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -12,7 +12,7 @@ class InterestsController < ApplicationController
     AuditExpressInterestEventJob.perform_later(
       datestamp: Time.zone.now.iso8601.to_s,
       vacancy_id: vacancy.id,
-      school_urn: vacancy.organisation.urn,
+      school_urn: vacancy.parent_organisation.urn,
       application_link: vacancy.application_link
     )
   end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -48,7 +48,7 @@ module VacanciesHelper
   end
 
   def organisation_from_job_location(vacancy)
-    vacancy.job_location == 'at_multiple_schools' ? 'multiple schools' : vacancy.organisation_name
+    vacancy.job_location == 'at_multiple_schools' ? 'multiple schools' : vacancy.parent_organisation_name
   end
 
   def page_title_no_vacancy
@@ -97,17 +97,17 @@ module VacanciesHelper
   end
 
   def vacancy_or_organisation_description(vacancy)
-    vacancy.about_school.presence || vacancy.organisation.description.presence
+    vacancy.about_school.presence || vacancy.parent_organisation.description.presence
   end
 
   def vacancy_about_school_label_organisation(vacancy)
-    vacancy.organisations.many? ? 'the schools' : vacancy.organisation.name
+    vacancy.organisations.many? ? 'the schools' : vacancy.parent_organisation.name
   end
 
   def vacancy_about_school_hint_text(vacancy)
     return I18n.t('helpers.hint.job_summary_form.about_schools') if vacancy.organisations.many?
     return I18n.t('helpers.hint.job_summary_form.about_organisation', organisation: 'Trust') if
-      vacancy.organisation.is_a?(SchoolGroup)
+      vacancy.parent_organisation.is_a?(SchoolGroup)
     I18n.t('helpers.hint.job_summary_form.about_organisation', organisation: 'School')
   end
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -230,7 +230,7 @@ class Vacancy < ApplicationRecord
   has_many :organisations, through: :organisation_vacancies
   accepts_nested_attributes_for :organisation_vacancies
 
-  delegate :name, to: :organisation, prefix: true, allow_nil: true
+  delegate :name, to: :parent_organisation, prefix: true, allow_nil: true
 
   acts_as_gov_uk_date :starts_on, :publish_on,
     :expires_on, error_clash_behaviour: :omit_gov_uk_date_field_error
@@ -364,7 +364,7 @@ class Vacancy < ApplicationRecord
   def slug_candidates
     [
       :job_title,
-      %i[job_title organisation_name],
+      %i[job_title parent_organisation_name],
       %i[job_title location]
     ]
   end

--- a/app/models/vacancy_publish_feedback.rb
+++ b/app/models/vacancy_publish_feedback.rb
@@ -13,7 +13,7 @@ class VacancyPublishFeedback < ApplicationRecord
       Time.zone.now.to_s,
       user&.oid,
       vacancy.id,
-      vacancy.organisation.urn,
+      vacancy.parent_organisation.urn,
       rating,
       comment,
       created_at.to_s,

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -96,8 +96,8 @@ class VacancyPresenter < BasePresenter
     }
   end
 
-  def job_title_and_organisation_name
-    "#{job_title} at #{organisation_name}"
+  def job_title_and_parent_organisation_name
+    "#{job_title} at #{parent_organisation_name}"
   end
 
   def show_job_roles

--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -71,9 +71,9 @@ class CopyVacancy
   end
 
   def setup_job_location
-    if @new_vacancy.organisation.is_a?(School)
+    if @new_vacancy.parent_organisation.is_a?(School)
       @new_vacancy.job_location = 'at_one_school'
-      @new_vacancy.readable_job_location = @new_vacancy.organisation_name
+      @new_vacancy.readable_job_location = @new_vacancy.parent_organisation.name
     else
       @new_vacancy.job_location = 'central_office'
       @new_vacancy.readable_job_location = I18n.t('hiring_staff.organisations.readable_job_location.central_office')

--- a/app/views/alert_mailer/daily_alert.text.haml
+++ b/app/views/alert_mailer/daily_alert.text.haml
@@ -5,7 +5,7 @@
 \
 - @vacancies.each do |vacancy|
   = notify_link(vacancy.share_url(source: 'subscription', medium: 'email', campaign: 'daily_alert'), vacancy.job_title).html_safe
-  = location(vacancy.organisation)
+  = location(vacancy.parent_organisation, job_location: vacancy.job_location)
   \
   = "Salary: #{vacancy.salary}"
   - if vacancy.working_patterns?

--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -19,10 +19,10 @@ json.jobLocation do
   json.set! '@type', 'Place'
   json.address do
     json.set! '@type', 'PostalAddress'
-    json.addressLocality vacancy.organisation&.town
-    json.addressRegion (vacancy.organisation&.region&.name if vacancy.organisation.is_a?(School))
-    json.streetAddress vacancy.organisation&.address
-    json.postalCode vacancy.organisation&.postcode
+    json.addressLocality vacancy.parent_organisation&.town
+    json.addressRegion (vacancy.parent_organisation&.region&.name if vacancy.parent_organisation.is_a?(School))
+    json.streetAddress vacancy.parent_organisation&.address
+    json.postalCode vacancy.parent_organisation&.postcode
   end
 end
 
@@ -30,8 +30,8 @@ json.url job_url(vacancy)
 
 json.hiringOrganization do
   json.set! '@type', 'School'
-  json.name vacancy.organisation&.name
-  json.identifier (vacancy.organisation&.urn || vacancy.organisation&.uid)
+  json.name vacancy.parent_organisation&.name
+  json.identifier (vacancy.parent_organisation&.urn || vacancy.parent_organisation&.uid)
   json.description vacancy.about_school
 end
 

--- a/app/views/shared/vacancy/_share_buttons.html.haml
+++ b/app/views/shared/vacancy/_share_buttons.html.haml
@@ -9,7 +9,7 @@
       %span.visually-hidden "#{t('jobs.share_on')}"
       Facebook
   %li.share-links__list-item
-    %a{ target: '_blank', class: 'govuk-link share-links__link vacancy-share-link', href: "https://twitter.com/share?url=#{CGI.escape(@vacancy.share_url)}&text=#{CGI.escape(@vacancy.job_title_and_organisation_name)}", data: { target: 'twitter' } }
+    %a{ target: '_blank', class: 'govuk-link share-links__link vacancy-share-link', href: "https://twitter.com/share?url=#{CGI.escape(@vacancy.share_url)}&text=#{CGI.escape(@vacancy.job_title_and_parent_organisation_name)}", data: { target: 'twitter' } }
       %span.share-links__link-icon
         %svg{ xmlns:"http://www.w3.org/2000/svg", width:"32", height:"32", viewBox:"0 0 32 32" }
           %path{ fill:"#005ea5", d:"M31.007 0H.993A.999.999 0 0 0 0 .993v30.014c0 .55.452.993.993.993h30.014a.997.997 0 0 0 .993-.993V.993A.998.998 0 0 0 31.007 0z" }

--- a/spec/components/jobseekers/school_group_overview_component_spec.rb
+++ b/spec/components/jobseekers/school_group_overview_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Jobseekers::SchoolGroupOverviewComponent, type: :component do
   end
 
   it 'renders the trust type' do
-    expect(rendered_component).to include(organisation_type(organisation: vacancy.organisation))
+    expect(rendered_component).to include(organisation_type(organisation: vacancy.parent_organisation))
   end
 
   it 'renders the trust email' do
@@ -53,6 +53,6 @@ RSpec.describe Jobseekers::SchoolGroupOverviewComponent, type: :component do
   end
 
   it 'renders the head office location' do
-    expect(rendered_component).to include(full_address(vacancy.organisation))
+    expect(rendered_component).to include(full_address(vacancy.parent_organisation))
   end
 end

--- a/spec/components/jobseekers/school_overview_component_spec.rb
+++ b/spec/components/jobseekers/school_overview_component_spec.rb
@@ -31,23 +31,23 @@ RSpec.describe Jobseekers::SchoolOverviewComponent, type: :component do
 
   context 'rendering the school type' do
     it 'renders the school type' do
-      expect(rendered_component).to include(organisation_type(organisation: vacancy.organisation,
+      expect(rendered_component).to include(organisation_type(organisation: vacancy.parent_organisation,
         with_age_range: false))
     end
 
     it 'does not render the age range as part of the school type' do
-      expect(rendered_component).not_to include(organisation_type(organisation: vacancy.organisation,
+      expect(rendered_component).not_to include(organisation_type(organisation: vacancy.parent_organisation,
         with_age_range: true))
     end
   end
 
   it 'renders the education phase' do
-    expect(rendered_component).to include(school_phase(vacancy.organisation))
+    expect(rendered_component).to include(school_phase(vacancy.parent_organisation))
   end
 
   context 'when the number of pupils is present' do
     it 'renders the school size as the number of pupils' do
-      expect(rendered_component).to include(school_size(vacancy.organisation))
+      expect(rendered_component).to include(school_size(vacancy.parent_organisation))
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe Jobseekers::SchoolOverviewComponent, type: :component do
       let(:school) { create(:school, gias_data: { 'NumberOfPupils' => nil, 'SchoolCapacity' => 1000 }) }
 
       it 'renders the school capacity as the school size' do
-        expect(rendered_component).to include(school_size(vacancy.organisation))
+        expect(rendered_component).to include(school_size(vacancy.parent_organisation))
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe Jobseekers::SchoolOverviewComponent, type: :component do
       let(:school) { create(:school, gias_data: { 'NumberOfPupils' => nil, 'SchoolCapacity' => nil }) }
 
       it 'renders the school no information translation' do
-        expect(rendered_component).to include(school_size(vacancy.organisation))
+        expect(rendered_component).to include(school_size(vacancy.parent_organisation))
       end
     end
   end
@@ -73,7 +73,7 @@ RSpec.describe Jobseekers::SchoolOverviewComponent, type: :component do
     let(:organisation) { create(:school, gias_data: { 'URN' => Faker::Number.number(digits: 6) }) }
 
     it 'renders the osted report' do
-      expect(rendered_component).to include(ofsted_report(vacancy.organisation))
+      expect(rendered_component).to include(ofsted_report(vacancy.parent_organisation))
     end
   end
 
@@ -84,7 +84,7 @@ RSpec.describe Jobseekers::SchoolOverviewComponent, type: :component do
   end
 
   it 'renders a link to the school website' do
-    expect(rendered_component).to include(vacancy.organisation.url)
+    expect(rendered_component).to include(vacancy.parent_organisation.url)
   end
 
   it 'renders the contact email' do
@@ -100,6 +100,6 @@ RSpec.describe Jobseekers::SchoolOverviewComponent, type: :component do
   end
 
   it 'renders the head office location' do
-    expect(rendered_component).to include(full_address(vacancy.organisation))
+    expect(rendered_component).to include(full_address(vacancy.parent_organisation))
   end
 end

--- a/spec/components/jobseekers/vacancy_summary_component_spec.rb
+++ b/spec/components/jobseekers/vacancy_summary_component_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
     end
 
     it 'renders the address' do
-      expect(rendered_component).to include(location(vacancy.organisation))
+      expect(rendered_component).to include(location(vacancy.parent_organisation))
     end
 
     it 'renders the school type label' do
@@ -28,7 +28,8 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
     end
 
     it 'renders the school type' do
-      expect(rendered_component).to include(organisation_type(organisation: vacancy.organisation, with_age_range: true))
+      expect(rendered_component)
+        .to include(organisation_type(organisation: vacancy.parent_organisation, with_age_range: true))
     end
 
     it 'renders the working pattern' do
@@ -55,7 +56,7 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
 
     it 'renders the trust type' do
       expect(rendered_component)
-        .to include(organisation_type(organisation: vacancy.organisation, with_age_range: true))
+        .to include(organisation_type(organisation: vacancy.parent_organisation, with_age_range: true))
     end
   end
 
@@ -64,7 +65,7 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
     let(:organisation) { create(:school_group) }
 
     it 'renders the address' do
-      assert_includes rendered_component, location(vacancy.organisation)
+      assert_includes rendered_component, location(vacancy.parent_organisation)
     end
 
     it 'renders the trust type label' do
@@ -72,7 +73,7 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
     end
 
     it 'renders the trust type' do
-      expect(rendered_component).to include(organisation_type(organisation: vacancy.organisation))
+      expect(rendered_component).to include(organisation_type(organisation: vacancy.parent_organisation))
     end
   end
 end

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -199,8 +199,8 @@ RSpec.describe Api::VacanciesController, type: :controller do
           hiring_organization = {
             'hiringOrganization': {
               '@type': 'School',
-              'name': vacancy.organisation.name,
-              'identifier': vacancy.organisation.urn,
+              'name': vacancy.parent_organisation.name,
+              'identifier': vacancy.parent_organisation.urn,
               'description': "<p>#{vacancy.about_school}</p>"
             }
           }

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe VacanciesHelper, type: :helper do
       allow(vacancy).to receive(:published?).and_return(false)
       allow(vacancy).to receive(:state).and_return('create')
       allow(vacancy).to receive(:job_location).and_return('at_one_school')
-      allow(vacancy).to receive(:organisation_name).and_return('Teaching Vacancies Academy')
+      allow(vacancy).to receive(:parent_organisation_name).and_return('Teaching Vacancies Academy')
 
       expect(page_title(vacancy)).to eql(I18n.t('jobs.create_a_job_title', organisation: 'Teaching Vacancies Academy'))
     end
@@ -58,7 +58,7 @@ RSpec.describe VacanciesHelper, type: :helper do
       allow(vacancy).to receive(:published?).and_return(false)
       allow(vacancy).to receive(:state).and_return('review')
       allow(vacancy).to receive(:job_location).and_return('at_one_school')
-      allow(vacancy).to receive(:organisation_name).and_return('Teaching Vacancies Academy')
+      allow(vacancy).to receive(:parent_organisation_name).and_return('Teaching Vacancies Academy')
 
       expect(page_title(vacancy)).to eql(I18n.t('jobs.create_a_job_title', organisation: 'Teaching Vacancies Academy'))
     end

--- a/spec/lib/job_posting_spec.rb
+++ b/spec/lib/job_posting_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe JobPosting do
       it 'assigns a random school' do
         allow(School).to receive(:offset).and_return(double(first: random_school))
         vacancy = to_vacancy
-        expect(vacancy.organisation).to eql(random_school)
+        expect(vacancy.parent_organisation).to eql(random_school)
       end
     end
 

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -64,10 +64,6 @@ RSpec.describe AlertMailer, type: :mailer do
       let(:first_vacancy_presenter) { VacancyPresenter.new(vacancies.first) }
       let(:second_vacancy_presenter) { VacancyPresenter.new(vacancies.last) }
 
-      before do
-        vacancies.each { |vacancy| vacancy.organisation_vacancies.create(organisation: school) }
-      end
-
       it 'shows vacancies' do
         expect(mail.subject).to eq(
           I18n.t(

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -400,14 +400,14 @@ RSpec.describe Vacancy, type: :model do
     end
   end
 
-  describe '#organisation_name' do
+  describe '#parent_organisation_name' do
     context 'when vacancy has a school' do
       it 'returns the school name for the vacancy' do
         school = create(:school, name: 'St James School')
         vacancy = create(:vacancy)
         vacancy.organisation_vacancies.create(organisation: school)
 
-        expect(vacancy.organisation_name).to eq(school.name)
+        expect(vacancy.parent_organisation_name).to eq(school.name)
       end
     end
 
@@ -417,7 +417,7 @@ RSpec.describe Vacancy, type: :model do
         vacancy = create(:vacancy, :at_central_office)
         vacancy.organisation_vacancies.create(organisation: school_group)
 
-        expect(vacancy.organisation_name).to eq(school_group.name)
+        expect(vacancy.parent_organisation_name).to eq(school_group.name)
       end
     end
   end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -186,17 +186,17 @@ module VacancyHelpers
         '@type': 'Place',
         'address': {
           '@type': 'PostalAddress',
-          'addressLocality': vacancy.organisation.town,
-          'addressRegion': vacancy.organisation.region.name,
-          'streetAddress': vacancy.organisation.address,
-          'postalCode': vacancy.organisation.postcode,
+          'addressLocality': vacancy.parent_organisation.town,
+          'addressRegion': vacancy.parent_organisation.region.name,
+          'streetAddress': vacancy.parent_organisation.address,
+          'postalCode': vacancy.parent_organisation.postcode,
         },
       },
       'url': job_url(vacancy, host: '127.0.0.1'), # TODO fix system specs to change default host to localhost:3000
       'hiringOrganization': {
         '@type': 'School',
-        'name': vacancy.organisation.name,
-        'identifier': vacancy.organisation.urn,
+        'name': vacancy.parent_organisation.name,
+        'identifier': vacancy.parent_organisation.urn,
         'description': vacancy.about_school
       },
       'validThrough': vacancy.expires_on.end_of_day.to_time.iso8601,
@@ -208,7 +208,7 @@ module VacancyHelpers
   def verify_vacancy_list_page_details(vacancy)
     expect(page.find('.vacancy')).not_to have_content(vacancy.publish_on)
     expect(page.find('.vacancy')).not_to have_content(vacancy.starts_on) if vacancy.starts_on?
-    expect(page.find('.vacancy')).to have_content(vacancy.organisation.school_type.label.singularize)
+    expect(page.find('.vacancy')).to have_content(vacancy.parent_organisation.school_type.label.singularize)
 
     verify_shared_vacancy_list_page_details(vacancy)
   end

--- a/spec/system/job_seekers_can_apply_for_a_vacancy_spec.rb
+++ b/spec/system/job_seekers_can_apply_for_a_vacancy_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Job seekers can apply for a vacancy' do
       express_interest_event = {
         datestamp: timestamp.to_s,
         vacancy_id: vacancy.id,
-        school_urn: vacancy.organisation.urn,
+        school_urn: vacancy.parent_organisation.urn,
         application_link: vacancy.application_link
       }
 


### PR DESCRIPTION
This PR finishes refactoring `vacancy.organisation` usage to `vacancy.parent_organisation`. It also refactors the delegated name variable on the vacancy model.