### PR TITLE
Ticket 1266 use build push action v2 buildkit with cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,26 +42,35 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
+
     - name: Login to DockerHub
       uses: docker/login-action@v1 
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Build and push
+
+    - name: Build and push docker dev-build image
       uses: docker/build-push-action@v2
       with:
-        tags: ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
-        target: production      
+        build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:build-cache-${{ env.BRANCH }}
         push: true
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+        tags: ${{ env.DOCKERHUB_REPOSITORY }}:build-cache-${{ env.BRANCH }}
+        target: dev-build
+
+    - name: Build and push docker production image
+      uses: docker/build-push-action@v2
+      with:
+        build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:build-cache-${{ env.BRANCH }}
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
+        push: true
+        tags: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
+        target: production
 
     - name: Deploy to staging
       env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,16 +39,29 @@ jobs:
       run: |
         TAG=${GITHUB_SHA}
         echo ::set-env name=TAG::${TAG}
-        echo ::set-env name=DOCKER_BUILDKIT::1
 
-    - name: build and push docker image
-      uses: docker/build-push-action@v1.1.0
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.DOCKERHUB_REPOSITORY }}
-        tags: ${{ env.TAG }}
-        target: production
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        tags: ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
+        target: production      
+        push: true
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Deploy to staging
       env:

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -50,26 +50,36 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
+
     - name: Login to DockerHub
       uses: docker/login-action@v1 
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Build and push
+
+    - name: Build and push docker dev-build image
       uses: docker/build-push-action@v2
       with:
-        tags: ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
-        target: production      
+        build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:build-cache-master 
+          ${{ env.DOCKERHUB_REPOSITORY }}:build-cache-${{ env.BRANCH }}
         push: true
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+        tags: ${{ env.DOCKERHUB_REPOSITORY }}:build-cache-${{ env.BRANCH }}
+        target: dev-build
+
+    - name: Build and push docker production image
+      uses: docker/build-push-action@v2
+      with:
+        build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:build-cache-${{ env.BRANCH }}
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
+        push: true
+        tags: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
+        target: production
 
     - name: Deploy
       env:

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -47,16 +47,29 @@ jobs:
         echo ::set-env name=TAG::${TAG}
         echo ::set-output name=BRANCH::${BRANCH}
         echo ::set-output name=TAG::${TAG}
-        echo ::set-env name=DOCKER_BUILDKIT::1
 
-    - name: build and push docker image
-      uses: docker/build-push-action@v1.1.0
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.DOCKERHUB_REPOSITORY }}
-        tags: ${{ env.TAG }}
-        target: production
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        tags: ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
+        target: production      
+        push: true
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Deploy
       env:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -43,6 +43,9 @@ jobs:
 
     - name: Login to DockerHub
       uses: docker/login-action@v1 
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Build and push docker dev-build image
       uses: docker/build-push-action@v2

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -52,7 +52,6 @@ jobs:
       with:
         build-args: BUILDKIT_INLINE_CACHE=1
         cache-from: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
-        push: true
         tags: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
         target: dev-build
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -48,6 +48,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ env.DOCKERHUB_REPOSITORY }}
         build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
         tags: latest-build-cache
         target: dev-build
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -42,25 +42,24 @@ jobs:
         echo ::set-env name=DOCKER_BUILDKIT::1
 
     - name: Build and push docker dev-build image
-      uses: docker/build-push-action@v1.1.1
+      uses: docker/build-push-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: ${{ env.DOCKERHUB_REPOSITORY }}
+        build_args: BUILDKIT_INLINE_CACHE=1
+        cache-from: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
+        push: true
+        tags: latest-build-cache
+        target: dev-build
+
+    - name: Build and push docker production image
+      uses: docker/build-push-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ env.DOCKERHUB_REPOSITORY }}
         add_git_labels: true
