### PR TITLE
[TEVA-635] Add selector for default max width for signed-out users

### DIFF
--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -111,3 +111,11 @@ p {
 .govuk-header__container {
   border-bottom: 10px solid govuk-colour('orange');
 }
+
+body {
+  .govuk-width-container {
+    @include govuk-media-query($from: desktop) {
+      max-width: 1020px;
+    }
+  }
+}


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-635

## Changes in this PR:

Added a selector that sets max-width to 1020px for signed-out users.

When signed in, this will be overwritten by the hiring-staff class

## Screenshots of UI changes:

### Signed-out

![Screenshot 2020-09-17 at 10 53 52](https://user-images.githubusercontent.com/30624173/93455679-92ed4580-f8d4-11ea-931a-a478237b3a96.png)

### Signed-in

![Screenshot 2020-09-17 at 10 56 05](https://user-images.githubusercontent.com/30624173/93455727-9e407100-f8d4-11ea-9c7b-e2b8ba1244b3.png)

