### PR TITLE
Log errors to Rollbar and redirect to DfE Sign In

### DIFF
--- a/spec/requests/dfe_sign_in_spec.rb
+++ b/spec/requests/dfe_sign_in_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'DfE Sign-in', type: :request do
   context 'when DfE Sign-in respond with an OIDC payload for authentication purposes' do
     context 'when that payload is unauthorised' do
-      it 'redirects the user to the not authorised page' do
+      it 'redirects the user to the DfE sign-in new session page' do
         params = {
           'code': 'a-long-secret',
           'session_state': '123.456'
@@ -12,7 +12,7 @@ RSpec.describe 'DfE Sign-in', type: :request do
         get auth_dfe_callback_path, params: params
 
         expect(response.status).to eq(302)
-        expect(response.body).to eq('Redirecting to /401...')
+        expect(response.body).to eq('Redirecting to /dfe/sessions/new...')
       end
     end
   end


### PR DESCRIPTION
This PR changes our approach when dealing with sign in related errors. 

Driven by https://rollbar.com/dfe/teacher-vacancies/items/2075/ and the now deleted ticket that raised concerns with the number of redirects to error 401 page. 

Now we redirect to DfE Sign In new session page whenever we suspect the users session is stale, or there is an error