### PR TITLE
[TEVA-1017] Allow multiple school types for multi school jobs

### DIFF
--- a/app/components/jobseekers/vacancy_summary_component.html.haml
+++ b/app/components/jobseekers/vacancy_summary_component.html.haml
@@ -1,16 +1,13 @@
 %li.vacancy{ 'role': 'listitem', 'tab-index': '0'}
   %h2.govuk-heading-m.mb0= link_to @vacancy.job_title, job_path(@vacancy), class: 'govuk-link view-vacancy-link'
-  %p.govuk-body= location(@vacancy.parent_organisation)
+  %p.govuk-body= location(@vacancy.parent_organisation, job_location: @vacancy.job_location)
   %dl
     %dt= t('jobs.salary')
     %dd.double
       = @vacancy.salary
-    - if @vacancy.parent_organisation.is_a?(School)
-      %dt= t('jobs.school_type')
-    - else
-      %dt= t('jobs.trust_type')
+    %dt= @vacancy.job_location == 'central_office' ? t('jobs.trust_type') : t('jobs.school_type')
     %dd.double
-      = organisation_type(organisation: @vacancy.parent_organisation, with_age_range: true)
+      = organisation_types(@vacancy.organisations)
     - if @vacancy.working_patterns?
       %dt= t('jobs.working_patterns')
       %dd.double

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -18,6 +18,11 @@ module OrganisationHelper
     school_type_details.reject(&:blank?).reject { |str| str == I18n.t('schools.not_given') }.join(', ')
   end
 
+  def organisation_types(organisations)
+    organisations.map { |organisation| organisation_type(organisation: organisation, with_age_range: true) }
+                 .uniq.join(', ')
+  end
+
   def organisation_type_basic(organisation)
     organisation.is_a?(School) ? 'school' : 'trust'
   end

--- a/spec/components/jobseekers/vacancy_summary_component_spec.rb
+++ b/spec/components/jobseekers/vacancy_summary_component_spec.rb
@@ -2,67 +2,105 @@ require 'rails_helper'
 
 RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
   let(:vacancy_presenter) { VacancyPresenter.new(vacancy) }
-  let(:organisation) { create(:school) }
-  let(:vacancy) { create(:vacancy) }
 
-  before do
-    vacancy.organisation_vacancies.create(organisation: organisation)
-    render_inline(described_class.new(vacancy: vacancy_presenter))
-  end
-
-  context 'when vacancy is at a school that is not in a trust' do
-    it 'renders the title' do
-      expect(rendered_component).to include(vacancy_presenter.job_title)
-    end
-
-    it 'renders the salary' do
-      expect(rendered_component).to include(vacancy_presenter.salary)
-    end
-
-    it 'renders the address' do
-      expect(rendered_component).to include(location(vacancy.parent_organisation))
-    end
-
-    it 'renders the school type label' do
-      expect(rendered_component).to include(I18n.t('jobs.school_type'))
-    end
-
-    it 'renders the school type' do
-      expect(rendered_component)
-        .to include(organisation_type(organisation: vacancy.parent_organisation, with_age_range: true))
-    end
-
-    it 'renders the working pattern' do
-      expect(rendered_component).to include(vacancy_presenter.working_patterns)
-    end
-
-    context 'when expiry time is nil' do
-      let(:vacancy) { create(:vacancy, expiry_time: nil) }
-
-      it 'renders the date it expires on but not the time' do
-        expect(rendered_component).to include(format_date(vacancy.expires_on))
-      end
-    end
-
-    context 'when expiry time is not nil' do
-      it 'renders the date and time it expires at' do
-        expect(rendered_component).to include(expiry_date_and_time(vacancy))
-      end
-    end
-  end
-
-  context 'when vacancy is at a single school in a trust' do
+  context 'when vacancy job_location is at_one_school' do
     let(:vacancy) { create(:vacancy, :at_one_school) }
 
