### PR TITLE
TEVA-1272 migrate staging domain from dxw

### DIFF
--- a/terraform/app/modules/cloudfront/data.tf
+++ b/terraform/app/modules/cloudfront/data.tf
@@ -1,0 +1,5 @@
+data aws_caller_identity current {}
+
+data aws_s3_bucket cloudfront_logs {
+  bucket = "${data.aws_caller_identity.current.account_id}-tv-cloudfront-logs"
+}

--- a/terraform/app/modules/cloudfront/data.tf
+++ b/terraform/app/modules/cloudfront/data.tf
@@ -3,3 +3,8 @@ data aws_caller_identity current {}
 data aws_s3_bucket cloudfront_logs {
   bucket = "${data.aws_caller_identity.current.account_id}-tv-cloudfront-logs"
 }
+
+data aws_route53_zone zones {
+  for_each = local.route53_zones
+  name     = each.value
+}

--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -149,9 +149,14 @@ resource aws_cloudfront_distribution default {
     ssl_support_method  = "sni-only"
   }
 
+  logging_config {
+    include_cookies = false
+    bucket          = data.aws_s3_bucket.cloudfront_logs.bucket_domain_name
+    prefix          = var.environment
+  }
+
   tags = {
     Name        = "${var.project_name}-${var.environment}"
     Environment = var.environment
   }
 }
-

--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -160,3 +160,25 @@ resource aws_cloudfront_distribution default {
     Environment = var.environment
   }
 }
