### PR TITLE
Rename 'algolia' services to 'search' services

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -3,7 +3,7 @@ class VacanciesController < ApplicationController
 
   def index
     @jobs_search_form = VacancyAlgoliaSearchForm.new(algolia_search_params)
-    @vacancies_search = Algolia::VacancySearchBuilder.new(@jobs_search_form.to_hash)
+    @vacancies_search = Search::VacancySearchBuilder.new(@jobs_search_form.to_hash)
     @vacancies_search.call
     @vacancies = VacanciesPresenter.new(
       @vacancies_search.vacancies,

--- a/app/jobs/alert_email/base.rb
+++ b/app/jobs/alert_email/base.rb
@@ -14,6 +14,6 @@ class AlertEmail::Base < ApplicationJob
 
   def vacancies_for_subscription(subscription)
     subscription.vacancies_for_range(from_date, Time.zone.today)
-                .limit(Algolia::VacancyAlertBuilder::MAXIMUM_SUBSCRIPTION_RESULTS)
+                .limit(Search::VacancyAlertBuilder::MAXIMUM_SUBSCRIPTION_RESULTS)
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -46,7 +46,7 @@ class Subscription < ApplicationRecord
   end
 
   def vacancies_for_range(date_from, date_to)
-    Algolia::VacancyAlertBuilder.new(
+    Search::VacancyAlertBuilder.new(
       search_criteria_to_h.symbolize_keys.merge(from_date: date_from, to_date: date_to),
     ).call
   end

--- a/app/services/search/vacancy_alert_builder.rb
+++ b/app/services/search/vacancy_alert_builder.rb
@@ -1,4 +1,4 @@
-class Algolia::VacancyAlertBuilder < Algolia::VacancySearchBuilder
+class Search::VacancyAlertBuilder < Search::VacancySearchBuilder
   attr_reader :vacancies
 
   MAXIMUM_SUBSCRIPTION_RESULTS = 500

--- a/app/services/search/vacancy_filters_builder.rb
+++ b/app/services/search/vacancy_filters_builder.rb
@@ -1,4 +1,4 @@
-class Algolia::VacancyFiltersBuilder
+class Search::VacancyFiltersBuilder
   def initialize(filters_hash)
     # Although we are no longer indexing expired and pending vacancies, we need to maintain this filter for now as
     # expired vacancies only get removed from the index once a day.

--- a/app/services/search/vacancy_location_builder.rb
+++ b/app/services/search/vacancy_location_builder.rb
@@ -1,4 +1,4 @@
-class Algolia::VacancyLocationBuilder
+class Search::VacancyLocationBuilder
   DEFAULT_RADIUS = 10
   MILES_TO_METRES = 1.60934 * 1000
 

--- a/app/services/search/vacancy_search_builder.rb
+++ b/app/services/search/vacancy_search_builder.rb
@@ -1,6 +1,6 @@
 require 'geocoding'
 
-class Algolia::VacancySearchBuilder
+class Search::VacancySearchBuilder
   attr_reader :keyword, :location_search,
               :point_coordinates, :search_filters, :search_replica, :sort_by, :stats, :vacancies
 
@@ -54,7 +54,7 @@ private
   end
 
   def build_location_search
-    @location_search = Algolia::VacancyLocationBuilder.new(
+    @location_search = Search::VacancyLocationBuilder.new(
       @params_hash[:location], @params_hash[:radius], @params_hash[:location_category]
     )
     @params_hash[:location_category] = @location_search.location_category if @location_search.location_category_search?
@@ -65,7 +65,7 @@ private
   end
 
   def build_search_filters
-    @search_filters = Algolia::VacancyFiltersBuilder.new(@params_hash).filter_query
+    @search_filters = Search::VacancyFiltersBuilder.new(@params_hash).filter_query
   end
 
   def build_search_replica

--- a/spec/components/jobseekers/search_results/heading_component_spec.rb
+++ b/spec/components/jobseekers/search_results/heading_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Jobseekers::SearchResults::HeadingComponent, type: :component do
   subject { described_class.new(vacancies_search: vacancies_search) }
 
-  let(:vacancies_search) { instance_double(Algolia::VacancySearchBuilder) }
+  let(:vacancies_search) { instance_double(Search::VacancySearchBuilder) }
   let(:keyword) { 'maths' }
   let(:location) { 'London' }
   let(:count) { 10 }

--- a/spec/components/jobseekers/search_results/job_alerts_link_component_spec.rb
+++ b/spec/components/jobseekers/search_results/job_alerts_link_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Jobseekers::SearchResults::JobAlertsLinkComponent, type: :component do
   subject { described_class.new(vacancies_search: vacancies_search, count: 1) }
 
-  let(:vacancies_search) { instance_double(Algolia::VacancySearchBuilder) }
+  let(:vacancies_search) { instance_double(Search::VacancySearchBuilder) }
   let(:active_hash) { { keyword: 'maths' } }
 
   before do

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe VacanciesController, type: :controller do
           }
         end
 
-        it 'passes only safe values to Algolia::VacancySearchBuilder' do
-          expect(Algolia::VacancySearchBuilder).to receive(:new).with(expected_safe_values).and_call_original
+        it 'passes only safe values to Search::VacancySearchBuilder' do
+          expect(Search::VacancySearchBuilder).to receive(:new).with(expected_safe_values).and_call_original
           subject
         end
       end
@@ -31,8 +31,8 @@ RSpec.describe VacanciesController, type: :controller do
         let(:expected_safe_values) { { jobs_sort: 'Text' } }
         let(:params) { { jobs_sort: "<body onload=alert('test1')>Text</script>" } }
 
-        it 'passes sanitised params to Algolia::VacancySearchBuilder' do
-          expect(Algolia::VacancySearchBuilder).to receive(:new).with(expected_safe_values).and_call_original
+        it 'passes sanitised params to Search::VacancySearchBuilder' do
+          expect(Search::VacancySearchBuilder).to receive(:new).with(expected_safe_values).and_call_original
           subject
         end
       end
@@ -71,7 +71,7 @@ RSpec.describe VacanciesController, type: :controller do
       context 'when parameters include the sort by newest listing option' do
         let(:sort) { 'publish_on_desc' }
 
-        it 'sets the search replica on Algolia::VacancySearchBuilder' do
+        it 'sets the search replica on Search::VacancySearchBuilder' do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql("Vacancy_#{sort}")
         end
@@ -80,7 +80,7 @@ RSpec.describe VacanciesController, type: :controller do
       context 'when parameters include the sort by most time to apply option' do
         let(:sort) { 'expiry_time_desc' }
 
-        it 'sets the search replica on Algolia::VacancySearchBuilder' do
+        it 'sets the search replica on Search::VacancySearchBuilder' do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql("Vacancy_#{sort}")
         end
@@ -89,7 +89,7 @@ RSpec.describe VacanciesController, type: :controller do
       context 'when parameters include the sort by least time to apply option' do
         let(:sort) { 'expiry_time_asc' }
 
-        it 'sets the search replica on Algolia::VacancySearchBuilder' do
+        it 'sets the search replica on Search::VacancySearchBuilder' do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql("Vacancy_#{sort}")
         end
@@ -104,7 +104,7 @@ RSpec.describe VacanciesController, type: :controller do
           }
         end
 
-        it 'sets the search replica on Algolia::VacancySearchBuilder to the default sort strategy: newest listing' do
+        it 'sets the search replica on Search::VacancySearchBuilder to the default sort strategy: newest listing' do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql('Vacancy_publish_on_desc')
         end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -148,13 +148,13 @@ RSpec.describe Subscription, type: :model do
     let(:algolia_search_args) do
       {
         filters: search_filter,
-        hitsPerPage: Algolia::VacancyAlertBuilder::MAXIMUM_SUBSCRIPTION_RESULTS
+        hitsPerPage: Search::VacancyAlertBuilder::MAXIMUM_SUBSCRIPTION_RESULTS
       }
     end
 
     before do
       travel_to expired_now
-      allow_any_instance_of(Algolia::VacancyFiltersBuilder)
+      allow_any_instance_of(Search::VacancyFiltersBuilder)
         .to receive(:expired_now_filter)
         .and_return(expired_now.to_time.to_i)
       allow(vacancies).to receive(:count).and_return(10)

--- a/spec/services/search/vacancy_alert_builder_spec.rb
+++ b/spec/services/search/vacancy_alert_builder_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Algolia::VacancyAlertBuilder do
+RSpec.describe Search::VacancyAlertBuilder do
   subject { described_class.new(subscription_hash) }
 
   let!(:expired_now) { Time.zone.now }
@@ -10,7 +10,7 @@ RSpec.describe Algolia::VacancyAlertBuilder do
   let(:default_radius) { 10 }
   let(:date_today) { Time.zone.today.to_time }
   let(:location_point_coordinates) { Geocoder::DEFAULT_STUB_COORDINATES }
-  let(:location_radius) { (default_radius * Algolia::VacancyLocationBuilder::MILES_TO_METRES).to_i }
+  let(:location_radius) { (default_radius * Search::VacancyLocationBuilder::MILES_TO_METRES).to_i }
   let(:location_polygon_boundary) { nil }
   let(:search_replica) { nil }
   let(:max_subscription_results) { 500 }
@@ -29,7 +29,7 @@ RSpec.describe Algolia::VacancyAlertBuilder do
 
   before do
     travel_to(expired_now)
-    allow_any_instance_of(Algolia::VacancyFiltersBuilder)
+    allow_any_instance_of(Search::VacancyFiltersBuilder)
       .to receive(:expired_now_filter)
       .and_return(expired_now.to_time.to_i)
   end

--- a/spec/services/search/vacancy_filters_builder_spec.rb
+++ b/spec/services/search/vacancy_filters_builder_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Algolia::VacancyFiltersBuilder do
+RSpec.describe Search::VacancyFiltersBuilder do
   subject { described_class.new(filters_hash) }
 
   let(:filters_hash) do
@@ -81,7 +81,7 @@ RSpec.describe Algolia::VacancyFiltersBuilder do
 
       before do
         travel_to(expired_now)
-        allow_any_instance_of(Algolia::VacancyFiltersBuilder)
+        allow_any_instance_of(Search::VacancyFiltersBuilder)
           .to receive(:expired_now_filter)
           .and_return(expired_now.to_time.to_i)
       end

--- a/spec/services/search/vacancy_location_builder_spec.rb
+++ b/spec/services/search/vacancy_location_builder_spec.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples 'a search using polygons' do
   end
 end
 
-RSpec.describe Algolia::VacancyLocationBuilder do
+RSpec.describe Search::VacancyLocationBuilder do
   subject { described_class.new(location, radius, location_category) }
 
   let(:location) { nil }
@@ -68,7 +68,7 @@ RSpec.describe Algolia::VacancyLocationBuilder do
           expect(subject.location_polygon).to be nil
           expect(subject.location_filter).to eql({
             point_coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
-            radius: (10 * Algolia::VacancyLocationBuilder::MILES_TO_METRES).to_i
+            radius: (10 * Search::VacancyLocationBuilder::MILES_TO_METRES).to_i
           })
         end
       end
@@ -82,7 +82,7 @@ RSpec.describe Algolia::VacancyLocationBuilder do
           expect(subject.location_polygon).to be nil
           expect(subject.location_filter).to eql({
             point_coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
-            radius: (radius * Algolia::VacancyLocationBuilder::MILES_TO_METRES).to_i
+            radius: (radius * Search::VacancyLocationBuilder::MILES_TO_METRES).to_i
           })
         end
       end

--- a/spec/services/search/vacancy_search_builder_spec.rb
+++ b/spec/services/search/vacancy_search_builder_spec.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples 'a search in the default search replica' do
   end
 end
 
-RSpec.describe Algolia::VacancySearchBuilder do
+RSpec.describe Search::VacancySearchBuilder do
   subject { described_class.new(params) }
 
   let(:keyword) { 'maths teacher' }
@@ -43,7 +43,7 @@ RSpec.describe Algolia::VacancySearchBuilder do
       let(:params) { { keyword: keyword, location: polygonable_location } }
 
       before do
-        allow_any_instance_of(Algolia::VacancyLocationBuilder).to receive(:missing_polygon).and_return(true)
+        allow_any_instance_of(Search::VacancyLocationBuilder).to receive(:missing_polygon).and_return(true)
       end
 
       it 'appends location to the keyword' do
@@ -59,7 +59,7 @@ RSpec.describe Algolia::VacancySearchBuilder do
       let(:params) { { keyword: keyword, location: polygonable_location } }
 
       before do
-        allow_any_instance_of(Algolia::VacancyLocationBuilder).to receive(:location_category_search?)
+        allow_any_instance_of(Search::VacancyLocationBuilder).to receive(:location_category_search?)
                                                               .and_return(true)
       end
 
@@ -180,7 +180,7 @@ RSpec.describe Algolia::VacancySearchBuilder do
     context 'a geographical radius location search' do
       let(:location) { point_location }
       let(:location_point_coordinates) { Geocoder::DEFAULT_STUB_COORDINATES }
-      let(:location_radius) { (default_radius * Algolia::VacancyLocationBuilder::MILES_TO_METRES).to_i }
+      let(:location_radius) { (default_radius * Search::VacancyLocationBuilder::MILES_TO_METRES).to_i }
       let(:location_polygon_boundary) { nil }
 
       it 'carries out search with correct criteria' do


### PR DESCRIPTION
I'd like to do this so that I can put my new service class `Search::CriteriaConcocter` into the same subfolder. But these classes are all dependent on Algolia so keeping it as it is would make sense too. Opinions?