### PR TITLE
[TEVA-1272] Additional IAM permissions for Cloudfront deployment

### DIFF
--- a/terraform/common/route53.tf
+++ b/terraform/common/route53.tf
@@ -1,0 +1,4 @@
+data aws_route53_zone zones {
+  for_each = local.route53_zones
+  name     = each.value
+}

--- a/terraform/common/variables.tf
+++ b/terraform/common/variables.tf
@@ -1,3 +1,12 @@
 variable region { default = "eu-west-2" }
 
 variable s3_bucket_name { default = "terraform-state-002" }
+
+variable route53_zones {
+  type    = list
+  default = ["teaching-jobs.service.gov.uk", "teaching-vacancies.service.gov.uk"]
+}
+
+locals {
+  route53_zones = toset(var.route53_zones)
+}


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1272

## Changes in this PR:

- Added granular IAM permissions for `deploy` user to Route53 and S3
