### PR TITLE
Remove utilities which duplicate govuk front end classes

### DIFF
--- a/app/components/jobseekers/vacancy_summary_component.html.haml
+++ b/app/components/jobseekers/vacancy_summary_component.html.haml
@@ -1,5 +1,5 @@
 %li.vacancy{ 'role': 'listitem', 'tab-index': '0'}
-  %h2.govuk-heading-m.mb0= link_to @vacancy.job_title, job_path(@vacancy), class: 'govuk-link view-vacancy-link'
+  %h2.govuk-heading-m{ class: 'govuk-!-margin-bottom-0' }= link_to @vacancy.job_title, job_path(@vacancy), class: 'govuk-link view-vacancy-link'
   %p.govuk-body= location(@vacancy.parent_organisation, job_location: @vacancy.job_location)
   %dl
     %dt= t('jobs.salary')

--- a/app/frontend/styles/base/_utilities.scss
+++ b/app/frontend/styles/base/_utilities.scss
@@ -1,24 +1,3 @@
-.mt0 {
-  margin-top: 0;
-}
-
-.mv0 {
-  margin-bottom: 0;
-  margin-top: 0;
-}
-
-.mb1 {
-  margin-bottom: $govuk-gutter;
-}
-
-.mb0 {
-  margin-bottom: 0;
-}
-
-.mt1 {
-  margin-top: $govuk-gutter;
-}
-
 .wordwrap {
   word-wrap: break-word;
 }

--- a/app/views/hiring_staff/organisations/_vacancy_awaiting_feedback.html.haml
+++ b/app/views/hiring_staff/organisations/_vacancy_awaiting_feedback.html.haml
@@ -7,4 +7,4 @@
     %td.govuk-table__cell= vacancy.expires_on
     %td.govuk-table__cell{ class: 'govuk-!-width-one-quarter' }= select_tag 'vacancy[hired_status]', options_for_select(hired_status_options, nil), form: vacancy.id, include_blank: '--', class: 'govuk-select form-control form-control-block govuk-!-width-full'
     %td.govuk-table__cell{ class: 'govuk-!-width-one-quarter' }= select_tag 'vacancy[listed_elsewhere]', options_for_select(listed_elsewhere_options, nil), form: vacancy.id, include_blank: '--', class: 'govuk-select form-control form-control-block govuk-!-width-full'
-    %td.govuk-table__cell= submit_tag t('buttons.submit'), form: vacancy.id, class: 'govuk-button mb0'
+    %td.govuk-table__cell= submit_tag t('buttons.submit'), form: vacancy.id, class: 'govuk-button govuk-!-margin-bottom-0'

--- a/app/views/hiring_staff/organisations/schools/index.html.haml
+++ b/app/views/hiring_staff/organisations/schools/index.html.haml
@@ -3,14 +3,14 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
 
-    %h1.govuk-heading-xl.mb0
+    %h1.govuk-heading-xl{ class: 'govuk-!-margin-bottom-0' }
       = t('.title')
     %p
       = t('.description')
 
     = render 'school_group'
 
-    %h2.govuk-heading-l.mb0
+    %h2.govuk-heading-l{ class: 'govuk-!-margin-bottom-0' }
       = t('.schools', count: current_organisation.schools.count)
 
     .schools

--- a/app/views/hiring_staff/vacancies/_preview_banner.html.haml
+++ b/app/views/hiring_staff/vacancies/_preview_banner.html.haml
@@ -2,5 +2,5 @@
   %h2.govuk-info-summary__title#info-summary-title= t('jobs.preview_listing.summary.heading_html', title: @vacancy.job_title)
   .govuk-info-summary__body
     %p= t('jobs.preview_listing.summary.body_html', count: @vacancy.publish_on.today? ? 0 : 1, date: @vacancy.publish_on.to_s.strip)
-    = link_to t('jobs.preview_listing.summary.buttons.submit'), organisation_job_publish_path(@vacancy.id), method: :post, class: 'govuk-button mb0 submit-listing-with-preview-gtm'
-    = link_to t('jobs.preview_listing.summary.buttons.make_changes'), organisation_job_review_path(@vacancy.id), class: 'govuk-button govuk-button--secondary mb0'
+    = link_to t('jobs.preview_listing.summary.buttons.submit'), organisation_job_publish_path(@vacancy.id), method: :post, class: 'govuk-button govuk-!-margin-bottom-0 submit-listing-with-preview-gtm'
+    = link_to t('jobs.preview_listing.summary.buttons.make_changes'), organisation_job_review_path(@vacancy.id), class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0'

--- a/app/views/hiring_staff/vacancies/_show.html.haml
+++ b/app/views/hiring_staff/vacancies/_show.html.haml
@@ -6,11 +6,11 @@
   .share-url-info
     .govuk-grid-row
       .govuk-grid-column-one-half
-        .share-url.mb1.display-none
-          %h2.govuk-heading-m.mt0 Share this job
+        .share-url.display-none{ class: 'govuk-!-margin-bottom-6' }
+          %h2.govuk-heading-m{ class: 'govuk-!-margin-top-0' } Share this job
           #{link_to t('jobs.view_public_link'), @vacancy.share_url, class: 'govuk-link', 'aria-label': t('jobs.view_public_link')}, or #{link_to t('jobs.copy_public_url'), '#', class: 'govuk-link copy-to-clipboard', 'data-clipboard-text': @vacancy.share_url, 'aria-label': t('jobs.copy_public_url')}
