### PR TITLE
[TEVA-1328] Add notifications on GitHub actions pipeline failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,17 +74,24 @@ jobs:
         terraform workspace select production terraform/app || terraform workspace new production terraform/app
         terraform apply -var-file terraform/workspace-variables/production.tfvars -auto-approve -input=false terraform/app
 
-  notify:
-    needs: deploy
-    name: Slack notification
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send slack message to twd_tv_dev channel
-        uses: rtCamp/action-slack-notify@v2.0.2
-        env:
-          SLACK_CHANNEL: twd_tv_dev
-          SLACK_USERNAME: CI Deployment
-          SLACK_ICON_EMOJI: ':tada:'
-          SLACK_TITLE: Successful deployment
-          SLACK_MESSAGE: 'Deployment to production on GOV.UK PaaS successful :rocket:'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    - name: Send success message to twd_tv_dev channel
+      if: ${{ success() }}
+      uses: rtCamp/action-slack-notify@v2.0.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_ICON_EMOJI: ':tada:'
+        SLACK_TITLE: Deployment success
+        SLACK_MESSAGE: 'Deployment to production on GOV.UK PaaS successful :rocket:'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+    - name: Send failure message to twd_tv_dev channel
+      if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@v2.0.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_ICON_EMOJI: ':cry:'
+        SLACK_TITLE: Deployment failure
+        SLACK_MESSAGE: 'Deployment to production failed'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -70,17 +70,24 @@ jobs:
         terraform workspace select ${BRANCH} terraform/app || terraform workspace new ${BRANCH} terraform/app
         terraform apply -var-file terraform/workspace-variables/${BRANCH}.tfvars -auto-approve -input=false terraform/app
 
-  notify:
-    needs: deploy
-    name: Slack notification
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send slack message to twd_tv_dev channel
-        uses: rtCamp/action-slack-notify@v2.0.2
-        env:
-          SLACK_CHANNEL: twd_tv_dev
-          SLACK_USERNAME: CI Deployment
-          SLACK_ICON_EMOJI: ':tada:'
-          SLACK_TITLE: Successful deployment
-          SLACK_MESSAGE: 'Deployment of ${{ needs.deploy.outputs.TAG }} to ${{ needs.deploy.outputs.BRANCH }} on GOV.UK PaaS successful :rocket:'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    - name: Send success message to twd_tv_dev channel
+      if: ${{ success() }}
+      uses: rtCamp/action-slack-notify@v2.0.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_ICON_EMOJI: ':tada:'
+        SLACK_TITLE: Deployment success
+        SLACK_MESSAGE: 'Deployment of ${{ steps.set_env_vars.outputs.TAG }} to ${{ steps.set_env_vars.outputs.BRANCH }} on GOV.UK PaaS successful :rocket:'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+    - name: Send failure message to twd_tv_dev channel
+      if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@v2.0.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_ICON_EMOJI: ':cry:'
+        SLACK_TITLE: Deployment failure
+        SLACK_MESSAGE: 'GitHub actions pipeline failed to deploy a review app for PR ${{ github.event.number }}'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -54,3 +54,14 @@ jobs:
         terraform workspace select review-${PR_NAME} terraform/app || terraform workspace new review-${PR_NAME} terraform/app
         terraform plan -var-file terraform/workspace-variables/review.tfvars -destroy -out=tfdestroy terraform/app
         terraform apply -auto-approve "tfdestroy" 
+
+    - name: Send failure message to twd_tv_dev channel
+      if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@v2.0.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_ICON_EMOJI: ':cry:'
+        SLACK_TITLE: Destroy failure
+        SLACK_MESSAGE: 'Failed destruction of review app PR ${{ github.event.number }}'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -64,6 +64,7 @@ jobs:
         terraform apply -var-file terraform/workspace-variables/review.tfvars -auto-approve -input=false terraform/app
 
     - name: Post PR comment
+      if: ${{ success() }}
       run: |
         curl --header "Accept: application/vnd.github.v3+json" \
              --header "Authorization: Bearer ${{ github.token }}" \
@@ -71,17 +72,24 @@ jobs:
              --data '{"body": "Review app deployed to https://teaching-vacancies-review-${{ format('pr-{0}', github.event.number) }}.london.cloudapps.digital"}' \
              https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/comments
 
-  notify:
-    needs: deploy
-    name: Slack notification
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send slack message to twd_tv_dev channel
-        uses: rtCamp/action-slack-notify@v2.0.2
-        env:
-          SLACK_CHANNEL: twd_tv_dev
-          SLACK_USERNAME: CI Deployment
-          SLACK_ICON_EMOJI: ':tada:'
-          SLACK_TITLE: Successful deployment
-          SLACK_MESSAGE: 'Review app for PR ${{ github.event.number }} deployed to https://teaching-vacancies-review-${{ env.PR_NAME }}.london.cloudapps.digital :rocket:'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    - name: Send success message to twd_tv_dev channel
+      if: ${{ success() }}
+      uses: rtCamp/action-slack-notify@v2.0.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_ICON_EMOJI: ':tada:'
+        SLACK_TITLE: Deployment success
+        SLACK_MESSAGE: 'Review app for PR ${{ github.event.number }} deployed to https://teaching-vacancies-review-${{ env.PR_NAME }}.london.cloudapps.digital :rocket:'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+    - name: Send failure message to twd_tv_dev channel
+      if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@v2.0.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_ICON_EMOJI: ':cry:'
+        SLACK_TITLE: Deployment failure
+        SLACK_MESSAGE: 'Review app deployment failed for PR ${{ github.event.number }}'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -49,6 +49,7 @@ jobs:
         env:
           SLACK_CHANNEL: twd_tv_dev
           SLACK_USERNAME: Smoke Test
+          SLACK_ICON_EMOJI: ':cry:'
           SLACK_TITLE: Smoke test failed
-          SLACK_MESSAGE: 'Production website smoke test has failed :cry: @channel'
+          SLACK_MESSAGE: 'Production website smoke test has failed @channel'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/sync_staging_db.yml
+++ b/.github/workflows/sync_staging_db.yml
@@ -53,18 +53,24 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: bin/upload-db-backup
 
-  sync_notify:
-    needs: sync
-    name: Slack notification
-    runs-on: ubuntu-latest
+    - name: Send success message to twd_tv_dev channel
+      if: ${{ success() }}
+      uses: rtCamp/action-slack-notify@v2.0.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_ICON_EMOJI: ':rocket:'
+        SLACK_TITLE: DB syncing success
+        SLACK_MESSAGE: 'Successful database backup and sync'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-    steps:
-      - name: Send slack message to twd_tv_dev channel
-        uses: rtCamp/action-slack-notify@v2.0.2
-        env:
-          SLACK_CHANNEL: twd_tv_dev
-          SLACK_USERNAME: CI Deployment
-          SLACK_ICON_EMOJI: ':tada:'
-          SLACK_TITLE: Successful syncing
-          SLACK_MESSAGE: 'Successful database backup and sync :rocket:'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    - name: Send failure message to twd_tv_dev channel
+      if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@v2.0.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_ICON_EMOJI: ':cry:'
+        SLACK_TITLE: DB syncing failure
+        SLACK_MESSAGE: 'Failed database backup and sync'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1328

## Changes in this PR:

- Took approach from `smoke-test` pipeline of testing for failure and now send different notifications on success or failure