### PR TITLE
Set cookies preferences

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,8 @@ class ApplicationController < ActionController::Base
   before_action :detect_device_format
   before_action :set_root_headers
 
+  helper_method :cookies_preference_set?
+
   include AuthenticationConcerns
   include Ip
 
@@ -51,6 +53,10 @@ class ApplicationController < ActionController::Base
         params[form_key][field] = params[form_key][field]&.reject(&:blank?) unless params[form_key][field].is_a?(String)
       end
     end
+  end
+
+  def cookies_preference_set?
+    cookies['consented-to-cookies'].present?
   end
 
 private

--- a/app/controllers/cookies_preferences_controller.rb
+++ b/app/controllers/cookies_preferences_controller.rb
@@ -1,0 +1,35 @@
+class CookiesPreferencesController < ApplicationController
+  before_action :redirect_unless_cookies_feature_enabled
+  before_action :set_previous_url_in_session
+
+  def new
+    @cookies_preferences_form = CookiesPreferencesForm.new({ cookies_consent: cookies['consented-to-cookies'] })
+  end
+
+  def create
+    @cookies_preferences_form = CookiesPreferencesForm.new(cookies_preferences_params)
+
+    if @cookies_preferences_form.valid?
+      cookies['consented-to-cookies'] = { value: @cookies_preferences_form.cookies_consent, expires: 6.months.from_now }
+      redirect_to session[:previous_url]
+    else
+      render :new
+    end
+  end
+
+private
+
+  def cookies_preferences_params
+    (params[:cookies_preferences_form] || params).permit(:cookies_consent)
+  end
+
+  def redirect_unless_cookies_feature_enabled
+    redirect_to page_path('cookies') unless CookiesBannerFeature.enabled?
+  end
+
+  def set_previous_url_in_session
+    previous_path = URI(request.referrer || '').path
+    session[:previous_url] = previous_path unless previous_path == cookies_preferences_path
+    session[:previous_url] = root_path if session[:previous_url].nil?
+  end
+end

--- a/app/form_models/cookies_preferences_form.rb
+++ b/app/form_models/cookies_preferences_form.rb
@@ -1,0 +1,11 @@
+class CookiesPreferencesForm
+  include ActiveModel::Model
+
+  attr_accessor :cookies_consent
+
+  validates :cookies_consent, inclusion: { in: %w[yes no] }
+
+  def initialize(params = {})
+    @cookies_consent = params[:cookies_consent]
+  end
+end

--- a/app/views/cookies_preferences/_cookies_consent_form.html.haml
+++ b/app/views/cookies_preferences/_cookies_consent_form.html.haml
@@ -1,0 +1,10 @@
+= form_for @cookies_preferences_form, url: create_cookies_preferences_path do |f|
+  = f.govuk_error_summary
+
+  = f.govuk_collection_radio_buttons :cookies_consent,
+    [['yes', t('cookies.form.options.consent')], ['no', t('cookies.form.options.no_consent')]],
+    :first,
+    :last,
+    legend: { text: t('cookies.form.legend') }
+
+  = f.govuk_submit t('cookies.form.buttons.save_changes')

