### PR TITLE
[TEVA-1199] Fix content outside of mobile viewport on joblisting page

### DIFF
--- a/app/frontend/styles/components/vacancy.scss
+++ b/app/frontend/styles/components/vacancy.scss
@@ -3,6 +3,7 @@
 
   p {
     margin-top: 5px;
+    overflow-wrap: break-word;
   }
 
   &--metadata {


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1199

## Changes in this PR:

- Added overflow-wrap: break-word style to p tag children of divs with the vacancy class applied

## Screenshots of UI changes:

### Before

#### Desktop

![Screenshot 2020-09-17 at 17 58 59](https://user-images.githubusercontent.com/30624173/93503541-209a5680-f910-11ea-8b19-e2c5ccca0cda.png)

#### Mobile

![Screenshot 2020-09-17 at 18 00 05](https://user-images.githubusercontent.com/30624173/93503603-36a81700-f910-11ea-842f-00313e74b90f.png)

### After

#### Desktop

![Screenshot 2020-09-17 at 17 59 19](https://user-images.githubusercontent.com/30624173/93503806-81299380-f910-11ea-9a9a-57e42aba1518.png)

#### Mobile

![Screenshot 2020-09-17 at 18 00 25](https://user-images.githubusercontent.com/30624173/93503815-84bd1a80-f910-11ea-8a25-94b366835533.png)
