### PR TITLE
[TEVA-1272] Move DFE sign in domains to env vars

### DIFF
--- a/terraform/workspace-variables/dev_app_env.yml
+++ b/terraform/workspace-variables/dev_app_env.yml
@@ -2,6 +2,9 @@
 AUTHENTICATION_FALLBACK: false
 BIG_QUERY_DATASET: staging_dataset
 CLOUD_STORAGE_BUCKET: tvs_staging
+DFE_SIGN_IN_ISSUER: https://test-oidc.signin.education.gov.uk
+DFE_SIGN_IN_REDIRECT_URL: https://teaching-vacancies-dev.london.cloudapps.digital/auth/dfe/callback
+DFE_SIGN_IN_URL: https://test-api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: true
 DOMAIN: teaching-vacancies-dev.london.cloudapps.digital
 FEATURE_COOKIES_BANNER: true

--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -2,6 +2,9 @@
 AUTHENTICATION_FALLBACK: false
 BIG_QUERY_DATASET: production_dataset
 CLOUD_STORAGE_BUCKET: tvs_production
+DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk
+DFE_SIGN_IN_REDIRECT_URL: https://teaching-vacancies.service.gov.uk/auth/dfe/callback
+DFE_SIGN_IN_URL: https://api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: false
 DOMAIN: teaching-vacancies.service.gov.uk
 FEATURE_COOKIES_BANNER: true

--- a/terraform/workspace-variables/review_app_env.yml
+++ b/terraform/workspace-variables/review_app_env.yml
@@ -3,7 +3,7 @@ AUTHENTICATION_FALLBACK: true
 BIG_QUERY_DATASET: staging_dataset
 CLOUD_STORAGE_BUCKET: tvs_staging
 DISABLE_EXPENSIVE_JOBS: true
-DOMAIN: teaching-vacancies-dev.london.cloudapps.digital
+DOMAIN: teaching-vacancies-review.london.cloudapps.digital
 FEATURE_COOKIES_BANNER: true
 FEATURE_EMAIL_ALERTS: true
 FEATURE_MULTI_SCHOOL_JOBS: true

--- a/terraform/workspace-variables/staging_app_env.yml
+++ b/terraform/workspace-variables/staging_app_env.yml
@@ -2,8 +2,11 @@
 AUTHENTICATION_FALLBACK: false
 BIG_QUERY_DATASET: staging_dataset
 CLOUD_STORAGE_BUCKET: tvs_staging
+DFE_SIGN_IN_ISSUER: https://test-oidc.signin.education.gov.uk
+DFE_SIGN_IN_REDIRECT_URL: https://staging.teaching-vacancies.service.gov.uk/auth/dfe/callback
+DFE_SIGN_IN_URL: https://test-api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: true
-DOMAIN: tvs.staging.dxw.net
+DOMAIN: staging.teaching-vacancies.service.gov.uk
 FEATURE_COOKIES_BANNER: true
 FEATURE_EMAIL_ALERTS: true
 FEATURE_MULTI_SCHOOL_JOBS: true


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1272

## Changes in this PR:

- Update `DOMAIN` env var from `dxw.net` to `staging.teaching-vacancies.service.gov.uk` in staging
- Move `DFE_SIGN_IN*` key/value pairs from Parameter Store to env vars

## Next steps:

- [ ] Update `/app/secrets` parameter in `dev`, `staging`, `production`