-        build_args: BUILDKIT_INLINE_CACHE=1
-        cache-from: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
-        push: true
-        tags: latest-build-cache
-     
-        target: dev-build
-
-    - name: Build and push docker production image
-      uses: docker/build-push-action@v1.1.1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.DOCKERHUB_REPOSITORY }}
         build_args: BUILDKIT_INLINE_CACHE=1
         cache-from: |
           ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -40,28 +40,13 @@ jobs:
         TAG=review-${PR_NAME}-${GITHUB_SHA}-$(date '+%Y%m%d%H%M%S')
         echo ::set-env name=TAG::${TAG}
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-    - name: Login to DockerHub
-      uses: docker/login-action@v1 
+    - name: Build and push docker image
+      uses: docker/build-push-action@v1.1.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Build and push
-      uses: docker/build-push-action@v2
-      with:
-        tags: ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
-        target: production      
-        push: true
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+        repository: ${{ env.DOCKERHUB_REPOSITORY }}
+        tags: ${{ env.TAG }}
 
     - name: Terraform deploy
       env:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -47,9 +47,12 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ env.DOCKERHUB_REPOSITORY }}
+        add_git_labels: true
         build_args: BUILDKIT_INLINE_CACHE=1
         cache_froms: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
+        push: true
         tags: latest-build-cache
+     
         target: dev-build
 
     - name: Build and push docker production image
@@ -59,8 +62,10 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ env.DOCKERHUB_REPOSITORY }}
         build_args: BUILDKIT_INLINE_CACHE=1
-        cache_froms: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
+        cache_froms: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache,${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache
         tags: ${{ env.TAG }}
+        tag_with_ref: true
+        tag_with_sha: true        
         target: dev-build        
 
     - name: Terraform deploy

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -58,16 +58,13 @@ jobs:
     - name: Build and push docker production image
       uses: docker/build-push-action@v2
       with:
-        add_git_labels: true
         build-args: BUILDKIT_INLINE_CACHE=1
         cache-from: |
           ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
           ${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache
         tags: |
           ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
-          ${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache
-        tag_with_ref: true
-        tag_with_sha: true        
+          ${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache    
         target: production        
 
     - name: Terraform deploy

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -52,6 +52,7 @@ jobs:
       with:
         build-args: BUILDKIT_INLINE_CACHE=1
         cache-from: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
+        push: true
         tags: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
         target: dev-build
 
@@ -62,6 +63,7 @@ jobs:
         cache-from: |
           ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
           ${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache
+        push: true
         tags: |
           ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
           ${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache    

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -41,31 +41,28 @@ jobs:
         echo ::set-env name=TAG::${TAG}
         echo ::set-env name=DOCKER_BUILDKIT::1
 
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
+
     - name: Build and push docker dev-build image
       uses: docker/build-push-action@v2
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.DOCKERHUB_REPOSITORY }}
-        build_args: BUILDKIT_INLINE_CACHE=1
+        build-args: BUILDKIT_INLINE_CACHE=1
         cache-from: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
         push: true
-        tags: latest-build-cache
+        tags: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
         target: dev-build
 
     - name: Build and push docker production image
       uses: docker/build-push-action@v2
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.DOCKERHUB_REPOSITORY }}
         add_git_labels: true
-        build_args: BUILDKIT_INLINE_CACHE=1
+        build-args: BUILDKIT_INLINE_CACHE=1
         cache-from: |
           ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
           ${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache
         tags: |
-          ${{ env.TAG }}
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
           ${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache
         tag_with_ref: true
         tag_with_sha: true        

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -42,31 +42,35 @@ jobs:
         echo ::set-env name=DOCKER_BUILDKIT::1
 
     - name: Build and push docker dev-build image
-      uses: docker/build-push-action@v1.1.0
+      uses: docker/build-push-action@v1.1.1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ env.DOCKERHUB_REPOSITORY }}
         add_git_labels: true
         build_args: BUILDKIT_INLINE_CACHE=1
-        cache_froms: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
+        cache-from: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
         push: true
         tags: latest-build-cache
      
         target: dev-build
 
     - name: Build and push docker production image
-      uses: docker/build-push-action@v1.1.0
+      uses: docker/build-push-action@v1.1.1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ env.DOCKERHUB_REPOSITORY }}
         build_args: BUILDKIT_INLINE_CACHE=1