-    it 'renders the trust type' do
-      expect(rendered_component)
-        .to include(organisation_type(organisation: vacancy.parent_organisation, with_age_range: true))
+    before do
+      vacancy.organisation_vacancies.create(organisation: organisation)
+      render_inline(described_class.new(vacancy: vacancy_presenter))
+    end
+
+    context 'when vacancy parent_organisation is a School' do
+      let(:organisation) { create(:school) }
+
+      it 'renders the title' do
+        expect(rendered_component).to include(vacancy_presenter.job_title)
+      end
+
+      it 'renders the salary' do
+        expect(rendered_component).to include(vacancy_presenter.salary)
+      end
+
+      it 'renders the address' do
+        expect(rendered_component).to include(location(vacancy.parent_organisation))
+      end
+
+      it 'renders the school type label' do
+        expect(rendered_component).to include(I18n.t('jobs.school_type'))
+      end
+
+      it 'renders the school type' do
+        expect(rendered_component)
+          .to include(organisation_type(organisation: vacancy.parent_organisation, with_age_range: true))
+      end
+
+      it 'renders the working pattern' do
+        expect(rendered_component).to include(vacancy_presenter.working_patterns)
+      end
+
+      context 'when expiry time is nil' do
+        let(:vacancy) { create(:vacancy, expiry_time: nil) }
+
+        it 'renders the date it expires on but not the time' do
+          expect(rendered_component).to include(format_date(vacancy.expires_on))
+        end
+      end
+
+      context 'when expiry time is not nil' do
+        it 'renders the date and time it expires at' do
+          expect(rendered_component).to include(expiry_date_and_time(vacancy))
+        end
+      end
+    end
+
+    context 'when vacancy parent_organisation is a SchoolGroup' do
+      let(:organisation) { create(:school_group) }
+
+      it 'renders the trust type' do
+        expect(rendered_component)
+          .to include(organisation_type(organisation: vacancy.parent_organisation, with_age_range: true))
+      end
     end
   end
 
-  context 'when vacancy is at central office in a trust' do
+  context 'when vacancy job_location is at_multiple_schools' do
+    let(:vacancy) { create(:vacancy, :at_multiple_schools) }
+    let(:school_type) { create(:school_type, label: 'Academy') }
+    let(:school_group) { create(:school_group) }
+    let(:school_1) { create(:school, :catholic, school_type: school_type) }
+    let(:school_2) { create(:school, :catholic, school_type: school_type) }
+    let(:school_3) { create(:school, :catholic, school_type: school_type, minimum_age: 16) }
+
+    before do
+      SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
+      SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
+      SchoolGroupMembership.find_or_create_by(school_id: school_3.id, school_group_id: school_group.id)
+      vacancy.organisation_vacancies.create(organisation: school_1)
+      vacancy.organisation_vacancies.create(organisation: school_2)
+      vacancy.organisation_vacancies.create(organisation: school_3)
+      render_inline(described_class.new(vacancy: vacancy_presenter))
+    end
+
+    it 'renders the job location' do
+      expect(rendered_component)
+        .to include(location(vacancy.parent_organisation, job_location: 'at_multiple_schools'))
+    end
+
+    it 'renders the unique school types' do
+      expect(rendered_component)
+        .to include('Academy, Roman Catholic, 11 to 18, Academy, Roman Catholic, 16 to 18')
+    end
+  end
+
+  context 'when vacancy job_location is central_office' do
     let(:vacancy) { create(:vacancy, :at_central_office) }
     let(:organisation) { create(:school_group) }
+
+    before do
+      vacancy.organisation_vacancies.create(organisation: organisation)
+      render_inline(described_class.new(vacancy: vacancy_presenter))
+    end
 
     it 'renders the address' do
       assert_includes rendered_component, location(vacancy.parent_organisation)

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -58,6 +58,23 @@ FactoryBot.define do
     trait :outside_london do
       association :region, name: 'East of England'
     end
+
+    trait :catholic do
+      gias_data { {
+        "CloseDate": nil,
+        "HeadFirstName": Faker::Name.first_name,
+        "HeadLastName": Faker::Name.last_name.gsub("'", ''),
+        "HeadPreferredJobTitle": Faker::Name.prefix.gsub('.', ''),
+        "DateOfLastInspectionVisit": Faker::Date.between(from: 999.days.ago, to: 5.days.ago),
+        "NumberOfPupils": Faker::Number.number(digits: 3),
+        "OfstedRating (name)": OFSTED_RATINGS.sample,
+        "OpenDate": Faker::Date.between(from: 10000.days.ago, to: 1000.days.ago),
+        "ReligiousCharacter (name)": 'Roman Catholic',
+        "SchoolCapacity": Faker::Number.number(digits: 4),
+        "TelephoneNum": Faker::Number.number(digits: 11).to_s,
+        "Trusts (name)": Faker::Company.name.gsub("'", '') + ' Trust'
+        } }
+    end
   end
 
   factory :academy, parent: :school do


### PR DESCRIPTION
This PR updates the search snippet on the search results page for multi school jobs. (N.B. multiple school types will probably look quite cumbersome if there are more than a few differences between schools for a given job)

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1017

## Changes in this PR:
- Show correct job location in search snippet for multi school jobs
- Show unique school types in search snippet for multi school jobs
