### PR TITLE
[TEVA-1280] Add organisation_uid column to dsi_users and dsi_approvers tables in BigQuery

### DIFF
--- a/lib/export_dsi_approvers_to_big_query.rb
+++ b/lib/export_dsi_approvers_to_big_query.rb
@@ -22,7 +22,8 @@ private
         email: user['email'],
         family_name: user['familyName'],
         given_name: user['givenName'],
-        school_urn: user.dig('organisation', 'urn')
+        school_urn: user.dig('organisation', 'urn'),
+        organisation_uid: user.dig('organisation', 'uid')
       }
     end
   end
@@ -36,6 +37,7 @@ private
       schema.string 'family_name', mode: :required
       schema.string 'given_name', mode: :required
       schema.integer 'school_urn', mode: :nullable
+      schema.integer 'organisation_uid', mode: :nullable
     end
   end
 

--- a/lib/export_dsi_users_to_big_query.rb
+++ b/lib/export_dsi_users_to_big_query.rb
@@ -23,7 +23,8 @@ private
         given_name: user['givenName'],
         family_name: user['familyName'],
         email: user['email'],
-        school_urn: user.dig('organisation', 'URN')
+        school_urn: user.dig('organisation', 'URN'),
+        organisation_uid: user.dig('organisation', 'UID')
       }
     end
   end
@@ -38,6 +39,7 @@ private
       schema.string 'family_name', mode: :nullable
       schema.string 'email', mode: :nullable
       schema.integer 'school_urn', mode: :nullable
+      schema.integer 'organisation_uid', mode: :nullable
     end
   end
 

--- a/spec/fixtures/dfe_sign_in_service_approvers_response_page_1.json
+++ b/spec/fixtures/dfe_sign_in_service_approvers_response_page_1.json
@@ -5,27 +5,37 @@
         "id": "13F20E54-79EA-4146-8E39-18197576F023",
         "name": "Department for Education",
         "category": {
+          "id": "001",
           "name": "Establishment"
         },
         "type": {
+          "id": "03",
           "name": "Voluntary Aided School"
         },
         "urn": "000012",
+        "uid": "120000",
+        "ukprn": null,
         "status": {
+          "id": 1,
           "name": "Open"
         },
-        "closedOn": null, 
+        "closedOn": null,
         "address": "Some Address, Some Address, Some Address, Some Address, AAA BBY",
         "telephone": "00000000000",
         "region": {
-          "name": "West Midlands"
+          "id" : "K",
+          "name": "South West"
         },
         "phaseOfEducation": {
+          "id": 1,
           "name": "Primary"
         },
         "statutoryLowAge": 3,
-        "statutoryHighAge": 11
+        "statutoryHighAge": 11,
+        "legacyId": "1000000",
+        "companyRegistrationNumber": null
       },
+      "roleID": 10000,
       "roleName": "Approver",
       "userId": "AAAA-BBB",
       "email": "foo@example.com",

--- a/spec/fixtures/dfe_sign_in_service_approvers_response_page_2.json
+++ b/spec/fixtures/dfe_sign_in_service_approvers_response_page_2.json
@@ -5,27 +5,37 @@
         "id": "13F20E54-79EA-4146-8E39-18197576F024",
         "name": "Department for Education",
         "category": {
+          "id": "001",
           "name": "Establishment"
         },
         "type": {
+          "id": "03",
           "name": "Voluntary Aided School"
         },
         "urn": "000013",
+        "uid": "130000",
+        "ukprn": null,
         "status": {
+          "id": 1,
           "name": "Open"
         },
-        "closedOn": null, 
+        "closedOn": null,
         "address": "Some Address, Some Address, Some Address, Some Address, AAA BBX",
         "telephone": "00000000001",
         "region": {
-          "name": "West Midlands"
+          "id": "K",
+          "name": "South West"
         },
         "phaseOfEducation": {
+          "id": 2,
           "name": "Primary"
         },
         "statutoryLowAge": 3,
-        "statutoryHighAge": 11
+        "statutoryHighAge": 11,
+        "legacyId": "1000001",
+        "companyRegistrationNumber": null
       },
+      "roleId": 10000,
       "roleName": "Approver",
       "userId": "AAAA-CCC",
       "email": "bar@example.com",

--- a/spec/lib/export_dsi_approver_records_to_big_query_spec.rb
+++ b/spec/lib/export_dsi_approver_records_to_big_query_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ExportDsiApproversToBigQuery do
       'given_name' => Faker::Name.first_name,
       'family_name' => Faker::Name.last_name,
       'email' => Faker::Internet.email,
-      'organisation' => { 'urn' => 100_000 }
+      'organisation' => { 'urn' => 100_000, 'uid' => 999_999 }
     }
   end
 
@@ -56,7 +56,8 @@ RSpec.describe ExportDsiApproversToBigQuery do
         email: approver['email'],
         family_name: approver['familyName'],
         given_name: approver['givenName'],
-        school_urn: approver['organisation']['urn']
+        school_urn: approver['organisation']['urn'],
+        organisation_uid: approver['organisation']['uid']
       },
     ]
   end

--- a/spec/lib/export_dsi_user_records_to_big_query_spec.rb
+++ b/spec/lib/export_dsi_user_records_to_big_query_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ExportDsiUsersToBigQuery do
       'given_name' => Faker::Name.first_name,
       'family_name' => Faker::Name.last_name,
       'email' => Faker::Internet.email,
-      'organisation' => { 'URN' => 100_000 }
+      'organisation' => { 'URN' => 100_000, 'UID' => 999_999 }
     }
   end
 
@@ -56,7 +56,8 @@ RSpec.describe ExportDsiUsersToBigQuery do
         given_name: user['givenName'],
         family_name: user['familyName'],
         email: user['email'],
-        school_urn: user['organisation']['URN']
+        school_urn: user['organisation']['URN'],
+        organisation_uid: user['organisation']['UID']
       },
     ]
   end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1280

## Changes in this PR:

- Added a column titled 'organisation_uid' to both the dsi_approvers and dsi_users tables in BigQuery. If the user is associated with an organisation with a UID, this column will contain the UID of the organisation.

- Updated specs accordingly

- Updated some fixtures that were missing certain key-value pairs