--- a/app/views/cookies_preferences/new.html.haml
+++ b/app/views/cookies_preferences/new.html.haml
@@ -1,0 +1,53 @@
+- content_for :page_title_prefix, t("cookies.page.title")
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl= t("cookies.page.heading")
+
+    %h2.govuk-heading-l= t("cookies.page.subheading")
+    %p.govuk-body= t("cookies.page.body.explanation")
+
+    %p.govuk-body= t("cookies.page.body.details.intro")
+    %ul.govuk-list.govuk-list--bullet
+      - t("cookies.page.body.details.list").each do |list_text|
+        %li=list_text
+
+    %p.govuk-body= t("cookies.page.body.anonymity")
+
+    = render "cookies_consent_form"
+
+    %h2.govuk-heading-l= t("cookies.page.body.usage.heading")
+
+    %h3.govuk-heading-m= t("cookies.page.body.usage.essential.heading")
+    %p.govuk-body= t("cookies.page.body.usage.essential.intro")
+
+    %table.govuk-table
+      %thead.govuk-table__head
+        %th.govuk-table__header= t("cookies.page.body.usage.essential.table.header.name")
+        %th.govuk-table__header= t("cookies.page.body.usage.essential.table.header.purpose")
+        %th.govuk-table__header= t("cookies.page.body.usage.essential.table.header.expires")
+      %tr.govuk-table__row
+        %td.govuk-table__cell= t("cookies.page.body.usage.essential.table.teaching_vacancies.name")
+        %td.govuk-table__cell= t("cookies.page.body.usage.essential.table.teaching_vacancies.purpose")
+        %td.govuk-table__cell= t("cookies.page.body.usage.essential.table.teaching_vacancies.expires")
+      %tr.govuk-table__row
+        %td.govuk-table__cell= t("cookies.page.body.usage.essential.table.consent.name")
+        %td.govuk-table__cell= t("cookies.page.body.usage.essential.table.consent.purpose")
+        %td.govuk-table__cell= t("cookies.page.body.usage.essential.table.consent.expires")
+
+    %h3.govuk-heading-m= t("cookies.page.body.usage.google_analytics.heading")
+    %p.govuk-body= t("cookies.page.body.usage.google_analytics.intro")
+
+    %table.govuk-table
+      %thead.govuk-table__head
+        %th.govuk-table__header= t("cookies.page.body.usage.google_analytics.table.header.name")
+        %th.govuk-table__header= t("cookies.page.body.usage.google_analytics.table.header.purpose")
+        %th.govuk-table__header= t("cookies.page.body.usage.google_analytics.table.header.expires")
+      - %w[first second third fourth].each do |row|
+        %tr.govuk-table__row
+          %td.govuk-table__cell= t("cookies.page.body.usage.google_analytics.table.#{row}.name")
+          %td.govuk-table__cell= t("cookies.page.body.usage.google_analytics.table.#{row}.purpose")
+          %td.govuk-table__cell= t("cookies.page.body.usage.google_analytics.table.#{row}.expires")
+
+    %h2.govuk-heading-l= t("cookies.page.body.service.heading")
+    %p.govuk-body= t("cookies.page.body.service.intro_html", feedback_link: link_to(t("cookies.page.body.service.feedback"), new_feedback_path, class: "govuk-link"))

--- a/app/views/layouts/_cookies_banner.html.haml
+++ b/app/views/layouts/_cookies_banner.html.haml
@@ -1,6 +1,6 @@
-.cookies-banner{ aria: { label: t("cookies_banner.aria_label") }, role: "region" }
+.cookies-banner{ aria: { label: t("cookies.banner.aria.label") }, role: "region" }
   .govuk-width-container
-    %h3.govuk-heading-s{ class: "govuk-!-margin-bottom-2" }= t("cookies_banner.heading")
-    %p.govuk-body= t("cookies_banner.body")
-    %button.govuk-button{ class: "govuk-!-margin-right-2 govuk-!-margin-bottom-3" }= t("cookies_banner.buttons.accept_all")
-    %button.govuk-button.govuk-button--secondary{ class: "govuk-!-margin-bottom-3" }= t("cookies_banner.buttons.set_preferences")
+    %h3.govuk-heading-s{ class: "govuk-!-margin-bottom-2" }= t("cookies.banner.heading")
+    %p.govuk-body= t("cookies.banner.body")
+    = link_to t("cookies.banner.buttons.accept_all"), create_cookies_preferences_path(cookies_consent: "yes"), method: :post, class: "govuk-button govuk-!-margin-bottom-3 govuk-!-margin-right-2"
+    = link_to t("cookies.banner.buttons.set_preferences"), cookies_preferences_path, class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-3"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,7 +4,7 @@
 %html.govuk-template.app-html-class{ lang: "en" }
   /<![endif]
   %head
