### PR TITLE
[TEVA-1266] Speed up build times with Docker caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,6 @@ jobs:
       run: |
         TAG=${GITHUB_SHA}
         echo ::set-env name=TAG::${TAG}
-        echo ::set-env name=DOCKER_BUILDKIT::1
 
     - name: Set up Ruby 2.7
       uses: actions/setup-ruby@v1
@@ -62,13 +61,27 @@ jobs:
         bin/run-in-env -t /tvs/production -o quiet \
           && echo Data in /tvs/production looks valid
 
-    - name: build and push docker image
-      uses: docker/build-push-action@v1.1.0
+    - name: Build and push docker image from builder target
+      uses: docker/build-push-action@v2
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.DOCKERHUB_REPOSITORY }}
-        tags: ${{ env.TAG }}
+        build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:builder-master
+        push: true
+        tags: ${{ env.DOCKERHUB_REPOSITORY }}:builder-master
+        target: builder
+
+    - name: Build and push docker image from production target
+      uses: docker/build-push-action@v2
+      with:
+        build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:builder-master
+          ${{ env.DOCKERHUB_REPOSITORY }}:master
+        push: true
+        tags: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:master
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
         target: production
 
     - name: Deploy to staging

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -52,7 +52,6 @@ jobs:
         echo ::set-env name=TAG::${TAG}
         echo ::set-output name=BRANCH::${BRANCH}
         echo ::set-output name=TAG::${TAG}
-        echo ::set-env name=DOCKER_BUILDKIT::1
 
     - name: Set up Ruby 2.7
       uses: actions/setup-ruby@v1
@@ -68,13 +67,29 @@ jobs:
         bin/run-in-env -t "/tvs/${BRANCH}" -o quiet \
           && echo Data in "/tvs/${BRANCH}" looks valid
 
-    - name: build and push docker image
-      uses: docker/build-push-action@v1.1.0
+    - name: Build and push docker image from builder target
+      uses: docker/build-push-action@v2
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.DOCKERHUB_REPOSITORY }}
-        tags: ${{ env.TAG }}
+        build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:builder-master
+          ${{ env.DOCKERHUB_REPOSITORY }}:builder-${{ env.BRANCH }}
+        push: true
+        tags: ${{ env.DOCKERHUB_REPOSITORY }}:builder-${{ env.BRANCH }}
+        target: builder
+
+    - name: Build and push docker image from production target
+      uses: docker/build-push-action@v2
+      with:
+        build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:builder-master
+          ${{ env.DOCKERHUB_REPOSITORY }}:builder-${{ env.BRANCH }}
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
+        push: true
+        tags: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
         target: production
 
     - name: Deploy

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -52,17 +52,45 @@ jobs:
     - name: Set environment variables
       id: set_env_vars
       run: |
+        BRANCH=${{ github.head_ref }}
         TAG=review-${PR_NAME}-${GITHUB_SHA}-$(date '+%Y%m%d%H%M%S')
+        echo ::set-env name=BRANCH::${BRANCH}
         echo ::set-env name=TAG::${TAG}
-        echo ::set-env name=DOCKER_BUILDKIT::1
+        echo ::set-output name=BRANCH::${BRANCH}
+        echo ::set-output name=TAG::${TAG}
 
-    - name: Build and push docker image
-      uses: docker/build-push-action@v1.1.0
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.DOCKERHUB_REPOSITORY }}
-        tags: ${{ env.TAG }}
+
+    - name: Build and push docker image from builder target
+      uses: docker/build-push-action@v2
+      with:
+        build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:builder-master
+          ${{ env.DOCKERHUB_REPOSITORY }}:builder-${{ env.BRANCH }}
+        push: true
+        tags: ${{ env.DOCKERHUB_REPOSITORY }}:builder-${{ env.BRANCH }}
+        target: builder
+
+    - name: Build and push docker image from production target
+      uses: docker/build-push-action@v2
+      with:
+        build-args: BUILDKIT_INLINE_CACHE=1
+        cache-from: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:builder-master
+          ${{ env.DOCKERHUB_REPOSITORY }}:builder-${{ env.BRANCH }}
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
+        push: true
+        tags: |
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
+          ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
         target: production
 
     - name: Terraform deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1-alpine AS dev-build
+FROM ruby:2.7.1-alpine AS builder
 
 ARG DEV_PACKAGES="gcc libc-dev make yarn postgresql-dev build-base libxml2-dev libxslt-dev"
 
@@ -37,8 +37,8 @@ RUN echo "Europe/London" > /etc/timezone && \
         cp /usr/share/zoneinfo/Europe/London /etc/localtime
 RUN gem install bundler:2.1.4 --no-document
 
-COPY --from=dev-build /teacher-vacancy /teacher-vacancy
-COPY --from=dev-build /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder /teacher-vacancy /teacher-vacancy
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
 EXPOSE 3000
 CMD bundle exec rails db:migrate && bundle exec rails s


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1266

## Changes in this PR:

- Add cache metadata to generated Docker images, stored in Docker Hub
- Use `cache-from` in generating new images
- Use v2 of `docker/build-push-action` to default to BUILDKIT