-        cache_froms: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache,${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache
-        tags: ${{ env.TAG }}
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
+          ${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache
+        tags: |
+          ${{ env.TAG }}
+          ${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache
         tag_with_ref: true
         tag_with_sha: true        
-        target: dev-build        
+        target: production        
 
     - name: Terraform deploy
       env:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -39,7 +39,9 @@ jobs:
       run: |
         TAG=review-${PR_NAME}-${GITHUB_SHA}-$(date '+%Y%m%d%H%M%S')
         echo ::set-env name=TAG::${TAG}
-        echo ::set-env name=DOCKER_BUILDKIT::1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
 
     - name: Login to DockerHub
       uses: docker/login-action@v1 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -37,8 +37,12 @@ jobs:
     - name: Set environment variables
       id: set_env_vars
       run: |
+        BRANCH=${{ github.head_ref }}
         TAG=review-${PR_NAME}-${GITHUB_SHA}-$(date '+%Y%m%d%H%M%S')
+        echo ::set-env name=BRANCH::${BRANCH}
         echo ::set-env name=TAG::${TAG}
+        echo ::set-output name=BRANCH::${BRANCH}
+        echo ::set-output name=TAG::${TAG}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -53,9 +57,11 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         build-args: BUILDKIT_INLINE_CACHE=1
-        cache-from: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:build-cache-master 
+          ${{ env.DOCKERHUB_REPOSITORY }}:build-cache-${{ env.BRANCH }}
         push: true
-        tags: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
+        tags: ${{ env.DOCKERHUB_REPOSITORY }}:build-cache-${{ env.BRANCH }}
         target: dev-build
 
     - name: Build and push docker production image
@@ -63,13 +69,13 @@ jobs:
       with:
         build-args: BUILDKIT_INLINE_CACHE=1
         cache-from: |
-          ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
-          ${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache
+          ${{ env.DOCKERHUB_REPOSITORY }}:build-cache-${{ env.BRANCH }}
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
         push: true
         tags: |
           ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
-          ${{ env.DOCKERHUB_REPOSITORY }}:latest-production-cache    
-        target: production        
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
+        target: production
 
     - name: Terraform deploy
       env:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -39,16 +39,29 @@ jobs:
       run: |
         TAG=review-${PR_NAME}-${GITHUB_SHA}-$(date '+%Y%m%d%H%M%S')
         echo ::set-env name=TAG::${TAG}
-        echo ::set-env name=DOCKER_BUILDKIT::1
 
-    - name: Build and push docker image
-      uses: docker/build-push-action@v1.1.0
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.DOCKERHUB_REPOSITORY }}
-        tags: ${{ env.TAG }}
-        target: production
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        tags: ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
+        target: production      
+        push: true
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Terraform deploy
       env:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -39,14 +39,28 @@ jobs:
       run: |
         TAG=review-${PR_NAME}-${GITHUB_SHA}-$(date '+%Y%m%d%H%M%S')
         echo ::set-env name=TAG::${TAG}
+        echo ::set-env name=DOCKER_BUILDKIT::1
 
-    - name: Build and push docker image
+    - name: Build and push docker dev-build image
       uses: docker/build-push-action@v1.1.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ env.DOCKERHUB_REPOSITORY }}
+        build-args: BUILDKIT_INLINE_CACHE=1
+        tags: latest-build-cache
+        target: dev-build
+
+    - name: Build and push docker production image
+      uses: docker/build-push-action@v1.1.0
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: ${{ env.DOCKERHUB_REPOSITORY }}
+        build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
         tags: ${{ env.TAG }}
+        target: dev-build        
 
     - name: Terraform deploy
       env:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -47,8 +47,8 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ env.DOCKERHUB_REPOSITORY }}
-        build-args: BUILDKIT_INLINE_CACHE=1
-        cache-from: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
+        build_args: BUILDKIT_INLINE_CACHE=1
+        cache_froms: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
         tags: latest-build-cache
         target: dev-build
 