-    = render partial: 'shared/google_tag_manager_head'
+    = render partial: 'shared/google_tag_manager_head' if !CookiesBannerFeature.enabled? || cookies['consented-to-cookies'] == 'yes'
     = render partial: 'shared/open_graph'
     = render partial: 'shared/meta'
     %meta{ charset: "utf-8" }/
@@ -29,7 +29,7 @@
     %meta{ content: asset_pack_path('media/images/govuk-opengraph-image.png'), property: "og:image" }/
     = csrf_meta_tags
   %body{ class: body_class, data: { vacancy_state: @vacancy.present? ? @vacancy.state : 'create' } }
-    = render partial: 'shared/google_tag_manager_body'
+    = render partial: 'shared/google_tag_manager_body' if !CookiesBannerFeature.enabled? || cookies['consented-to-cookies'] == 'yes'
     :javascript
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     = render 'shared/skip_links'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -33,7 +33,7 @@
     :javascript
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     = render 'shared/skip_links'
-    = render 'layouts/cookies_banner' if CookiesBannerFeature.enabled? && !current_page?(page_path('cookies'))
+    = render 'layouts/cookies_banner' unless !CookiesBannerFeature.enabled? || controller_name == 'cookies_preferences' || cookies_preference_set?
     %header.govuk-header{ "data-module": "govuk-header", role: "banner" }
       .govuk-header__container.govuk-width-container
         .govuk-header__logo
@@ -95,7 +95,7 @@
                   %li.govuk-footer-list-item
                     = link_to t('footer.provide_feedback'), new_feedback_path, class: 'govuk-footer__link'
                   %li.govuk-footer-list-item
-                    =link_to 'Cookies', page_path('cookies'), class: 'govuk-footer__link'
+                    =link_to 'Cookies', CookiesBannerFeature.enabled? ? cookies_preferences_path : page_path('cookies'), class: 'govuk-footer__link'
                   %li.govuk-footer-list-item
                     =link_to 'Privacy policy', page_path('privacy-policy'), class: 'govuk-footer__link'
                   %li.govuk-footer-list-item

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -65,6 +65,9 @@ en:
   hiring_staff_user_preference_errors:
     managed_organisations:
       blank: Select which schools' job listings you would like to view
+  cookies_preferences_errors: &cookies_preferences_errors
+    cookies_consent:
+      inclusion: Please select an option
   errors:
     format: "%{message}"
     title:
@@ -107,6 +110,9 @@ en:
         organisation_form:
           attributes:
             <<: *organisation_errors
+        cookies_preferences_form:
+          attributes:
+            <<: *cookies_preferences_errors
         nqt_job_alerts_form:
           attributes:
             keywords:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,7 +49,7 @@ en:
             - how you got to the site
             - what you click on while you're visiting the site
         explanation: >-
-          We use Google Analytics software to collection information about how you use Teaching Vacancies.
+          We use Google Analytics software to collect information about how you use Teaching Vacancies.
           We do this to make sure the site is meeting the needs of our users and to help us make improvements
           based on those needs.
         usage:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,15 +17,94 @@ en:
     menu: 'Menu'
     description: 'The free service for schools in England to list teaching roles and for jobseekers to find them.'
     govuk: 'GOV.UK'
