### PR TITLE
[TEVA-1240] Add breadcrumb to job listing page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   before_action :detect_device_format
   before_action :set_root_headers
 
-  helper_method :cookies_preference_set?
+  helper_method :cookies_preference_set?, :referred_from_host?
 
   include AuthenticationConcerns
   include Ip
@@ -57,6 +57,10 @@ class ApplicationController < ActionController::Base
 
   def cookies_preference_set?
     cookies['consented-to-cookies'].present?
+  end
+
+  def referred_from_host?
+    request.host == URI(request.referrer || '').host
   end
 
 private

--- a/app/views/shared/vacancy/_jobseeker_view.html.haml
+++ b/app/views/shared/vacancy/_jobseeker_view.html.haml
@@ -7,7 +7,7 @@
   .govuk-width-container
     = render(Shared::BreadcrumbComponent.new(collapse_on_mobile: false,
                                              crumbs: [{ link_path: root_path, link_text: t('breadcrumbs.home') },
-                                                      { link_path: request.host == URI(request.referrer || '').host ? request.referrer : jobs_path, link_text: t('breadcrumbs.jobs') },
+                                                      { link_path: referred_from_host? ? request.referrer : jobs_path, link_text: t('breadcrumbs.jobs') },
                                                       { link_path: '#', link_text: @vacancy.job_title }]))
     .govuk-grid-row
       .govuk-grid-column-full

--- a/app/views/shared/vacancy/_jobseeker_view.html.haml
+++ b/app/views/shared/vacancy/_jobseeker_view.html.haml
@@ -5,7 +5,10 @@
 
 .jobs-banner
   .govuk-width-container
-    = render 'vacancies/back_link'
+    = render(Shared::BreadcrumbComponent.new(collapse_on_mobile: false,
+                                             crumbs: [{ link_path: root_path, link_text: t('breadcrumbs.home') },
+                                                      { link_path: request.host == URI(request.referrer || '').host ? request.referrer : jobs_path, link_text: t('breadcrumbs.jobs') },
+                                                      { link_path: '#', link_text: @vacancy.job_title }]))
     .govuk-grid-row
       .govuk-grid-column-full
         %h1.govuk-heading-xl{ class: 'govuk-!-margin-bottom-2 govuk-!-margin-top-5' }

--- a/app/views/vacancies/_back_link.html.haml
+++ b/app/views/vacancies/_back_link.html.haml
@@ -1,6 +1,0 @@
-.govuk-grid-row
-  .govuk-grid-column-full
-    -if request.referrer
-      = link_to t('nav.back'), request.referrer, class: 'govuk-back-link with-referrer', role: 'button'
-    -else
-      = link_to t('nav.back'), root_path, class: 'govuk-back-link'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,7 +191,6 @@ en:
     trusts_index_link: 'Schools in your trust'
     jobseekers_index_link: 'View public jobs'
     find_job: 'Find a teaching job'
-    back: 'Back'
   pages:
     accessibility:
       page_description:


### PR DESCRIPTION
This PR adds a breadcrumb to the job listing page

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1240

## Changes in this PR:
- Add breadcrumb to the job listing page
