### PR TITLE
Bigquery include mat users in school signup counts

### DIFF
--- a/bigquery/scheduled_queries/calculated-daily-school-time-metrics.sql
+++ b/bigquery/scheduled_queries/calculated-daily-school-time-metrics.sql
@@ -87,12 +87,6 @@ WITH
       `teacher-vacancy-service.production_dataset.schoolgroup` AS trust
     ON
       trust.id = schools.trust_id
-      #    LEFT JOIN
-      #      `teacher-vacancy-service.production_dataset.CALCULATED_timestamped_dsi_users` AS users
-      #    ON
-      #IF(users.school_urn IS NOT NULL,users.school_urn = CAST(schools.urn AS INT64),users.organisation_uid=trust.uid)
-      #COALESCE(users.school_urn,users.organisation_uid) = COALESCE(CAST(schools.urn AS INT64),trust.uid)
-      #      users.school_urn = CAST(schools.urn AS INT64)
     LEFT JOIN
       `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
     ON

--- a/bigquery/scheduled_queries/timestamped-dsi-users.sql
+++ b/bigquery/scheduled_queries/timestamped-dsi-users.sql
@@ -28,18 +28,27 @@ IF
   COALESCE(dsi_users_now.email,
     latest_timestamped_dsi_users.email) AS email,
   COALESCE(dsi_users_now.school_urn,
-    latest_timestamped_dsi_users.school_urn) AS school_urn
+    latest_timestamped_dsi_users.school_urn) AS school_urn,
+  COALESCE( dsi_users_now.organisation_uid,
+    latest_timestamped_dsi_users.organisation_uid) AS organisation_uid
 FROM
   `teacher-vacancy-service.production_dataset.dsi_users` AS dsi_users_now
 FULL JOIN
   `teacher-vacancy-service.production_dataset.CALCULATED_timestamped_dsi_users` AS latest_timestamped_dsi_users
 ON
   dsi_users_now.user_id=latest_timestamped_dsi_users.user_id
-  AND dsi_users_now.school_urn=latest_timestamped_dsi_users.school_urn
+  AND (dsi_users_now.school_urn=latest_timestamped_dsi_users.school_urn
+    OR COALESCE(dsi_users_now.school_urn,
+      latest_timestamped_dsi_users.school_urn) IS NULL)
+  AND (dsi_users_now.organisation_uid=latest_timestamped_dsi_users.organisation_uid
+    OR COALESCE(dsi_users_now.organisation_uid,
+      latest_timestamped_dsi_users.organisation_uid) IS NULL)
   AND CAST(dsi_users_now.approval_datetime AS DATE)=latest_timestamped_dsi_users.from_date
 WHERE
   COALESCE(dsi_users_now.school_urn,
-    latest_timestamped_dsi_users.school_urn) IS NOT NULL
+    latest_timestamped_dsi_users.school_urn,
+    dsi_users_now.organisation_uid,
+    latest_timestamped_dsi_users.organisation_uid ) IS NOT NULL
   AND
 IF
   ((


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1068

## Changes in this PR:

- If a school is within a trust that has MAT level access, count that school as signed up to TV. Note that they'll only be counted as *using* TV if a vacancy was published at that specific school, or a multi school role at that school. (Trust level vacancies are not counted as school usage of TV.)
- Replicate these changes to calculated-daily-time-metrics.sql as well
- Add organisation_uid field to table of DSI users over time