-  cookies_banner:
-    aria_label: Cookies banner
-    body: >-
-      We use cookies to collect information about how you use Teaching Vacancies. This helps us to make our service work
-      as well as possible and helps us to improve it in the future.
-    buttons:
-      accept_all: Accept all cookies
-      set_preferences: Set your preferences
-    heading: Cookies on Teaching Vacancies
+
+  cookies:
+    banner:
+      aria:
+        label: Cookies banner
+      body: >-
+        We use cookies to collect information about how you use Teaching Vacancies. This helps us to make our service work
+        as well as possible and helps us to improve it in the future.
+      buttons:
+        accept_all: Accept all cookies
+        set_preferences: Set your preferences
+      heading: Cookies on Teaching Vacancies
+    form:
+      buttons:
+        save_changes: Save changes
+      legend: Do you want to accept Google Analytics cookies?
+      options:
+        consent: Yes, opt-in to Google Analytics cookies
+        no_consent: No, do not use cookies to track my website usage
+    page:
+      body:
+        anonymity: >-
+          We don't allow Google to use or share our analytics data. We anonymise any personally identifiable data,
+          like your IP address or your postcode before we share it with Google.
+        details:
+          intro: 'Google Analytics stores information about:'
+          list:
+            - the pages you visit on Teaching Vacancies
+            - how long you spend on each page
+            - how you got to the site
+            - what you click on while you're visiting the site
+        explanation: >-
+          We use Google Analytics software to collection information about how you use Teaching Vacancies.
+          We do this to make sure the site is meeting the needs of our users and to help us make improvements
+          based on those needs.
+        usage:
+          heading: How we use cookies
+          essential:
+            heading: Essential cookies
+            intro: 'Essential Teaching Vacancies cookies include:'
+            table:
+              header:
+                expires: Expires
+                name: Name
+                purpose: Purpose
+              consent:
+                expires: 6 months
+                name: consented-to-cookies
+                purpose: Saves your cookie consent settings
+              teaching_vacancies:
+                expires: When you close your browser
+                name: _teachingvacancies_session
+                purpose: Stores encrypted information about your time on the website
+          google_analytics:
+            heading: Measuring website usage (Google Analytics)
+            intro: 'Google Analytics sets the following cookies:'
+            table:
+              header:
+                expires: Expires
+                name: Name
+                purpose: Purpose
+              first:
+                expires: 2 years
+                name: _ga
+                purpose: Used to distinguish anonymous users
+              second:
+                expires: 24 hours
+                name: _gid
+                purpose: Used to distinguish anonymous users
+              third:
+                expires: 10 minutes
+                name: _gat_UA_11508887-2
+                purpose: Used to regulate how quickly data is passed to Google Analytics
+              fourth:
+                expires: 10 minutes
+                name: _gat_UA_145652997-2
+                purpose: Used to regulate how quickly data is passed to Google Analytics
+        service:
+          feedback: Your feedback
+          heading: Our service
+          intro_html: >-
+            Teaching Vacancies is a free job-listing service from the Department for Education.
+            It helps schools to save money on recruitment and you to take the next step in your career.
+            %{feedback_link} will help us improve the service
+      heading: Cookies
+      subheading: Cookies that measure website use
+      title: Cookies
+
   hiring_staff:
     managed_organisations:
       page_title: Manage your view

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
 
   get '/pages/*id' => 'pages#show', as: :page, format: false
 
+  get '/cookies-preferences', to: 'cookies_preferences#new', as: 'cookies_preferences'
+  post '/cookies-preferences', to: 'cookies_preferences#create', as: 'create_cookies_preferences'
+
   resources :updates, only: %i[index]
 
   resources :jobs, only: %i[index show], controller: 'vacancies' do

--- a/spec/controllers/cookies_preferences_controller_spec.rb
+++ b/spec/controllers/cookies_preferences_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe CookiesPreferencesController, type: :controller do
+  before do
+    allow(CookiesBannerFeature).to receive(:enabled?).and_return(cookies_banner_enabled)
+  end
+
+  context 'when CookiesBannerFeature is enabled' do
+    let(:cookies_banner_enabled) { true }
+
+    describe '#new' do
+      it 'returns success' do
+        get :new
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    describe '#create' do
+      it 'sets cookie value' do
+        post :create, params: { cookies_consent: 'yes' }
+        expect(response.cookies['consented-to-cookies']).to eql('yes')
+      end
+    end
+  end
+
+  context 'when CookiesBannerFeature is disabled' do
+    let(:cookies_banner_enabled) { false }
+
+    describe '#new' do
+      it 'redirects to the cookies page' do
+        get :new
+        expect(response).to redirect_to(page_path('cookies'))
+      end
+    end
+
+    describe '#create' do
+      it 'redirects to the cookies page' do
+        post :create
+        expect(response).to redirect_to(page_path('cookies'))
+      end
+    end
+  end
+end

