### PR TITLE
Update_nqt_job_alerts_2020_07_29.html.erb

### DIFF
--- a/app/views/updates/update_files/_nqt_job_alerts_2020_07_29.html.erb
+++ b/app/views/updates/update_files/_nqt_job_alerts_2020_07_29.html.erb
@@ -1,2 +1,3 @@
-Newly qualified teachers (NQTs) can now set up a [job alert](https://teaching-vacancies.service.gov.uk/sign-up-for-NQT-job-alerts) that will notify them of any jobs that are suitable for NQTs. 
+Newly qualified teachers (NQTs) can now set up a <%= link_to “job alerts”, "https://teaching-vacancies.service.gov.uk/sign-up-for-NQT-job-alerts"
+%> that will notify them of any jobs that are suitable for NQTs. 
 Users will receive an email each morning with any new roles that have been listed.

--- a/app/views/updates/update_files/_nqt_job_alerts_2020_07_29.html.erb
+++ b/app/views/updates/update_files/_nqt_job_alerts_2020_07_29.html.erb
@@ -1,3 +1,2 @@
-Newly qualified teachers (NQTs) can now set up a <%= link_to “job alerts”, "https://teaching-vacancies.service.gov.uk/sign-up-for-NQT-job-alerts"
-%> that will notify them of any jobs that are suitable for NQTs. 
+Newly qualified teachers (NQTs) can now set up a <%= link_to 'job alert', nqt_job_alerts_path %> that will notify them of any jobs that are suitable for NQTs. 
 Users will receive an email each morning with any new roles that have been listed.

--- a/app/views/updates/update_files/_nqt_job_alerts_2020_07_29.html.erb
+++ b/app/views/updates/update_files/_nqt_job_alerts_2020_07_29.html.erb
@@ -1,2 +1,2 @@
-Newly qualified teachers (NQTs) can now set up a <%= link_to 'job alert', nqt_job_alerts_path %> that will notify them of any jobs that are suitable for NQTs. 
+Newly qualified teachers (NQTs) can now set up a <%= link_to 'job alert', nqt_job_alerts_path, class: 'govuk-link' %> that will notify them of any jobs that are suitable for NQTs. 
 Users will receive an email each morning with any new roles that have been listed.


### PR DESCRIPTION
I have _attempted_ to update the broken link. The text 'job alert' should be a link to the page where NQTs can sign up.