@@ -58,8 +58,8 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ env.DOCKERHUB_REPOSITORY }}
-        build-args: BUILDKIT_INLINE_CACHE=1
-        cache-from: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
+        build_args: BUILDKIT_INLINE_CACHE=1
+        cache_froms: ${{ env.DOCKERHUB_REPOSITORY }}:latest-build-cache
         tags: ${{ env.TAG }}
         target: dev-build        
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,44 @@
-FROM dfedigital/teaching-vacancies:builder AS builder
-FROM dfedigital/teaching-vacancies:final
-USER app
+FROM ruby:2.7.1-alpine AS dev-build
+
+ARG DEV_PACKAGES="gcc libc-dev make yarn postgresql-dev build-base libxml2-dev libxslt-dev"
+
+WORKDIR /teacher-vacancy
+
+RUN apk add --no-cache libxml2 libxslt libpq tzdata nodejs $DEV_PACKAGES
+RUN echo "Europe/London" > /etc/timezone && \
+        cp /usr/share/zoneinfo/Europe/London /etc/localtime
+RUN gem install bundler:2.1.4 --no-document
+
+COPY Gemfile* ./
+RUN bundle install --no-binstubs --retry=5 --jobs=4 --no-cache --without development test
+
+COPY package.json yarn.lock ./
+RUN yarn install --check-files
+
+COPY . .
+
+RUN RAILS_ENV=staging bundle exec rake webpacker:compile
+
+RUN rm -rf node_modules log tmp yarn.lock && \
+      rm -rf /usr/local/bundle/cache && \
+      rm -rf .env && touch .env && \
+      find /usr/local/bundle/gems -name "*.c" -delete && \
+      find /usr/local/bundle/gems -name "*.h" -delete && \
+      find /usr/local/bundle/gems -name "*.o" -delete && \
+      find /usr/local/bundle/gems -name "*.html" -delete
+
+
+# this stage reduces the image size.
+FROM ruby:2.7.1-alpine AS production
+WORKDIR /teacher-vacancy
+
+RUN apk update && apk add --no-cache libxml2 libxslt libpq tzdata nodejs
+RUN echo "Europe/London" > /etc/timezone && \
+        cp /usr/share/zoneinfo/Europe/London /etc/localtime
+RUN gem install bundler:2.1.4 --no-document
+
+COPY --from=dev-build /teacher-vacancy /teacher-vacancy
+COPY --from=dev-build /usr/local/bundle/ /usr/local/bundle/
+
+EXPOSE 3000
 CMD bundle exec rails db:migrate && bundle exec rails s

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,4 @@
-FROM ruby:2.7.1-alpine AS dev-build
-
-ARG DEV_PACKAGES="gcc libc-dev make yarn postgresql-dev build-base libxml2-dev libxslt-dev"
-
-WORKDIR /teacher-vacancy
-
-RUN apk add --no-cache libxml2 libxslt libpq tzdata nodejs $DEV_PACKAGES
-RUN echo "Europe/London" > /etc/timezone && \
-        cp /usr/share/zoneinfo/Europe/London /etc/localtime
-RUN gem install bundler:2.1.4 --no-document
-
-COPY Gemfile* ./
-RUN bundle install --no-binstubs --retry=5 --jobs=4 --no-cache --without development test
-
-COPY package.json yarn.lock ./
-RUN yarn install --check-files
-
-COPY . .
-
-RUN RAILS_ENV=staging bundle exec rake webpacker:compile
-
-RUN rm -rf node_modules log tmp yarn.lock && \
-      rm -rf /usr/local/bundle/cache && \
-      rm -rf .env && touch .env && \
-      find /usr/local/bundle/gems -name "*.c" -delete && \
-      find /usr/local/bundle/gems -name "*.h" -delete && \
-      find /usr/local/bundle/gems -name "*.o" -delete && \
-      find /usr/local/bundle/gems -name "*.html" -delete
-
-
-# this stage reduces the image size.
-FROM ruby:2.7.1-alpine AS production
-WORKDIR /teacher-vacancy
-
-RUN apk update && apk add --no-cache libxml2 libxslt libpq tzdata nodejs
-RUN echo "Europe/London" > /etc/timezone && \
-        cp /usr/share/zoneinfo/Europe/London /etc/localtime
-RUN gem install bundler:2.1.4 --no-document
-
-COPY --from=dev-build /teacher-vacancy /teacher-vacancy
-COPY --from=dev-build /usr/local/bundle/ /usr/local/bundle/
-
-EXPOSE 3000
+FROM dfedigital/teaching-vacancies:builder AS builder
+FROM dfedigital/teaching-vacancies:final
+USER app
 CMD bundle exec rails db:migrate && bundle exec rails s

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,75 @@
+FROM ruby:2.7.1-alpine
+
+WORKDIR /app
+
+RUN set -eux; \
+	\
+        apk update && \
+        apk add --no-cache \
+                build-base \
+                gcc \
+                libc-dev \
+                libpq \
+                libxml2 \
+                libxml2-dev \
+                libxslt \
+                libxslt \
+                make \
+                nodejs \
+                postgresql-dev \
+                tzdata \
+                yarn
+
+RUN echo "Europe/London" > /etc/timezone && \
+        cp /usr/share/zoneinfo/Europe/London /etc/localtime
+
+# skip installing gem documentation
+RUN set -eux; \
+	mkdir -p /usr/local/etc; \
+	{ \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+# Install the version of bundler which generated Gemfile.lock
+RUN gem install bundler:2.1.4
+
+# Install standard Node modules
+COPY package.json yarn.lock /app/
+RUN yarn install --frozen-lockfile
+
+# Install standard gems
+COPY Gemfile* /app/
+RUN bundle config --local frozen 1 && \
+    bundle install --no-binstubs --retry=5 --jobs=4
+
+#### ONBUILD: Add triggers to the image, executed later while building a child image
+
+# Install Ruby gems (for production only)
+ONBUILD COPY Gemfile* /app/
+ONBUILD RUN bundle config --local without 'development test' && \
+            bundle --no-binstubs --retry=5 --jobs=4 && \
+            # Remove unneeded gems
+            bundle clean --force && \
+            # Remove unneeded files from installed gems (cached *.gem, *.o, *.c)
+            rm -rf /usr/local/bundle/cache/*.gem && \
+            find /usr/local/bundle/gems/ -name "*.c" -delete && \
+            find /usr/local/bundle/gems/ -name "*.h" -delete && \
+            find /usr/local/bundle/gems/ -name "*.o" -delete && \
+            find /usr/local/bundle/gems/ -name "*.html"
+
+# Copy the whole application folder into the image
+ONBUILD COPY . /app
+
+# Compile assets with Webpacker or Sprockets
+#
+# Notes:
+#   1. Executing "assets:precompile" runs "yarn:install" prior
+#   2. Executing "assets:precompile" runs "webpacker:compile", too
+#
+ONBUILD RUN RAILS_ENV=staging \
+            bundle exec rails assets:precompile
+
+# Remove folders not needed in resulting image
+ONBUILD RUN rm -rf log node_modules spec test tmp vendor/bundle yarn.lock && \
+            rm -rf .env && touch .env

--- a/Dockerfile.final
+++ b/Dockerfile.final
@@ -1,0 +1,38 @@
+FROM ruby:2.7.1-alpine
+WORKDIR /app
+
+RUN set -eux; \
+	\
+        apk update && \
+        apk add --no-cache \
+                libpq \
+                libxml2 \
+                libxslt \
+                nodejs \
+                tzdata               
+RUN echo "Europe/London" > /etc/timezone && \
+        cp /usr/share/zoneinfo/Europe/London /etc/localtime
+
+# skip installing gem documentation
+RUN set -eux; \
+	mkdir -p /usr/local/etc; \
+	{ \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+# Install the version of bundler which generated Gemfile.lock
+RUN gem install bundler:2.1.4
+
+# This image is for production env only
+ENV RAILS_ENV staging
+
+# Add user
+ONBUILD RUN addgroup -g 1000 -S app && \
+            adduser -u 1000 -S app -G app
+
+# Copy app with gems from former build stage
+ONBUILD COPY --from=builder --chown=app:app /usr/local/bundle/ /usr/local/bundle/
+ONBUILD COPY --from=builder --chown=app:app /app /app
+
+EXPOSE 3000

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ build-local-image:
 			--target production \
 			.
 
+		docker push $(repository):latest-production-cache
 		docker push $(repository):$(tag)
 
 .PHONY: deploy-local-image

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,20 @@ production:
 		$(eval env=production)
 		$(eval var_file=production)
 
+.PHONY: build-builder-image
+build-builder-image:
+		$(eval tag=builder)
+		docker pull $(repository):$(tag)
+		docker build -t $(repository):$(tag) --file Dockerfile.$(tag) .
+		docker push $(repository):$(tag)
+
+.PHONY: build-final-image
+build-final-image:
+		$(eval tag=final)
+		docker pull $(repository):$(tag)
+		docker build -t $(repository):$(tag) --file Dockerfile.$(tag) .
+		docker push $(repository):$(tag)		
+
 .PHONY: build-local-image
 build-local-image:
 		$(eval tag=dev-$(shell git rev-parse HEAD)-$(shell date '+%Y%m%d%H%M%S'))


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1266

## Changes in this PR:

- Update GitHub action `docker/build-push-action` to v2 which has buildkit enabled
- Uses GitHub cache action for Docker layer caching
