### PR TITLE
Bigquery fix vacancy tagging complexity

### DIFF
--- a/bigquery/calculate-daily-vacancy-tag-time-metrics.sql
+++ b/bigquery/calculate-daily-vacancy-tag-time-metrics.sql
@@ -38,19 +38,6 @@ WITH
     vacancy.id,
     job_roles,
     category),
-  scraped_vacancies_in_scope AS (
-  SELECT
-    scraped_vacancy.scraped_url AS url,
-    MIN(scraped_vacancy.publish_on) AS publish_on,
-    MIN(scraped_vacancy.expires_on) AS expires_on,
-    scraped_vacancy.vacancy_category AS category,
-    scraped_vacancy.source AS source
-  FROM
-    `teacher-vacancy-service.production_dataset.scraped_vacancies_in_scope` AS scraped_vacancy
-  GROUP BY
-    url,
-    category,
-    source ),
   all_vacancy_metrics AS (
   SELECT
     dates.date AS date,
@@ -84,7 +71,7 @@ WITH
   FROM
     dates
   CROSS JOIN
-    scraped_vacancies_in_scope
+     `teacher-vacancy-service.production_dataset.scraped_vacancies_in_scope` AS scraped_vacancies_in_scope
   WHERE
     scraped_vacancies_in_scope.source="TES"
   GROUP BY

--- a/bigquery/views/scraped_vacancies.sql
+++ b/bigquery/views/scraped_vacancies.sql
@@ -247,7 +247,7 @@ WITH
           scraped_words=TV_words))<0.2 #allow only 1 in 5 words to be in one title but not in the other
       AND vacancies_joined_to_schools_and_groups.publish_on > DATE_SUB(TV_vacancy.publish_on, INTERVAL 14 DAY) #only match vacancies which were published within a fortnight of a vacancy in our database
       AND vacancies_joined_to_schools_and_groups.publish_on < DATE_ADD(TV_vacancy.publish_on, INTERVAL 14 DAY) )
-  SELECT
+  SELECT DISTINCT
     vacancies_joined_to_schools_and_groups.*,
   IF
     (LOWER(vacancies_joined_to_schools_and_groups.title) LIKE '%head%'


### PR DESCRIPTION
## Changes in this PR:

- Ensure that the scraped_vacancy and scraped_vacancies_in_scope views only contain DISTINCT vacancies.
- Remove a subquery from a query that was failing due to surpassing BigQuery's complexity limit.
- Didn't fix the root cause - the crawler appears to be recording the same vacancy multiple times. Will work on this next.