-        .share-url-no-js.mb1
-          %h2.govuk-heading-s.mt0 Share this job
+        .share-url-no-js{ class: 'govuk-!-margin-bottom-6' }
+          %h2.govuk-heading-s{ class: 'govuk-!-margin-top-0' } Share this job
           #{link_to "#{t('jobs.view_public_link')} (#{@vacancy.share_url})", job_path(@vacancy), class: 'govuk-link'}
         = render partial: '/shared/vacancy/share_buttons'
       .govuk-grid-column-one-half

--- a/app/views/hiring_staff/vacancies/summary.html.haml
+++ b/app/views/hiring_staff/vacancies/summary.html.haml
@@ -16,7 +16,7 @@
         - else
           %p= link_to t('jobs.confirmation_page.view_posted_job'), organisation_job_path(@vacancy.id), class: 'reversed-link'
 
-        %p.mb0= t('jobs.confirmation_page.dashboard_link', link: link_to('your dashboard', organisation_path, class: 'reversed-link')).html_safe
+        %p{ class: 'govuk-!-margin-bottom-0' }= t('jobs.confirmation_page.dashboard_link', link: link_to('your dashboard', organisation_path, class: 'reversed-link')).html_safe
 
   .govuk-grid-column-two-thirds
     %h3.govuk-heading-m= t('jobs.confirmation_page.next_step')

--- a/app/views/pages/cookies.html.haml
+++ b/app/views/pages/cookies.html.haml
@@ -37,7 +37,7 @@
 
     %p=t('static_pages.cookies.how_we_use.analytics.line_4')
 
-    %table.govuk-table.mb1
+    %table.govuk-table{ class: 'govuk-!-margin-bottom-6' }
       %thead.govuk-table__head
         %th.govuk-table__header=t('static_pages.cookies.name')
         %th.govuk-table__header=t('static_pages.cookies.purpose')
@@ -61,7 +61,7 @@
 
     %p=t('static_pages.cookies.sessions.about')
 
-    %table.govuk-table.mb1
+    %table.govuk-table{ class: 'govuk-!-margin-bottom-6' }
       %thead.govuk-table__head
         %th.govuk-table__header=t('static_pages.cookies.name')
         %th.govuk-table__header=t('static_pages.cookies.purpose')
@@ -75,7 +75,7 @@
 
     %p=t('static_pages.cookies.introductory_message.about')
 
-    %table.govuk-table.mb1
+    %table.govuk-table{ class: 'govuk-!-margin-bottom-6' }
       %thead.govuk-table__head
         %th.govuk-table__header=t('static_pages.cookies.name')
         %th.govuk-table__header=t('static_pages.cookies.purpose')
@@ -85,7 +85,7 @@
         %td.govuk-table__cell=t('static_pages.cookies.types.seen_cookie_message.purpose')
         %td.govuk-table__cell=t('static_pages.cookies.types.seen_cookie_message.expires')
 
-    %table.govuk-table.mb1
+    %table.govuk-table{ class: 'govuk-!-margin-bottom-6' }
       %thead.govuk-table__head
         %th.govuk-table__header=t('static_pages.cookies.name')
         %th.govuk-table__header=t('static_pages.cookies.purpose')

--- a/app/views/shared/_file_remove_confirmation_dialogue.html.haml
+++ b/app/views/shared/_file_remove_confirmation_dialogue.html.haml
@@ -4,7 +4,7 @@
     .gem-c-modal-dialogue__content
       %p.govuk-body{ class: 'govuk-!-font-weight-bold' }
         = t('.are_you_sure_html')
-      .govuk-error-summary.mb1.display-none#js-gem-c-modal-dialogue__error{ role: 'alert', tabindex: '-1' }
+      .govuk-error-summary.display-none#js-gem-c-modal-dialogue__error{ role: 'alert', tabindex: '-1', class: 'govuk-!-margin-bottom-6' }
         .govuk-error-summary__body
           = t('.delete_error')
     .gem-c-modal-dialogue__footer

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -8,7 +8,7 @@
     = render 'shared/search/radius', f: f, filters: true
 
     = f.hidden_field :jobs_sort, value: @vacancies_search&.sort_by
-    = f.govuk_submit t('buttons.search'), classes: 'govuk-button mb0 govuk-!-width-full'
+    = f.govuk_submit t('buttons.search'), classes: 'govuk-button govuk-!-margin-bottom-0 govuk-!-width-full'
 
   %aside
     = render 'components/shared/filters_component', form: f, options: { remove_buttons: true, mobile_variant: true, close_all: true }, filters: { total_count: @jobs_search_form.total_filters, title: 'Filter results' }, items: [{ title: 'Job role', key: 'job_roles', search: false, scroll: false, attribute: :job_roles, selected: @jobs_search_form.job_roles, options: @jobs_search_form.job_role_options, value_method: :first, text_method: :last, selected_method: :last, small: true }, { title: 'Education phase', key: 'education_phase', search: false, scroll: false, attribute: :phases, selected: @jobs_search_form.phases, options: @jobs_search_form.phase_options, value_method: :first, text_method: :last, selected_method: :last, small: true }, { title: 'Working pattern', key: 'working_patterns', search: false, scroll: false, attribute: :working_patterns, selected: @jobs_search_form.working_patterns, options: @jobs_search_form.working_pattern_options, value_method: :first, text_method: :last, selected_method: :last, small: true }]


### PR DESCRIPTION
Replacing 'utility' styles for which there are perfectly decent govuk frontend classes available.

Pro: it's overhead and hard to read what these mean e.g. `mt0`

Con: the govuk spacing classes include ! meaning we have to use the lengthy { class: 'govuk-!-margin-bottom-6' } formation in haml
