### PR TITLE
Initial trust level / multi school vacancy calculations

### DIFF
--- a/bigquery/scheduled_queries/mats-with-metrics.sql
+++ b/bigquery/scheduled_queries/mats-with-metrics.sql
@@ -15,6 +15,7 @@ FROM (
     trust_name,
     trust.id AS id,
     COUNT(school.id) AS trust_size,
+    #count trust-level vacancies published by this trust
     (
     SELECT
       COUNTIF(schoolgroup_level)
@@ -26,6 +27,26 @@ FROM (
       vacancy.id=organisationvacancy.vacancy_id
     WHERE
       trust.id=organisationvacancy.organisation_id) AS trust_level_vacancies_published,
+    #count multi-school vacancies where at least 1 of the schools is part of this trust
+    (
+    SELECT
+      COUNTIF(vacancy.number_of_organisations > 1)
+    FROM
+      `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
+    LEFT JOIN
+      `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
+    ON
+      vacancy.id=organisationvacancy.vacancy_id
+    LEFT JOIN
+      `teacher-vacancy-service.production_dataset.feb20_organisation` AS organisation
+    ON
+      organisation.id=organisationvacancy.organisation_id
+    LEFT JOIN
+      `teacher-vacancy-service.production_dataset.feb20_schoolgroupmembership` AS schoolgroupmembership
+    ON
+      organisation.id=schoolgroupmembership.school_id
+    WHERE
+      trust.id=schoolgroupmembership.school_group_id) AS multischool_vacancies_published,
     COUNTIF(signed_up IS TRUE) AS schools_signed_up,
     COUNTIF(vacancies_published_in_the_last_year>0) AS schools_that_published_vacancies_in_the_last_year,
     COUNTIF(vacancies_published_in_the_last_quarter>0) AS schools_that_published_vacancies_in_the_last_quarter,

--- a/bigquery/scheduled_queries/mats-with-metrics.sql
+++ b/bigquery/scheduled_queries/mats-with-metrics.sql
@@ -1,23 +1,53 @@
-SELECT *,
-SAFE_DIVIDE(schools_signed_up,trust_size) AS proportion_of_schools_signed_up,
-SAFE_DIVIDE(schools_that_published_vacancies_in_the_last_year,trust_size) AS proportion_of_schools_that_published_vacancies_in_the_last_year,
-SAFE_DIVIDE(schools_that_published_vacancies_in_the_last_quarter,trust_size) AS proportion_of_schools_that_published_vacancies_in_the_last_quarter,
-SAFE_DIVIDE(schools_that_published_vacancies,trust_size) AS proportion_of_schools_that_published_vacancies,
-SAFE_DIVIDE(schools_with_live_vacancies,trust_size) AS proportion_of_schools_with_live_vacancies
-FROM
-(
 SELECT
-  trust_name,
-  MAX(academies_in_trust) AS trust_size,
-  COUNTIF(signed_up IS TRUE) AS schools_signed_up,
-  COUNTIF(vacancies_published_in_the_last_year>0) AS schools_that_published_vacancies_in_the_last_year,
-  COUNTIF(vacancies_published_in_the_last_quarter>0) AS schools_that_published_vacancies_in_the_last_quarter,
-  COUNTIF(vacancies_published>0) AS schools_that_published_vacancies,
-  COUNTIF(vacancies_currently_live>0) AS schools_with_live_vacancies
-FROM
-  `teacher-vacancy-service.production_dataset.CALCULATED_schools_joined_with_metrics`
-WHERE academies_in_trust > 1 #exclude schools which aren't in trusts, and single academy trusts
-GROUP BY
-  trust_name,academies_in_trust
-)
-ORDER BY trust_size DESC
+  *,
+  SAFE_DIVIDE(schools_signed_up,
+    trust_size) AS proportion_of_schools_signed_up,
+  SAFE_DIVIDE(schools_that_published_vacancies_in_the_last_year,
+    trust_size) AS proportion_of_schools_that_published_vacancies_in_the_last_year,
+  SAFE_DIVIDE(schools_that_published_vacancies_in_the_last_quarter,
+    trust_size) AS proportion_of_schools_that_published_vacancies_in_the_last_quarter,
+  SAFE_DIVIDE(schools_that_published_vacancies,
+    trust_size) AS proportion_of_schools_that_published_vacancies,
+  SAFE_DIVIDE(schools_with_live_vacancies,
+    trust_size) AS proportion_of_schools_with_live_vacancies
+FROM (
+  SELECT
+    trust_name,
+    trust.id AS id,
+    COUNT(school.id) AS trust_size,
+    (
+    SELECT
+      COUNT(DISTINCT vacancy.id)
+    FROM
+      `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
+    LEFT JOIN
+      `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
+    ON
+      vacancy.id=organisationvacancy.vacancy_id
+    WHERE
+      trust.id=organisationvacancy.organisation_id) AS trust_level_vacancies_published,
+    COUNTIF(signed_up IS TRUE) AS schools_signed_up,
+    COUNTIF(vacancies_published_in_the_last_year>0) AS schools_that_published_vacancies_in_the_last_year,
+    COUNTIF(vacancies_published_in_the_last_quarter>0) AS schools_that_published_vacancies_in_the_last_quarter,
+    COUNTIF(vacancies_published>0) AS schools_that_published_vacancies,
+    COUNTIF(vacancies_currently_live>0) AS schools_with_live_vacancies
+  FROM
+    `teacher-vacancy-service.production_dataset.feb20_organisation` AS trust
+  LEFT JOIN
+    `teacher-vacancy-service.production_dataset.feb20_schoolgroupmembership` AS schoolgroupmembership
+  ON
+    trust.id=schoolgroupmembership.school_group_id
+  LEFT JOIN
+    `teacher-vacancy-service.production_dataset.CALCULATED_schools_joined_with_metrics` AS school
+  ON
+    schoolgroupmembership.school_id=school.id
+  WHERE
+    data_group_type = "Multi-academy trust"
+  GROUP BY
+    trust_name,
+    id
+  HAVING
+    trust_size > 1 #exclude schools which aren't in trusts, and single academy trusts
+    )
+ORDER BY
+  trust_size DESC

--- a/bigquery/scheduled_queries/mats-with-metrics.sql
+++ b/bigquery/scheduled_queries/mats-with-metrics.sql
@@ -17,7 +17,7 @@ FROM (
     COUNT(school.id) AS trust_size,
     (
     SELECT
-      COUNT(DISTINCT vacancy.id)
+      COUNTIF(schoolgroup_level)
     FROM
       `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
     LEFT JOIN

--- a/bigquery/views/vacancies_published.sql
+++ b/bigquery/views/vacancies_published.sql
@@ -1,6 +1,7 @@
   # Filters the feb20_vacancies table into the vacancies_published view by excluding vacancies from out of scope statuses or roles
 SELECT
   vacancy.*,
+  #categorises each vacancy as leadership,teaching_assistant,teacher or NULL
 IF
   (LOWER(job_title) LIKE '%head%'
     OR LOWER(job_title) LIKE '%ordinat%'
@@ -21,7 +22,28 @@ IF
       (LOWER(job_title) LIKE '%teacher%'
         OR LOWER(job_title) LIKE '%lecturer%',
         "teacher",
-        NULL))) AS category #categorises each vacancy as leadership,teaching_assistant,teacher or NULL
+        NULL))) AS category,
+  #the number of organisations linked to this vacancy - if > 1 then this is a multi-school vacancy
+  (
+  SELECT
+    COUNT(organisation_id)
+  FROM
+    `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
+  WHERE
+    organisationvacancy.vacancy_id=vacancy.id) AS number_of_organisations,
+  #whether the vacancy was published by a schoolgroup e.g. a MAT
+  (
+  SELECT
+    COUNT(*)
+  FROM
+    `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
+  LEFT JOIN
+    `teacher-vacancy-service.production_dataset.feb20_organisation` AS organisation
+  ON
+    organisation.id=organisationvacancy.organisation_id
+  WHERE
+    organisation.type="SchoolGroup"
+    AND organisationvacancy.vacancy_id=vacancy.id) > 0 AS schoolgroup_level
 FROM
   `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
 WHERE

--- a/bigquery/views/vacancies_published.sql
+++ b/bigquery/views/vacancies_published.sql
@@ -34,7 +34,7 @@ IF
   #whether the vacancy was published by a schoolgroup e.g. a MAT
   (
   SELECT
-    COUNT(*)
+    COUNT(organisationvacancy.id)
   FROM
     `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
   LEFT JOIN
@@ -43,7 +43,16 @@ IF
     organisation.id=organisationvacancy.organisation_id
   WHERE
     organisation.type="SchoolGroup"
-    AND organisationvacancy.vacancy_id=vacancy.id) > 0 AS schoolgroup_level
+    AND organisationvacancy.vacancy_id=vacancy.id) > 0 AS schoolgroup_level,
+  (
+  SELECT
+    COUNT(document.id)
+  FROM
+    `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
+  LEFT JOIN
+    `teacher-vacancy-service.production_dataset.feb20_document` AS document
+  ON
+    document.vacancy_id=vacancy.id) AS number_of_documents
 FROM
   `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
 WHERE


### PR DESCRIPTION
## Jira ticket URL

Enables for https://dfedigital.atlassian.net/browse/TEVA-1300

## Changes in this PR:

- Massive refactor of the table of metrics about 'tags' for vacancies over time (like 'suitable_for_nqts') to use CASEs instead of UNION ALLs to join the metric values for each tag together - this significantly reduces the number of subqueries, and stops the number of subqueries scaling with the number of tags, preventing future subquery limit breaches.
- Add new mat_level and multi_school tags to the table of metrics about 'tags' for vacancies over time
- Refactor document counter out of the query that calculates metrics about tags for vacancies over time into the vacancies_published view to reduce duplication in the query it was in before
- Add count of multischool_vacancies_published and trust_level_vacancies_published to the comms team's table of MATs
- Migrate the query that calculates stuff for each MAT to use the new data model with MATs in the organisation table (instead of deducing them from the list of school trusts from GIAS as before)
- Add number_of_organisations that published a vacancy to vacancies_published view
- Add schoolgroup_level field to vacancies_published view that indicates whether the vacancy was published at a schoolgroup level (e.g. MAT)
