### PR TITLE
[TEVA-1248] Update Organisation Details Page and Notification

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -106,9 +106,9 @@ module VacanciesHelper
 
   def vacancy_about_school_hint_text(vacancy)
     return I18n.t('helpers.hint.job_summary_form.about_schools') if vacancy.organisations.many?
-    return I18n.t('helpers.hint.job_summary_form.about_organisation', organisation: 'Trust') if
+    return I18n.t('helpers.hint.job_summary_form.about_organisation', organisation_type: 'Trust') if
       vacancy.parent_organisation.is_a?(SchoolGroup)
-    I18n.t('helpers.hint.job_summary_form.about_organisation', organisation: 'School')
+    I18n.t('helpers.hint.job_summary_form.about_organisation', organisation_type: 'School')
   end
 
   def vacancy_about_school_value(vacancy)

--- a/app/views/hiring_staff/organisations/schools/edit.html.haml
+++ b/app/views/hiring_staff/organisations/schools/edit.html.haml
@@ -12,11 +12,11 @@
       = f.govuk_error_summary
 
       %h2.govuk-heading-l
-        = t('.title')
+        = t('.title', organisation_type: organisation_type_basic(@organisation))
 
       = f.govuk_text_area :description,
-        label: { text: t('helpers.fieldset.organisation_form.description'), size: 's' },
-        hint_text: t('helpers.hint.organisation_form.description'),
+        label: { text: t('helpers.fieldset.organisation_form.description', organisation_type: organisation_type_basic(@organisation)), size: 's' },
+        hint_text: t('helpers.hint.organisation_form.description', organisation_type: organisation_type_basic(@organisation)),
         rows: 10
 
       = f.govuk_submit t('buttons.save_changes'), classes: 'disabled-on-load'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,7 +57,7 @@ en:
             If a school in your trust is missing from this list,
             or the information isn't correct, please %{mail_to}.
         edit:
-          title: Change description
+          title: Change %{organisation_type} details
       readable_job_location:
         at_multiple_schools: More than one school
         at_multiple_schools_with_count: More than one school (%{count})
@@ -187,7 +187,7 @@ en:
         job_summary_html: "Job summary (<span class='text-red'>Required</span>)"
         about_organisation_html: "About %{organisation} (<span class='text-red'>Required</span>)"
       organisation_form:
-        description: Description of school or trust
+        description: Description of %{organisation_type}
     hint:
       copy_vacancy_form:
         publish_on: For example, 01 01 2020
@@ -230,12 +230,12 @@ en:
           Give a brief summary of the job that job seekers can quickly scan.
           This will be the first thing they see on the listing or in search engine results
         about_organisation: >-
-          This will appear next to the job details under '%{organisation} overview'. Feel free to adapt this text
+          This will appear next to the job details under '%{organisation_type} overview'. Feel free to adapt this text
         about_schools: >-
           Give a brief summary of the schools where the jobseeker would be teaching and any relevant information about
           the trust
       organisation_form:
-        description: Jobseekers will see this description of the school in the job listing
+        description: Jobseekers will see this description of the %{organisation_type} in the job listing
   organisation:
     view_more_or_change: View more or change
   jobs:
@@ -863,7 +863,7 @@ en:
     feedback:
       submitted: Your feedback has been successfully submitted
     organisation:
-      description_updated_html: 'Description updated for <span class="govuk-!-font-weight-bold">%{organisation}</span>'
+      description_updated_html: 'Details updated for <span class="govuk-!-font-weight-bold">%{organisation}</span>'
     subscriptions:
       created: Email subscription created successfully.
   errors:

--- a/spec/system/hiring_staff_can_manage_schools_in_trust_spec.rb
+++ b/spec/system/hiring_staff_can_manage_schools_in_trust_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Schools in your trust' do
     click_button I18n.t('buttons.save_changes')
 
     expect(page).to have_content('New description of the trust')
-    expect(page).to have_content("Description updated for #{school_group.name}")
+    expect(page).to have_content("Details updated for #{school_group.name}")
 
     visit edit_organisation_school_path(school_1)
 
@@ -53,6 +53,6 @@ RSpec.describe 'Schools in your trust' do
     click_button I18n.t('buttons.save_changes')
 
     expect(page).to have_content('New description of the school')
-    expect(page).to have_content("Description updated for #{school_1.name}")
+    expect(page).to have_content("Details updated for #{school_1.name}")
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1248

## Screenshots of UI changes:

### Trust Details

<img width="1050" alt="Screenshot 2020-09-09 at 16 38 22" src="https://user-images.githubusercontent.com/30624173/92620768-f23acc80-f2ba-11ea-8178-02ec3f2729e6.png">

### School Details

<img width="1010" alt="Screenshot 2020-09-09 at 16 39 23" src="https://user-images.githubusercontent.com/30624173/92620856-0a125080-f2bb-11ea-8db7-ebbde3f7d411.png">

### Notification Change

<img width="1232" alt="Screenshot 2020-09-09 at 16 40 03" src="https://user-images.githubusercontent.com/30624173/92620930-20b8a780-f2bb-11ea-834a-1eaf4dde9bd4.png">
