### PR TITLE
[TEVA-1330] Manage Route53 zones and records via Terraform

### DIFF
--- a/documentation/dns-records.md
+++ b/documentation/dns-records.md
@@ -1,0 +1,124 @@
+# DNS
+
+## DNS management
+
+DNS is managed via AWS's Route53, through Infrastructure as Code using Terraform.
+
+## Zones
+
+Teaching vacancies has two Route53 hosted zones:
+- teaching-jobs.service.gov.uk
+- teaching-vacancies.service.gov.uk
+
+We create DNS records in both zones, but treat `teaching-vacancies.service.gov.uk` as the primary
+
+## Zone creation
+
+The code in `terraform/common` manages the zones.
+
+## Record types
+
+The following record types are in use:
+
+### [A record](https://www.cloudflare.com/learning/dns/dns-records/dns-a-record/)
+> The `A` stands for `address` and this is the most fundamental type of DNS record: it indicates the IP address of a given domain. For example, if you pull the DNS records of cloudflare.com, the A record currently returns an IP address of: 104.17.210.9.
+>
+> A records only hold IPv4 addresses. If a website has an IPv6 address, it will instead use an ‘AAAA’ record.
+
+In a TVS hosted zone, [this is set](https://toolbox.googleapps.com/apps/dig/#A/teaching-vacancies.service.gov.uk) as an Alias to the Cloudfront distribution, so responds with multiple IP addresses, e.g.:
+```
+teaching-vacancies.service.gov.uk. 59 IN A 13.33.242.3
+teaching-vacancies.service.gov.uk. 59 IN A 13.33.242.81
+teaching-vacancies.service.gov.uk. 59 IN A 13.33.242.97
+teaching-vacancies.service.gov.uk. 59 IN A 13.33.242.96
+```
+
+### [CNAME record](https://www.cloudflare.com/learning/dns/dns-records/dns-cname-record/)
+> The `canonical name` (CNAME) record is used in lieu of an A record, when a domain or subdomain is an alias of another domain. All CNAME records must point to a domain, never to an IP address. Imagine a scavenger hunt where each clue points to another clue, and the final clue points to the treasure. A domain with a CNAME record is like a clue that can point you to another clue (another domain with a CNAME record) or to the treasure (a domain with an A record).
+
+In a TVS hosted zone, CNAMEs are used for three purposes:
+- verification of Amazon Certificate Manager certificates
+- verification of bing searches
+- [alias to the Cloudfront distribution](https://toolbox.googleapps.com/apps/dig/#CNAME/www.teaching-vacancies.service.gov.uk)
+
+### [CAA record](https://letsencrypt.org/docs/caa/)
+> CAA is a type of DNS record that allows site owners to specify which Certificate Authorities (CAs) are allowed to issue certificates containing their domain names. It was standardized in 2013 by RFC 6844 to allow a CA “reduce the risk of unintended certificate mis-issue.” By default, every public CA is allowed to issue certificates for any domain name in the public DNS, provided they validate control of that domain name. That means that if there’s a bug in any one of the many public CAs’ validation processes, every domain name is potentially affected. CAA provides a way for domain holders to reduce that risk.
+
+In a TVS hosted zone, [this is set](https://toolbox.googleapps.com/apps/dig/#CAA/teaching-vacancies.service.gov.uk) to `0 issue "amazon.com"` with a TTL of 300 seconds
+
+### [NS records](https://www.cloudflare.com/learning/dns/dns-records/dns-ns-record/) and [SOA record](https://www.cloudflare.com/learning/dns/dns-records/dns-soa-record/)
+The [Route 53 developer guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html) has:
+> For each public hosted zone that you create, Amazon Route 53 automatically creates a name server (NS) record and a start of authority (SOA) record. You rarely need to change these records.
+
+These are used for delegation, so are set in the parent zone for `service.gov.uk` by GDS.
+
+### [TXT records](https://www.cloudflare.com/learning/dns/dns-records/dns-txt-record/)
+> The DNS `text` (TXT) record lets a domain administrator enter text into the Domain Name System (DNS). The TXT record was originally intended as a place for human-readable notes. However, now it is also possible to put some machine-readable data into TXT records. One domain can have many TXT records.
+>
+> Today, two of the most important uses for DNS TXT records are email spam prevention and domain ownership verification, although TXT records were not designed for these uses originally.
+
+In a TVS hosted zone, we set TXT records for DMARC and SPF purposes to indicate *that this domain does not send any email*
+
+### DMARC
+
+```
+"v=DMARC1; p=reject; sp=reject; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk"
+```
+
+Deriving from [Setting up DMARC](https://www.gov.uk/government/publications/email-security-standards/domain-based-message-authentication-reporting-and-conformance-dmarc) and the [DMARC specifications](https://dmarc.org/resources/specification/)
+
+This tells anyone receiving email from you that:
+
+- you have a DMARC policy (v=DMARC1)
+- any messages that fail DMARC checks should be rejected (p=reject)
+- any messages that fail DMARC checks *for this subdomain* should be rejected (sp=reject)
+- they should send aggregate reports of email received back to a specific address (rua=mailto:dmarc-rua@dmarc.service.gov.uk)
+- they should send forensic reports of email received back to a specific address (ruf=mailto:dmarc-ruf@dmarc.service.gov.uk)
+
+### SPF
+
+[Sender Policy Framework](https://www.gov.uk/government/publications/email-security-standards/sender-policy-framework-spf)
+> Sender Policy Framework (SPF) lets you publish a DNS record of all the domains or IP addresses you use to send email. Receiving email services check the record and know to treat email from anywhere else as spam.
+>
+> You can include more than one sending service in your SPF record. For example, your corporate email service and an email marketing service.
+
+[Set up Government email services securely](https://www.gov.uk/guidance/set-up-government-email-services-securely#authenticate-email) covers this in more detail:
+
+> Implement Sender Policy Framework (SPF) by:
+>
+> -publishing public DNS records for SPF, including all systems that send email, using a minimum soft fail (~all) qualifier
+
+From [this SPF syntax table](https://dmarcian.com/spf-syntax-table/) we see
+```
+“v=spf1 ~all”
+```
+> The domain sends no mail at all
+
+Note from this discussion on [What is the difference between SPF ~all and -all?](https://dmarcian.com/what-is-the-difference-between-spf-all-and-all/)
+
+>By adding a prefix of “~” or “-“, the meaning of the mechanism is changed to be:
+>
+> - “softfail” in the case of “~”
+> - “fail” in the case of “-“
+
+## Record creation
+
+The [Route 53 developer guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html) has:
+> For each public hosted zone that you create, Amazon Route 53 automatically creates a name server (NS) record and a start of authority (SOA) record. You rarely need to change these records.
+
+Records are created in `terraform/common`:
+- TXT records for DMARC, SPF, search engine validation
+- CAA record
+
+Records are created in `terraform/app` by two different modules:
+
+- `terraform/app/modules/certificates` creates:
+    - CNAME records to `acm-validations.aws.`
+
+- `terraform/app/modules/cloudfront` creates:
+    - CNAME records pointing to a Cloudfront distribution, for `www.` and `staging.`
+    - Alias A records pointing to the Cloudfront distribution, for the `naked` (root) domain
+
+## Tools
+
+Google's [G Suite Toolbox Dig](https://toolbox.googleapps.com/apps/dig/#A/) is excellent for checking the DNS records listed above.

--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -180,18 +180,21 @@ data aws_iam_policy_document route53_hosted_zones {
 
   statement {
     actions = [
-      "route53:GetChange",
+      "route53:CreateHostedZone",
       "route53:GetHostedZone",
+      "route53:GetHostedZoneCount",
+      "route53:ListHostedZones",
+      "route53:ListHostedZonesByName",
+      "route53:UpdateHostedZoneComment",
+      "route53:GetChange",
       "route53:ListResourceRecordSets",
       "route53:ListTagsForResource",
       "route53:ChangeResourceRecordSets",
       "route53:ListResourceRecordSets",
-      "route53:GetHostedZoneCount",
-      "route53:ListHostedZonesByName"
     ]
     resources = [
       for zone in var.route53_zones :
-      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.zones[zone].zone_id}"
+      "arn:aws:route53:::hostedzone/${aws_route53_zone.zones[zone].zone_id}"
     ]
   }
 }

--- a/terraform/common/route53.tf
+++ b/terraform/common/route53.tf
@@ -4,3 +4,12 @@ resource aws_route53_zone zones {
   comment       = "DNS Zone for Teaching Vacancies"
   force_destroy = false
 }
+
+resource aws_route53_record route53_records {
+  for_each = var.route53_records
+  zone_id  = aws_route53_zone.zones[each.value.zone_name].zone_id
+  name     = each.value.record_name
+  records  = [each.value.record_value]
+  ttl      = each.value.record_ttl
+  type     = each.value.record_type
+}

--- a/terraform/common/route53.tf
+++ b/terraform/common/route53.tf
@@ -1,4 +1,6 @@
-data aws_route53_zone zones {
-  for_each = local.route53_zones
-  name     = each.value
+resource aws_route53_zone zones {
+  for_each      = local.route53_zones
+  name          = each.value
+  comment       = "DNS Zone for Teaching Vacancies"
+  force_destroy = false
 }

--- a/terraform/common/variables.tf
+++ b/terraform/common/variables.tf
@@ -2,6 +2,68 @@ variable region { default = "eu-west-2" }
 
 variable s3_bucket_name { default = "terraform-state-002" }
 
+variable route53_records {
+  type = map(object({
+    zone_name    = string
+    record_name  = string
+    record_ttl   = string
+    record_type  = string
+    record_value = string
+  }))
+  default = {
+    "jobs-CAA" = {
+      zone_name    = "teaching-jobs.service.gov.uk"
+      record_name  = "teaching-jobs.service.gov.uk"
+      record_ttl   = "300"
+      record_type  = "CAA"
+      record_value = "0 issue \"amazon.com\""
+    }
+    "jobs-SPF" = {
+      zone_name    = "teaching-jobs.service.gov.uk"
+      record_name  = "teaching-jobs.service.gov.uk"
+      record_ttl   = "300"
+      record_type  = "TXT"
+      record_value = "v=spf1 -all"
+    }
+    "jobs-DMARC" = {
+      zone_name    = "teaching-jobs.service.gov.uk"
+      record_name  = "_dmarc.teaching-jobs.service.gov.uk"
+      record_ttl   = "300"
+      record_type  = "TXT"
+      record_value = "v=DMARC1; p=reject; sp=reject; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk"
+    }
+    "jobs-bing" = {
+      zone_name    = "teaching-jobs.service.gov.uk"
+      record_name  = "c0e62f5bc2cefff55a28530903b208b7.teaching-jobs.service.gov.uk"
+      record_ttl   = "300"
+      record_type  = "CNAME"
+      record_value = "verify.bing.com."
+    }
+    "vacancies-CAA" = {
+      zone_name    = "teaching-vacancies.service.gov.uk"
+      record_name  = "teaching-vacancies.service.gov.uk"
+      record_ttl   = "300"
+      record_type  = "CAA"
+      record_value = "0 issue \"amazon.com\""
+    }
+    "vacancies-SPF" = {
+      zone_name    = "teaching-vacancies.service.gov.uk"
+      record_name  = "teaching-vacancies.service.gov.uk"
+      record_ttl   = "300"
+      record_type  = "TXT"
+      record_value = "v=spf1 -all"
+    }
+    "vacancies-DMARC" = {
+      zone_name    = "teaching-vacancies.service.gov.uk"
+      record_name  = "_dmarc.teaching-vacancies.service.gov.uk"
+      record_ttl   = "300"
+      record_type  = "TXT"
+      record_value = "v=DMARC1; p=reject; sp=reject; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk"
+    }
+  }
+}
+
+
 variable route53_zones {
   type    = list
   default = ["teaching-jobs.service.gov.uk", "teaching-vacancies.service.gov.uk"]


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1330

## Changes in this PR:

- Added Route53 zones to terraform/common
- Added Route53 records to terraform/common (CNAMEs for Cloudfront are created in terraform/app)
- Added documentation on DNS in general, and specifics of how records are used in Teaching Vacancies

## Next steps:

- [x] Import existing zones and records into Terraform common state
