### PR TITLE
[TEVA-1372] Terraform - derive Cloudfront aliases from Route53 zones

### DIFF
--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -12,7 +12,7 @@ resource aws_cloudfront_distribution default {
 
     custom_header {
       name  = "X-Forwarded-Host"
-      value = var.domain
+      value = local.domain
     }
   }
 
@@ -46,7 +46,7 @@ resource aws_cloudfront_distribution default {
   }
 
   enabled = true
-  aliases = var.cloudfront_aliases
+  aliases = local.cloudfront_aliases
 
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -10,18 +10,12 @@ variable cloudfront_enable_standard_logs {
 variable cloudfront_origin_domain_name {
 }
 
-variable cloudfront_aliases {
-  type = list(string)
-}
-
 variable offline_bucket_domain_name {
 }
 
 variable offline_bucket_origin_path {
 }
 
-variable domain {
-}
 
 variable default_header_list {
   default = [
@@ -49,4 +43,8 @@ locals {
   route53_zones_with_a_records = local.is_production ? local.route53_zones : toset([])
   route53_zones_with_cnames    = local.route53_zones
   cloudfront_cert_cn           = "${var.project_name}.service.gov.uk"
+  domain                       = local.is_production ? local.cloudfront_cert_cn : "${var.environment}.${local.cloudfront_cert_cn}"
+  cloudfront_aliases_a_records = local.is_production ? [for zone in var.route53_zones : zone] : []
+  cloudfront_aliases_cnames    = [for zone in var.route53_zones : "${local.route53_prefix}.${zone}"]
+  cloudfront_aliases           = concat(local.cloudfront_aliases_a_records, local.cloudfront_aliases_cnames)
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -43,10 +43,8 @@ module cloudfront {
   environment                     = var.environment
   project_name                    = var.project_name
   cloudfront_origin_domain_name   = each.value.cloudfront_origin_domain_name
-  cloudfront_aliases              = each.value.cloudfront_aliases
   offline_bucket_domain_name      = each.value.offline_bucket_domain_name
   offline_bucket_origin_path      = each.value.offline_bucket_origin_path
-  domain                          = each.value.domain
   cloudfront_enable_standard_logs = each.value.cloudfront_enable_standard_logs
   route53_zones                   = var.route53_zones
   providers = {

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -15,11 +15,9 @@ variable environment {
 variable distribution_list {
   description = "Define Cloudfront distributions with the attributes below"
   type = map(object({
-    cloudfront_aliases              = list(string)
     offline_bucket_domain_name      = string
     offline_bucket_origin_path      = string
     cloudfront_origin_domain_name   = string
-    domain                          = string
     cloudfront_enable_standard_logs = bool
   }))
   default = {}

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -8,11 +8,9 @@ parameter_store_environment = "dev"
 # CloudFront
 distribution_list = {
   "tvsdev" = {
-    cloudfront_aliases              = ["dev.teaching-vacancies.service.gov.uk"]
     offline_bucket_domain_name      = "tvs-offline.s3.amazonaws.com"
     offline_bucket_origin_path      = "/school-jobs-offline"
     cloudfront_origin_domain_name   = "teaching-vacancies-dev.london.cloudapps.digital"
-    domain                          = "dev.teaching-vacancies.service.gov.uk"
     cloudfront_enable_standard_logs = false
   }
 }

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -8,11 +8,9 @@ parameter_store_environment = "production"
 # CloudFront
 distribution_list = {
   "tvsprod" = {
-    cloudfront_aliases              = ["teaching-jobs.service.gov.uk", "www.teaching-jobs.service.gov.uk", "teaching-vacancies.service.gov.uk", "www.teaching-vacancies.service.gov.uk"]
     offline_bucket_domain_name      = "tvs-offline.s3.amazonaws.com"
     offline_bucket_origin_path      = "/school-jobs-offline"
     cloudfront_origin_domain_name   = "teaching-vacancies-production.london.cloudapps.digital"
-    domain                          = "teaching-vacancies.service.gov.uk"
     cloudfront_enable_standard_logs = false
   }
 }

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -8,11 +8,9 @@ app_environment             = "review"
 # CloudFront
 distribution_list = {
   # "tvsreviewpr2012" = {
-  #   cloudfront_aliases            = ["review-pr-2012.teaching-jobs.service.gov.uk","review-pr-2012.teaching-vacancies.service.gov.uk"]
   #   offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
   #   offline_bucket_origin_path    = "/school-jobs-offline"
   #   cloudfront_origin_domain_name = "teaching-vacancies-review-pr-2012.london.cloudapps.digital"
-  #   domain                        = "review-pr-2012.teaching-vacancies.service.gov.uk"
   #   cloudfront_enable_standard_logs = false
   # }
 }

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -8,11 +8,9 @@ parameter_store_environment = "staging"
 # CloudFront
 distribution_list = {
   "tvsstaging" = {
-    cloudfront_aliases              = ["staging.teaching-jobs.service.gov.uk", "staging.teaching-vacancies.service.gov.uk"]
     offline_bucket_domain_name      = "tvs-offline.s3.amazonaws.com"
     offline_bucket_origin_path      = "/school-jobs-offline"
     cloudfront_origin_domain_name   = "teaching-vacancies-staging.london.cloudapps.digital"
-    domain                          = "staging.teaching-vacancies.service.gov.uk"
     cloudfront_enable_standard_logs = false
   }
 }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1372

## Changes in this PR:

- Use Terraform local variables to create Cloudfront aliases only for the Route53 zones which are passed to the module.
- Simplify Cloudfront object in per-stage `.tfvars` files

## Next steps:

- [ ] Rebase and merge after PR 2084