--- a/spec/form_models/cookies_preferences_form_spec.rb
+++ b/spec/form_models/cookies_preferences_form_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe CookiesPreferencesForm, type: :model do
+  let(:cookies_consent) { 'yes' }
+
+  let(:params) { { cookies_consent: cookies_consent } }
+  let(:subject) { described_class.new(params) }
+
+  describe '#initialize' do
+    it 'assigns attributes' do
+      expect(subject.cookies_consent).to eql(cookies_consent)
+    end
+  end
+
+  describe '#validations' do
+    context 'when cookies_consent is blank' do
+      let(:cookies_consent) { nil }
+
+      it 'is invalid' do
+        expect(subject.valid?).to be false
+      end
+
+      it 'raises correct error message' do
+        subject.valid?
+
+        expect(subject.errors.messages[:cookies_consent].first).to eql(
+          I18n.t('cookies_preferences_errors.cookies_consent.inclusion'),
+        )
+      end
+    end
+
+    context "when cookies_consent is not 'yes' or 'no'" do
+      let(:cookies_consent) { 'invalid_option' }
+
+      it 'is invalid' do
+        expect(subject.valid?).to be false
+      end
+
+      it 'raises correct error message' do
+        subject.valid?
+
+        expect(subject.errors.messages[:cookies_consent].first).to eql(
+          I18n.t('cookies_preferences_errors.cookies_consent.inclusion'),
+        )
+      end
+    end
+
+    context 'when cookies_consent is valid' do
+      let(:cookies_consent) { 'yes' }
+
+      it 'is valid' do
+        expect(subject.valid?).to be true
+      end
+    end
+  end
+end

--- a/spec/system/cookies_banner_spec.rb
+++ b/spec/system/cookies_banner_spec.rb
@@ -1,8 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Cookies banner' do
+  let(:cookies_preference_set) { false }
+
   before do
     allow(CookiesBannerFeature).to receive(:enabled?).and_return(cookies_banner_enabled)
+    allow_any_instance_of(ApplicationController).to receive(:cookies_preference_set?).and_return(cookies_preference_set)
     visit root_path
   end
 
@@ -11,14 +14,22 @@ RSpec.describe 'Cookies banner' do
 
     scenario 'displays cookies banner' do
       within '.cookies-banner' do
-        expect(page).to have_content(I18n.t('cookies_banner.heading'))
+        expect(page).to have_content(I18n.t('cookies.banner.heading'))
       end
     end
 
-    context 'when visiting cookies page' do
+    context 'when visiting cookies_preferences page' do
       scenario 'does not display cookies banner' do
-        visit page_path('cookies')
-        expect(page).to_not have_content(I18n.t('cookies_banner.heading'))
+        visit cookies_preferences_path
+        expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
+      end
+    end
+
+    context 'when cookies_preference_set? is true' do
+      let(:cookies_preference_set) { true }
+
+      scenario 'does not display cookies banner' do
+        expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
       end
     end
   end
@@ -27,7 +38,7 @@ RSpec.describe 'Cookies banner' do
     let(:cookies_banner_enabled) { false }
 
     scenario 'does not display cookies banner' do
-      expect(page).to_not have_content(I18n.t('cookies_banner.heading'))
+      expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
     end
   end
 end

