### PR TITLE
Remove hyphens from relevant cities

### DIFF
--- a/lib/tasks/data/cities.yml
+++ b/lib/tasks/data/cities.yml
@@ -15,7 +15,7 @@
 - Brighton and Hove
 - Bristol
 - Burnley
-- Burton-upon-Trent
+- Burton upon Trent
 - Bury
 - Cambridge
 - Carlisle
@@ -47,7 +47,7 @@
 - High Wycombe
 - Huddersfield
 - Ipswich
-- Kingston-upon-Hull
+- Kingston upon Hull
 - Leeds
 - Leicester
 - Lincoln
@@ -59,7 +59,7 @@
 - Mansfield
 - Middlesbrough
 - Milton Keynes
-- Newcastle-upon-Tyne
+- Newcastle upon Tyne
 - Newcastle-under-Lyme
 - Northampton
 - Norwich
@@ -101,7 +101,7 @@
 - Warrington
 - Watford
 - West Bromwich
-- Weston-super-Mare
+- Weston-Super-Mare
 - Wigan
 - Woking
 - Wolverhampton


### PR DESCRIPTION
## Changes in this PR:

![Screenshot 2020-10-05 at 14 02 03](https://user-images.githubusercontent.com/30624173/95178015-cd048580-07b6-11eb-9d29-227d9e52968a.png)

Noticed that location polygon searches for towns like Burton-upon-Trent were returning a lot of results. 

After investigating I found that this was due the fact that certain city/town names in our cities.yml file had hyphens in, but didn't in the API data. This meant that polygons were not being created for these cities/towns. 

In order to make sure that polygon searches return an accurate result, I removed the hyphens from the relevant city/town names in the cities.yml file.