### PR TITLE
Block Simplecov gem at version 0.17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :test do
   gem 'rack_session_access'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
-  gem 'simplecov', require: false
+  gem 'simplecov', '<= 0.17.1', require: false # Newer versions of simplecov are not compatible with Sonarqube
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,10 +455,11 @@ GEM
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simplecov (0.19.0)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     skylight (4.3.1)
       skylight-core (= 4.3.1)
     skylight-core (4.3.1)
@@ -586,7 +587,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   sidekiq-cron
-  simplecov
+  simplecov (<= 0.17.1)
   skylight
   spring
   spring-watcher-listen


### PR DESCRIPTION
Successive versions of simplecov break Sonarqube