### PR TITLE
Fix CSV encoding on import

### DIFF
--- a/lib/import_school_group_data.rb
+++ b/lib/import_school_group_data.rb
@@ -17,7 +17,7 @@ private
 
   def import_data(url, location, method)
     save_csv_file(url, location)
-    CSV.foreach(location, headers: true, encoding: 'windows-1251:utf-8').each do |row|
+    CSV.foreach(location, headers: true, encoding: 'windows-1252:utf-8').each do |row|
       send(method, row)
     end
     File.delete(location)

--- a/lib/update_school_data.rb
+++ b/lib/update_school_data.rb
@@ -32,7 +32,7 @@ class UpdateSchoolData
 
   def run!
     save_csv_file
-    CSV.foreach(csv_file_location, headers: true, encoding: 'windows-1251:utf-8').each do |row|
+    CSV.foreach(csv_file_location, headers: true, encoding: 'windows-1252:utf-8').each do |row|
       School.transaction do
         school = convert_to_school(row)
         school.save


### PR DESCRIPTION
For some reason, CSVs were being imported with the wrong encoding. This meant characters like `é` were imported incorrectly.