### PR TITLE
[TEVA-1331] Terraform use datasource not YAML secret for cert ARN

### DIFF
--- a/terraform/app/modules/cloudfront/data.tf
+++ b/terraform/app/modules/cloudfront/data.tf
@@ -8,3 +8,11 @@ data aws_route53_zone zones {
   for_each = local.route53_zones
   name     = each.value
 }
+
+data aws_acm_certificate cloudfront_cert {
+  domain      = local.cloudfront_cert_cn
+  statuses    = ["ISSUED"]
+  types       = ["AMAZON_ISSUED"]
+  most_recent = true
+  provider    = aws.aws_us_east_1
+}

--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -145,7 +145,7 @@ resource aws_cloudfront_distribution default {
   }
 
   viewer_certificate {
-    acm_certificate_arn = var.cloudfront_certificate_arn
+    acm_certificate_arn = data.aws_acm_certificate.cloudfront_cert.arn
     ssl_support_method  = "sni-only"
   }
 

--- a/terraform/app/modules/cloudfront/provider.tf
+++ b/terraform/app/modules/cloudfront/provider.tf
@@ -1,0 +1,7 @@
+provider aws {
+  alias = "aws_us_east_1"
+}
+
+provider aws {
+  alias = "default"
+}

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -14,9 +14,6 @@ variable cloudfront_aliases {
   type = list(string)
 }
 
-variable cloudfront_certificate_arn {
-}
-
 variable offline_bucket_domain_name {
 }
 
@@ -51,4 +48,5 @@ locals {
   route53_zones                = toset(var.route53_zones)
   route53_zones_with_a_records = local.is_production ? local.route53_zones : toset([])
   route53_zones_with_cnames    = local.route53_zones
+  cloudfront_cert_cn           = "${var.project_name}.service.gov.uk"
 }

--- a/terraform/app/modules/cloudfront/versions.tf
+++ b/terraform/app/modules/cloudfront/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-
+  required_version = ">= 0.13.1"
   required_providers {
     aws = {
       source  = "-/aws"
-      version = ">= 2.70.0"
+      version = "~> 3.8.0"
     }
   }
 }

--- a/terraform/app/modules/cloudwatch/versions.tf
+++ b/terraform/app/modules/cloudwatch/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-
+  required_version = ">= 0.13.1"
   required_providers {
     aws = {
       source  = "-/aws"
-      version = ">= 2.70.0"
+      version = "~> 3.8.0"
     }
     template = {
       source  = "hashicorp/template"

--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -1,14 +1,14 @@
 resource cloudfoundry_service_instance postgres_instance {
   name         = local.postgres_service_name
   space        = data.cloudfoundry_space.space.id
-  service_plan = data.cloudfoundry_service.postgres.service_plans["${var.postgres_service_plan}"]
+  service_plan = data.cloudfoundry_service.postgres.service_plans[var.postgres_service_plan]
   json_params  = "{\"enable_extensions\": [\"pgcrypto\", \"fuzzystrmatch\", \"plpgsql\"]}"
 }
 
 resource cloudfoundry_service_instance redis_instance {
   name         = local.redis_service_name
   space        = data.cloudfoundry_space.space.id
-  service_plan = data.cloudfoundry_service.redis.service_plans["${var.redis_service_plan}"]
+  service_plan = data.cloudfoundry_service.redis.service_plans[var.redis_service_plan]
 }
 
 resource cloudfoundry_user_provided_service papertrail {

--- a/terraform/app/modules/paas/versions.tf
+++ b/terraform/app/modules/paas/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-
+  required_version = ">= 0.13.1"
   required_providers {
     aws = {
       source  = "-/aws"
-      version = ">= 2.70.0"
+      version = "~> 3.8.0"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/app/modules/statuscake/versions.tf
+++ b/terraform/app/modules/statuscake/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-
+  required_version = ">= 0.13.1"
   required_providers {
     statuscake = {
       source  = "terraform-providers/statuscake"

--- a/terraform/app/provider.tf
+++ b/terraform/app/provider.tf
@@ -1,0 +1,16 @@
+provider aws {
+  region = var.region
+}
+
+# The two aliases below are passed to the Cloudfront module
+# Certificates for Cloudfront must be in us_east_1 region
+
+provider aws {
+  alias  = "default"
+  region = var.region
+}
+
+provider aws {
+  alias  = "aws_us_east_1"
+  region = "us-east-1"
+}

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -1,7 +1,3 @@
-provider aws {
-  region = var.region
-}
-
 /*
 For username / password authentication:
 - user
@@ -48,12 +44,15 @@ module cloudfront {
   project_name                    = var.project_name
   cloudfront_origin_domain_name   = each.value.cloudfront_origin_domain_name
   cloudfront_aliases              = each.value.cloudfront_aliases
-  cloudfront_certificate_arn      = local.infra_secrets.cloudfront_certificate_arn
   offline_bucket_domain_name      = each.value.offline_bucket_domain_name
   offline_bucket_origin_path      = each.value.offline_bucket_origin_path
   domain                          = each.value.domain
   cloudfront_enable_standard_logs = each.value.cloudfront_enable_standard_logs
   route53_zones                   = var.route53_zones
+  providers = {
+    aws.default       = aws.default
+    aws.aws_us_east_1 = aws.aws_us_east_1
+  }
 }
 
 module cloudwatch {

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.5.0"
+      version = "~> 3.8.0"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -7,14 +7,14 @@ parameter_store_environment = "dev"
 
 # CloudFront
 distribution_list = {
-  #  "tvsdev" = {
-  #    cloudfront_aliases            = ["dev.teaching-vacancies.service.gov.uk"]
-  #    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
-  #    offline_bucket_origin_path    = "/school-jobs-offline"
-  #    cloudfront_origin_domain_name = "teaching-vacancies-dev.london.cloudapps.digital"
-  #    domain                        = "dev.teaching-vacancies.service.gov.uk"
-  #    cloudfront_enable_standard_logs = false
-  #  }
+  "tvsdev" = {
+    cloudfront_aliases              = ["dev.teaching-vacancies.service.gov.uk"]
+    offline_bucket_domain_name      = "tvs-offline.s3.amazonaws.com"
+    offline_bucket_origin_path      = "/school-jobs-offline"
+    cloudfront_origin_domain_name   = "teaching-vacancies-dev.london.cloudapps.digital"
+    domain                          = "dev.teaching-vacancies.service.gov.uk"
+    cloudfront_enable_standard_logs = false
+  }
 }
 
 # Monitoring


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1331

## Changes in this PR:

- Bumped AWS provider version to 3.8.0 for consistency with `common`
- Now passing certificate ARN to Cloudfront module with Terraform datasource, and not from `/infra/secrets`

## Next steps:

- [ ] Terraform deployment required
- [ ] Remove `cloudfront_certificate_arn` secret from `/infra/secrets` in dev, staging, production
