### PR TITLE
Ensure job location fields are never nil

### DIFF
--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -78,6 +78,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   end
 
   def save_vacancy_without_validation
+    set_job_location_fields
     set_organisation_vacancies
     @form.vacancy.send :set_slug
     @form.vacancy.status = :draft
@@ -98,6 +99,14 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
       organisation_ids.each do |organisation_id|
         @form.vacancy.organisation_vacancies.build(organisation_id: organisation_id)
       end
+    end
+  end
+
+  def set_job_location_fields
+    if current_organisation.is_a?(School)
+      @form.vacancy.job_location = 'at_one_school'
+      @form.vacancy.readable_job_location = readable_job_location('at_one_school',
+                                                                  school_name: current_organisation.name)
     end
   end
 

--- a/db/migrate/20200903155529_populate_job_location_fields_on_vacancies.rb
+++ b/db/migrate/20200903155529_populate_job_location_fields_on_vacancies.rb
@@ -1,0 +1,11 @@
+class PopulateJobLocationFieldsOnVacancies < ActiveRecord::Migration[6.0]
+  def change
+    Vacancy.where(job_location: nil).in_batches(of: 100).each_record do |vacancy|
+      vacancy.update_columns(job_location: 'at_one_school')
+    end
+
+    Vacancy.where(readable_job_location: nil).in_batches(of: 100).each_record do |vacancy|
+      vacancy.update_columns(readable_job_location: vacancy.parent_organisation_name)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_25_081501) do
+ActiveRecord::Schema.define(version: 2020_09_03_155529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"


### PR DESCRIPTION
What it says on the tin

When SchoolGroup users manage jobs created as Schools, these fields would otherwise be blank and the cause of some bugs when editing those jobs.

https://dfedigital.atlassian.net/browse/TEVA-1255
https://dfedigital.atlassian.net/browse/TEVA-1253