### PR TITLE
Refactor job alert confirmation page

### DIFF
--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -45,6 +45,7 @@ $govuk-image-url-function: frontend-image-url;
 @import 'components/notification';
 @import 'components/og-preview';
 @import 'components/pagination';
+@import 'components/panel';
 @import 'components/pill-link';
 @import 'components/school';
 @import 'components/schools-in-your-trust';

--- a/app/frontend/styles/components/hiring-staff.scss
+++ b/app/frontend/styles/components/hiring-staff.scss
@@ -52,32 +52,3 @@ body.hiring-staff {
   color: $govuk-link-hover-colour;
   text-decoration: underline;
 }
-
-.hod-checkmark {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 50%;
-  display: block;
-  font-size: 35px;
-  height: 70px;
-  margin: 15px auto;
-  position: relative;
-  width: 70px;
-
-  &::before {
-    left: 50%;
-    position: absolute;
-    top: 50%;
-    transform: translate(-50%, -50%);
-  }
-
-  svg {
-    left: 50%;
-    position: absolute;
-    top: 50%;
-    transform: translate(-50%, -50%);
-  }
-
-  + .govuk-heading-l {
-    margin-top: 0;
-  }
-}

--- a/app/frontend/styles/components/panel.scss
+++ b/app/frontend/styles/components/panel.scss
@@ -1,0 +1,32 @@
+.tvs-panel {
+  margin-bottom: govuk-spacing(6);
+}
+
+.hod-checkmark {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  display: block;
+  font-size: 35px;
+  height: 70px;
+  margin: 15px auto;
+  position: relative;
+  width: 70px;
+
+  &::before {
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  svg {
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  + .govuk-heading-l {
+    margin-top: 0;
+  }
+}

--- a/app/views/hiring_staff/vacancies/summary.html.haml
+++ b/app/views/hiring_staff/vacancies/summary.html.haml
@@ -2,10 +2,8 @@
 
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds
-    .govuk-panel.govuk-panel--confirmation.submit-listing-success-gtm
-      %span.hod-checkmark
-        %svg{ xmlns: "http://www.w3.org/2000/svg", role: "presentation", focusable: "false", viewBox: "0 0 25 25", height: "40", width: "40" }
-          %path{ fill: "currentColor", d: "M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" }
+    .govuk-panel.tvs-panel.govuk-panel--confirmation.submit-listing-success-gtm
+      = render partial: 'shared/checkmark'
 
       %h1.govuk-panel__title
         = t('jobs.confirmation_page.submitted')

--- a/app/views/nqt_job_alerts/confirm.html.haml
+++ b/app/views/nqt_job_alerts/confirm.html.haml
@@ -2,10 +2,8 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    .govuk-panel.govuk-panel--confirmation.nqt-job-alert-success-gtm
-      %span.hod-checkmark
-        %svg{ xmlns: "http://www.w3.org/2000/svg", role: "presentation", focusable: "false", viewBox: "0 0 25 25", height: "40", width: "40" }
-          %path{ fill: "currentColor", d: "M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" }
+    .govuk-panel.tvs-panel.govuk-panel--confirmation.nqt-job-alert-success-gtm
+      = render partial: 'shared/checkmark'
 
       %h1.govuk-panel__title{ class: 'govuk-!-font-size-24' }= t('nqt_job_alerts.confirm.splash.heading')
 

--- a/app/views/shared/_checkmark.html.haml
+++ b/app/views/shared/_checkmark.html.haml
@@ -1,0 +1,3 @@
+%span.hod-checkmark
+  %svg{ xmlns: "http://www.w3.org/2000/svg", role: "presentation", focusable: "false", viewBox: "0 0 25 25", height: "40", width: "40" }
+    %path{ fill: "currentColor", d: "M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" }

--- a/app/views/subscriptions/confirm.html.haml
+++ b/app/views/subscriptions/confirm.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title_prefix, 'Subscription confirmation'
 
 .govuk-grid-row
-  .govuk-grid-column-three-quarters
+  .govuk-grid-column-two-thirds
     .govuk-panel.tvs-panel.govuk-panel--confirmation
       = render partial: 'shared/checkmark'
 
@@ -22,7 +22,7 @@
         %li{ class: 'govuk-!-margin-top-2 govuk-!-margin-bottom-0' }
           %span
             = t('subscriptions.confirmation.frequency_label')
-          = t("subscriptions.frequency.#{@subscription.frequency}")
+          = t("subscriptions.frequency.downcase.#{@subscription.frequency}")
 
     %p.govuk-body= t('subscriptions.confirmation.unsubscribe')
     %p.govuk-body

--- a/app/views/subscriptions/confirm.html.haml
+++ b/app/views/subscriptions/confirm.html.haml
@@ -1,14 +1,14 @@
 - content_for :page_title_prefix, 'Subscription confirmation'
 
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
-    .govuk-panel.govuk-panel--confirmation
-      %span.hod-checkmark
-        %svg{ xmlns: "http://www.w3.org/2000/svg", role: "presentation", focusable: "false", viewBox: "0 0 25 25", height: "40", width: "40" }
-          %path{ fill: "currentColor", d: "M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" }
+  .govuk-grid-column-three-quarters
+    .govuk-panel.tvs-panel.govuk-panel--confirmation
+      = render partial: 'shared/checkmark'
+
       %h1.govuk-panel__title{ class: 'govuk-!-font-size-36' }= t('subscriptions.confirmation.header')
+
       .govuk-panel__body
-        %h2{ class: 'govuk-!-font-size-24' }=t('subscriptions.confirmation.receipt_confirmation', email: @subscription.email)
+        %p= t('subscriptions.confirmation.body', email: @subscription.email)
 
     %h2.govuk-heading-m=t('subscriptions.confirmation.next_step')
     %p.govuk-body=t('subscriptions.confirmation.next_step_details')

--- a/app/views/subscriptions/unsubscribe.html.haml
+++ b/app/views/subscriptions/unsubscribe.html.haml
@@ -2,7 +2,9 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    .govuk-panel.govuk-panel--confirmation
+    .govuk-panel.tvs-panel.govuk-panel--confirmation
+      = render partial: 'shared/checkmark'
+      
       %h1.govuk-panel__title= t('subscriptions.deletion.header')
       .govuk-panel__body
         - if hex?(@subscription.reference)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -788,6 +788,7 @@ en:
     website: 'Trust website'
     school_visits_heading: 'Arranging a visit to %{school}'
   subscriptions:
+    back_to_search_results: 'Return to your search results'
     benefits:
       title: Subscribers
       list:
@@ -797,56 +798,55 @@ en:
     frequency:
       daily: Daily, at approx 3 pm
       weekly: Weekly (Friday evening at approx 6 pm)
-    link:
-      text: 'Receive a job alert'
-      help_text: 'whenever a job matching this search is listed'
-      no_search_results_html: 'Or <a href="%{link_href}" id="job-alert-link-search" class="govuk-link">get notified</a> when a job like this gets listed'
-    intro: 'We’ll send you an alert for any new jobs that match the following criteria:'
-    new:
-      page_description: Subscribe to job alerts
-    info: You can unsubscribe at any time by following the simple instructions at the bottom of the alert.
-    location_radius_text: Within %{radius} miles of %{location}
-    location_category_text: In %{location}
-    reference: 'for'
-    next_steps: >-
-      You’ll receive an email every morning with any new job that’s been listed that matches your search criteria.
     confirmation:
       header: 'Your email subscription has started'
-      receipt_confirmation: We have sent a confirmation email to %{email}.
-      next_step: 'What happens next'
-      reference: 'Your reference: %{reference}'
-      unsubscribe: "You can unsubscribe by following the link at the bottom of these emails."
-      next_step_details: 'We’ll email you details of any new teaching jobs that match the following criteria:'
+      body: We sent an email confirmation to %{email}.
       frequency_label: 'You will receive alerts:'
+      next_step_details: 'We’ll email you details of any new teaching jobs that match the following criteria:'
+      next_step: 'What happens next'
+      unsubscribe: "You can unsubscribe by following the link at the bottom of these emails."
     deletion:
-      title: Subscription deleted
-      header: Your email subscription has been deleted
-      confirmation: You will no longer receive updates for this alert.
       confirmation_with_reference: You will no longer receive updates for your '%{reference}' alert.
+      confirmation: You will no longer receive updates for this alert.
+      header: Your email subscription has been deleted
       resubscribe_html: If you unsubscribed accidentally, you can %{link}.
       resubscribe_link_text: resubscribe here
-    back_to_search_results: 'Return to your search results'
+      title: Subscription deleted
     email:
-      unsubscribe_text_html: "You can unsubscribe by following the link at the bottom of these emails."
-      unsubscribe_link_text: "Unsubscribe here"
       confirmation:
-        subject: "Teaching Vacancies job alert confirmation for '%{reference}'"
+        expiry_text_html: "Your job alert subscription will end on %{date}."
         heading: "You have subscribed to a job alert for '%{reference}'."
         subheading: 'We’ll email you details of any new jobs that match the following search criteria:'
-        expiry_text_html: "Your job alert subscription will end on %{date}."
+        subject: "Teaching Vacancies job alert confirmation for '%{reference}'"
+      unsubscribe_text_html: "You can unsubscribe by following the link at the bottom of these emails."
+      unsubscribe_link_text: "Unsubscribe here"
       your_feedback: >-
         Teaching Vacancies is a free job-listing service from the Department for Education. It helps
         schools to save money on recruitment and you to take the next step in your career.
         [Your feedback](https://teaching-vacancies.service.gov.uk/feedback/new) will help
         us improve the service.
-    manage: Manage your subscription
-    unsubscribe: Unsubscribe
     labels:
       email_html: Email address (<span class="text-red">Required</span>)
-      frequency_html: When do you want to receive alerts? (<span class="text-red">Required</span>)
     hints:
       email: Enter your email address. We'll only use it to send you job alerts.
       reference: This text will appear in the subject line of emails for this job alert subscription. Feel free to change it.
+    info: You can unsubscribe at any time by following the simple instructions at the bottom of the alert.
+    intro: 'We’ll email you details of any new jobs that match the following search criteria:'
+    labels:
+      email_html: Email address (<span class="text-red">Required</span>)
+      frequency_html: When do you want to receive alerts? (<span class="text-red">Required</span>)
+    link:
+      help_text: 'whenever a job matching this search is published'
+      no_search_results_html: 'Or <a href="%{link_href}" id="job-alert-link-search" class="govuk-link">get notified</a> when a job like this gets listed'
+      text: 'Receive a job alert'
+    location_radius_text: Within %{radius} miles of %{location}
+    location_category_text: In %{location}
+    manage: Manage your subscription
+    new:
+      page_description: Subscribe to job alerts
+    next_steps: >-
+      You’ll receive an email every morning with any new job that’s been listed that matches your search criteria.  
+    unsubscribe: Unsubscribe
   job_alerts:
     confirmation:
       email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -798,10 +798,13 @@ en:
     frequency:
       daily: Daily, at approx 3 pm
       weekly: Weekly (Friday evening at approx 6 pm)
+      downcase:
+        daily: daily, at approx 3 pm
+        weekly: weekly (Friday evening at approx 6 pm)
     confirmation:
       header: 'Your email subscription has started'
       body: We sent an email confirmation to %{email}.
-      frequency_label: 'You will receive alerts:'
+      frequency_label: 'You will receive alerts '
       next_step_details: 'We’ll email you details of any new teaching jobs that match the following criteria:'
       next_step: 'What happens next'
       unsubscribe: "You can unsubscribe by following the link at the bottom of these emails."


### PR DESCRIPTION
This is a first slice of https://dfedigital.atlassian.net/browse/TEVA-1294-similar-jobs

- refactors the en.yml to be more alphabetical
- refactors the confirmation panel which is shared across various of our pages
- Question: to add a common style to all confirmation panels, should one add a style onto a govuk-frontend class, or create a new class and apply it to the panels? I've done the latter. I called it 'tvs-panel' because it's an early step towards a TVS Design System.