+
+resource aws_route53_record cloudfront-a-records {
+  for_each = local.route53_zones_with_a_records
+  zone_id  = data.aws_route53_zone.zones[each.value].zone_id
+  name     = each.value
+  type     = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.default.domain_name
+    zone_id                = aws_cloudfront_distribution.default.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource aws_route53_record cloudfront-cnames {
+  for_each = local.route53_zones_with_cnames
+  zone_id  = data.aws_route53_zone.zones[each.value].zone_id
+  name     = "${local.route53_prefix}.${each.value}"
+  type     = "CNAME"
+  ttl      = "300"
+  records  = ["${aws_cloudfront_distribution.default.domain_name}."]
+}

--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -149,10 +149,13 @@ resource aws_cloudfront_distribution default {
     ssl_support_method  = "sni-only"
   }
 
-  logging_config {
-    include_cookies = false
-    bucket          = data.aws_s3_bucket.cloudfront_logs.bucket_domain_name
-    prefix          = var.environment
+  dynamic "logging_config" {
+    for_each = var.cloudfront_enable_standard_logs ? [1] : []
+    content {
+      include_cookies = false
+      bucket          = data.aws_s3_bucket.cloudfront_logs.bucket_domain_name
+      prefix          = var.environment
+    }
   }
 
   tags = {

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -38,3 +38,14 @@ variable default_header_list {
   ]
 }
 
+variable route53_zones {
+  type = list
+}
+
+locals {
+  is_production                = var.environment == "production"
+  route53_prefix               = local.is_production ? "www" : var.environment
+  route53_zones                = toset(var.route53_zones)
+  route53_zones_with_a_records = local.is_production ? local.route53_zones : toset([])
+  route53_zones_with_cnames    = local.route53_zones
+}

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -4,6 +4,9 @@ variable environment {
 variable project_name {
 }
 
+variable cloudfront_enable_standard_logs {
+}
+
 variable cloudfront_origin_domain_name {
 }
 

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -43,17 +43,18 @@ terraform {
 
 
 module cloudfront {
-  source                        = "./modules/cloudfront"
-  for_each                      = var.distribution_list
-  environment                   = var.environment
-  project_name                  = var.project_name
-  cloudfront_origin_domain_name = each.value.cloudfront_origin_domain_name
-  cloudfront_aliases            = each.value.cloudfront_aliases
-  cloudfront_certificate_arn    = local.infra_secrets.cloudfront_certificate_arn
-  offline_bucket_domain_name    = each.value.offline_bucket_domain_name
-  offline_bucket_origin_path    = each.value.offline_bucket_origin_path
-  domain                        = each.value.domain
-  route53_zones                 = var.route53_zones
+  source                          = "./modules/cloudfront"
+  for_each                        = var.distribution_list
+  environment                     = var.environment
+  project_name                    = var.project_name
+  cloudfront_origin_domain_name   = each.value.cloudfront_origin_domain_name
+  cloudfront_aliases              = each.value.cloudfront_aliases
+  cloudfront_certificate_arn      = local.infra_secrets.cloudfront_certificate_arn
+  offline_bucket_domain_name      = each.value.offline_bucket_domain_name
+  offline_bucket_origin_path      = each.value.offline_bucket_origin_path
+  domain                          = each.value.domain
+  cloudfront_enable_standard_logs = each.value.cloudfront_enable_standard_logs
+  route53_zones                   = var.route53_zones
 }
 
 module cloudwatch {

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -53,6 +53,7 @@ module cloudfront {
   offline_bucket_domain_name    = each.value.offline_bucket_domain_name
   offline_bucket_origin_path    = each.value.offline_bucket_origin_path
   domain                        = each.value.domain
+  route53_zones                 = var.route53_zones
 }
 
 module cloudwatch {

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -15,11 +15,12 @@ variable environment {
 variable distribution_list {
   description = "Define Cloudfront distributions with the attributes below"
   type = map(object({
-    cloudfront_aliases            = list(string)
-    offline_bucket_domain_name    = string
-    offline_bucket_origin_path    = string
-    cloudfront_origin_domain_name = string
-    domain                        = string
+    cloudfront_aliases              = list(string)
+    offline_bucket_domain_name      = string
+    offline_bucket_origin_path      = string
+    cloudfront_origin_domain_name   = string
+    domain                          = string
+    cloudfront_enable_standard_logs = bool
   }))
   default = {}
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -24,6 +24,11 @@ variable distribution_list {
   default = {}
 }
 
+variable route53_zones {
+  type    = list
+  default = ["teaching-jobs.service.gov.uk", "teaching-vacancies.service.gov.uk"]
+}
+
 # CloudWatch
 variable channel_list {
   description = "Define slack channels CloudWatch should send alerts to"

--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -122,3 +122,22 @@ resource aws_iam_user_policy_attachment upload_db_backups_to_s3 {
   user       = aws_iam_user.deploy.name
   policy_arn = aws_iam_policy.upload_db_backups_to_s3.arn
 }
+
+# Cloudfront logs to S3
+
+data aws_iam_policy_document cloudfront_logs_to_s3 {
+  statement {
+    actions   = ["s3:GetBucketAcl", "s3:PutBucketAcl"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.cloudfront_logs.bucket}"]
+  }
+}
+
+resource aws_iam_policy cloudfront_logs_to_s3 {
+  name   = "cloudfront_logs_to_s3"
+  policy = data.aws_iam_policy_document.cloudfront_logs_to_s3.json
+}
+
+resource aws_iam_user_policy_attachment cloudfront_logs_to_s3 {
+  user       = aws_iam_user.deploy.name
+  policy_arn = aws_iam_policy.cloudfront_logs_to_s3.arn
+}

--- a/terraform/common/s3.tf
+++ b/terraform/common/s3.tf
@@ -3,3 +3,7 @@ data aws_caller_identity current {}
 resource aws_s3_bucket db_backups {
   bucket = "${data.aws_caller_identity.current.account_id}-tv-db-backups"
 }
+
+resource aws_s3_bucket cloudfront_logs {
+  bucket = "${data.aws_caller_identity.current.account_id}-tv-cloudfront-logs"
+}

--- a/terraform/common/terraform.tf
+++ b/terraform/common/terraform.tf
@@ -3,7 +3,6 @@ provider aws {
 }
 
 terraform {
-  required_version = ">= 0.12.29"
 
   backend "s3" {
     bucket  = "terraform-state-002"

--- a/terraform/common/versions.tf
+++ b/terraform/common/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13.1"
+  required_providers {
+    aws = {
+      source  = "-/aws"
+      version = "~> 3.5.0"
+    }
+  }
+}

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -13,6 +13,7 @@ distribution_list = {
   #    offline_bucket_origin_path    = "/school-jobs-offline"
   #    cloudfront_origin_domain_name = "teaching-vacancies-dev.london.cloudapps.digital"
   #    domain                        = "dev.teaching-vacancies.service.gov.uk"
+  #    cloudfront_enable_standard_logs = false
   #  }
 }
 

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -8,11 +8,12 @@ parameter_store_environment = "production"
 # CloudFront
 distribution_list = {
   "tvsprod" = {
-    cloudfront_aliases            = ["teaching-jobs.service.gov.uk", "www.teaching-jobs.service.gov.uk", "teaching-vacancies.service.gov.uk", "www.teaching-vacancies.service.gov.uk"]
-    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
-    offline_bucket_origin_path    = "/school-jobs-offline"
-    cloudfront_origin_domain_name = "teaching-vacancies-production.london.cloudapps.digital"
-    domain                        = "teaching-vacancies.service.gov.uk"
+    cloudfront_aliases              = ["teaching-jobs.service.gov.uk", "www.teaching-jobs.service.gov.uk", "teaching-vacancies.service.gov.uk", "www.teaching-vacancies.service.gov.uk"]
+    offline_bucket_domain_name      = "tvs-offline.s3.amazonaws.com"
+    offline_bucket_origin_path      = "/school-jobs-offline"
+    cloudfront_origin_domain_name   = "teaching-vacancies-production.london.cloudapps.digital"
+    domain                          = "teaching-vacancies.service.gov.uk"
+    cloudfront_enable_standard_logs = false
   }
 }
 

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -13,6 +13,7 @@ distribution_list = {
   #   offline_bucket_origin_path    = "/school-jobs-offline"
   #   cloudfront_origin_domain_name = "teaching-vacancies-review-pr-2012.london.cloudapps.digital"
   #   domain                        = "review-pr-2012.teaching-vacancies.service.gov.uk"
+  #   cloudfront_enable_standard_logs = false
   # }
 }
 

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -7,13 +7,13 @@ app_environment             = "review"
 
 # CloudFront
 distribution_list = {
-  #  "tvsreview" = {
-  #    cloudfront_aliases            = ["review.teaching-vacancies.service.gov.uk"]
-  #    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
-  #    offline_bucket_origin_path    = "/school-jobs-offline"
-  #    cloudfront_origin_domain_name = "teaching-vacancies-review.london.cloudapps.digital"
-  #    domain                        = "review.teaching-vacancies.service.gov.uk"
-  #  }
+  # "tvsreviewpr2012" = {
+  #   cloudfront_aliases            = ["review-pr-2012.teaching-jobs.service.gov.uk","review-pr-2012.teaching-vacancies.service.gov.uk"]
+  #   offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
+  #   offline_bucket_origin_path    = "/school-jobs-offline"
+  #   cloudfront_origin_domain_name = "teaching-vacancies-review-pr-2012.london.cloudapps.digital"
+  #   domain                        = "review-pr-2012.teaching-vacancies.service.gov.uk"
+  # }
 }
 
 # CloudWatch

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -8,11 +8,12 @@ parameter_store_environment = "staging"
 # CloudFront
 distribution_list = {
   "tvsstaging" = {
-    cloudfront_aliases            = ["staging.teaching-jobs.service.gov.uk", "staging.teaching-vacancies.service.gov.uk"]
-    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
-    offline_bucket_origin_path    = "/school-jobs-offline"
-    cloudfront_origin_domain_name = "teaching-vacancies-staging.london.cloudapps.digital"
-    domain                        = "staging.teaching-vacancies.service.gov.uk"
+    cloudfront_aliases              = ["staging.teaching-jobs.service.gov.uk", "staging.teaching-vacancies.service.gov.uk"]
+    offline_bucket_domain_name      = "tvs-offline.s3.amazonaws.com"
+    offline_bucket_origin_path      = "/school-jobs-offline"
+    cloudfront_origin_domain_name   = "teaching-vacancies-staging.london.cloudapps.digital"
+    domain                          = "staging.teaching-vacancies.service.gov.uk"
+    cloudfront_enable_standard_logs = false
   }
 }
 

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -8,11 +8,11 @@ parameter_store_environment = "staging"
 # CloudFront
 distribution_list = {
   "tvsstaging" = {
-    cloudfront_aliases            = ["tvs.staging.dxw.net", "*.tvs.staging.dxw.net"]
+    cloudfront_aliases            = ["staging.teaching-jobs.service.gov.uk", "staging.teaching-vacancies.service.gov.uk"]
     offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
     offline_bucket_origin_path    = "/school-jobs-offline"
     cloudfront_origin_domain_name = "teaching-vacancies-staging.london.cloudapps.digital"
-    domain                        = "tvs.staging.dxw.net"
+    domain                        = "staging.teaching-vacancies.service.gov.uk"
   }
 }
 

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -11,6 +11,7 @@ distribution_list = {
     offline_bucket_origin_path    = "/school-jobs-offline"
     cloudfront_origin_domain_name = "teaching-vacancies-staging.london.cloudapps.digital"
     domain                        = "staging.teaching-vacancies.service.gov.uk"
+    cloudfront_enable_standard_logs = false
   }
 }
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1272

## Changes in this PR:

- Add Cloudfront standard logs
- Bring Route53 records under Terraform management
- Bring staging domain / URL in line with production and development

## Next steps:

- [x] Update `cloudfront_certificate_arn` in `/tvs/staging/infra/secrets` to use prod cert value
- [x] Import DNS records into Terraform production state
- [ ] Terraform deployment required
- [ ] AWS Certificate Manager - remove certificate for `tvs.staging.dxw.net`, `*.tvs.staging.dxw.net`
- [ ] Request DXW to delete domain `tvs.staging.dxw.net`
- [ ] Circulate updated domain / URL to team