### PR TITLE
[TEVA-1346] Redirect to domain if request host is different

### DIFF
--- a/config/initializers/default_url_options.rb
+++ b/config/initializers/default_url_options.rb
@@ -1,7 +1,7 @@
 default_domains = {
   test: 'localhost:3000',
   development: 'localhost:3000',
-  staging: 'tvs.staging.dxw.net',
+  staging: 'staging.teaching-vacancies.service.gov.uk',
   production: 'teaching-vacancies.service.gov.uk'
 }
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationController, type: :controller do
+  describe '#redirect_to_domain' do
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+      stub_const('DOMAIN', 'localhost')
+      @request.host = fake_domain
+    end
+
+    context 'when request.host_with_port is different to DOMAIN' do
+      let(:fake_domain) { 'DIFFERENT_DOMAIN' }
+
+      it 'redirects to DOMAIN' do
+        get :check
+        expect(response.location).to eql("http://#{DOMAIN}/check")
+        expect(response.status).to eql(301)
+      end
+    end
+
+    context 'when request.host_with_port is DOMAIN' do
+      let(:fake_domain) { DOMAIN }
+
+      it 'does not redirect to DOMAIN' do
+        get :check
+        expect(response.status).to eql(200)
+      end
+    end
+  end
+
   describe 'routing' do
     it 'check endpoint is publically accessible' do
       expect(get: '/check').to route_to(controller: 'application', action: 'check')

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -66,10 +66,12 @@ locals {
     yamldecode(data.aws_ssm_parameter.app_env_api_key_google.value)
   )
   app_env_secrets = yamldecode(data.aws_ssm_parameter.app_env_secrets.value)
+  app_env_domain  = { "DOMAIN" = "teaching-vacancies-${var.environment}.london.cloudapps.digital" }
   app_environment = merge(
     local.app_env_api_keys,
     local.app_env_secrets,
-    var.app_env_values
+    local.app_env_domain,
+    var.app_env_values #Because of merge order, if present, the value of DOMAIN in .tfvars will overwrite app_env_domain
   )
   app_cloudfoundry_service_instances = [
     cloudfoundry_service_instance.postgres_instance.id,

--- a/terraform/workspace-variables/review_app_env.yml
+++ b/terraform/workspace-variables/review_app_env.yml
@@ -3,7 +3,6 @@ AUTHENTICATION_FALLBACK: true
 BIG_QUERY_DATASET: staging_dataset
 CLOUD_STORAGE_BUCKET: tvs_staging
 DISABLE_EXPENSIVE_JOBS: true
-DOMAIN: teaching-vacancies-review.london.cloudapps.digital
 FEATURE_COOKIES_BANNER: true
 FEATURE_EMAIL_ALERTS: true
 FEATURE_MULTI_SCHOOL_JOBS: true


### PR DESCRIPTION
This PR redirects requests with different host names to DOMAIN.

See tv_engineering slack channel for context

**Note:** the rspec/capybara/selenium host/domain config saga was more than a pain the backside, hence not running the redirect before_action in tests