--- a/spec/system/cookies_consent_spec.rb
+++ b/spec/system/cookies_consent_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe 'Cookies consent' do
+  before do
+    allow(CookiesBannerFeature).to receive(:enabled?).and_return(cookies_banner_enabled)
+  end
+
+  context 'when CookiesBannerFeature is disabled' do
+    let(:cookies_banner_enabled) { false }
+
+    scenario 'redirects to cookies page' do
+      visit cookies_preferences_path
+      expect(page.current_path).to eql(page_path('cookies'))
+    end
+  end
+
+  context 'when CookiesBannerFeature is enabled' do
+    let(:cookies_banner_enabled) { true }
+
+    scenario 'can accept all cookies' do
+      visit root_path
+
+      click_on I18n.t('cookies.banner.buttons.accept_all')
+
+      expect(page.current_path).to eql(root_path)
+      expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
+
+      visit cookies_preferences_path
+      expect(find('#cookies-preferences-form-cookies-consent-yes-field')).to be_checked
+    end
+
+    describe 'setting your preferences' do
+      before do
+        visit jobs_path
+        click_on I18n.t('cookies.banner.buttons.set_preferences')
+      end
+
+      scenario 'can consent to cookies' do
+        find('#cookies-preferences-form-cookies-consent-yes-field').click
+        click_on I18n.t('cookies.form.buttons.save_changes')
+
+        expect(page.current_path).to eql(jobs_path)
+        expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
+
+        visit cookies_preferences_path
+        expect(find('#cookies-preferences-form-cookies-consent-yes-field')).to be_checked
+      end
+
+      scenario 'can not consent to cookies' do
+        find('#cookies-preferences-form-cookies-consent-no-field').click
+        click_on I18n.t('cookies.form.buttons.save_changes')
+
+        expect(page.current_path).to eql(jobs_path)
+        expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
+
+        visit cookies_preferences_path
+        expect(find('#cookies-preferences-form-cookies-consent-no-field')).to be_checked
+      end
+
+      scenario 'renders error if no option selected' do
+        click_on I18n.t('cookies.form.buttons.save_changes')
+
+        expect(page.current_path).to eql(cookies_preferences_path)
+        expect(page).to have_content(I18n.t('cookies_preferences_errors.cookies_consent.inclusion'))
+      end
+    end
+
+    context 'when navigating directly to cookies page' do
+      scenario 'redirects to home page after setting preferences' do
+        visit cookies_preferences_path
+
+        find('#cookies-preferences-form-cookies-consent-yes-field').click
+        click_on I18n.t('cookies.form.buttons.save_changes')
+
+        expect(page.current_path).to eql(root_path)
+        expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
+      end
+    end
+
+    context 'when consented-to-cookies has expired' do
+      scenario 'must re-set cookies_preferences' do
+        visit root_path
+
+        click_on I18n.t('cookies.banner.buttons.accept_all')
+
+        expect(page.current_path).to eql(root_path)
+        expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
+
+        travel_to 7.months.from_now
+
+        visit root_path
+
+        expect(page).to have_content(I18n.t('cookies.banner.heading'))
+      end
+    end
+  end
+end

--- a/spec/system/support_links_spec.rb
+++ b/spec/system/support_links_spec.rb
@@ -1,13 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe 'A visitor to the website can access the support links' do
-  scenario 'the cookie policy' do
-    visit root_path
-    click_on 'Cookies'
+  describe 'the cookie policy' do
+    before do
+      allow(CookiesBannerFeature).to receive(:enabled?).and_return(cookies_banner_feature)
+    end
 
-    expect(page).to have_content('Cookies')
-    expect(page).to have_content("Teaching Vacancies puts small files (known as 'cookies') onto your computer " \
-                                 'to collect information about how you use the service.')
+    context 'when CookiesBannerFeature is enabled' do
+      let(:cookies_banner_feature) { true }
+
+      scenario 'can access cookies policy' do
+        visit root_path
+        click_on 'Cookies'
+
+        expect(page.current_path).to eql(cookies_preferences_path)
+      end
+    end
+
+    context 'when CookiesBannerFeature is disabled' do
+      let(:cookies_banner_feature) { false }
+
+      scenario 'can access cookies policy' do
+        visit root_path
+        click_on 'Cookies'
+
+        expect(page).to have_content('Cookies')
+        expect(page).to have_content("Teaching Vacancies puts small files (known as 'cookies') onto your computer " \
+                                     'to collect information about how you use the service.')
+      end
+    end
   end
 
   scenario 'the privacy policy' do


### PR DESCRIPTION
This PR allows users to set and update their cookie preferences

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1232

## Changes in this PR
- User can set cookies preference
- Cookies banner is only rendered if cookies preference has not been set
- Only run GTM script if user has consented to cookies
