### PR TITLE
For school groups, save gias_data to an attribute on organisation

### DIFF
--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -3,27 +3,7 @@ class SchoolGroup < Organisation
   has_many :schools, through: :school_group_memberships
 
   # TODO: This should ideally be a stored as column in the database table
-  def name
-    gias_data['Group Name']&.titlecase
-  end
-
   def group_type
     gias_data['Group Type']
-  end
-
-  def address
-    gias_data['Group Locality']
-  end
-
-  def town
-    gias_data['Group Town']
-  end
-
-  def county
-    gias_data['Group County']
-  end
-
-  def postcode
-    gias_data['Group Postcode']
   end
 end

--- a/lib/import_school_group_data.rb
+++ b/lib/import_school_group_data.rb
@@ -58,15 +58,18 @@ private
   def convert_to_school_group(row)
     school_group = SchoolGroup.find_or_initialize_by(uid: row['Group UID'])
     set_gias_data_as_json(school_group, row)
-    set_geolocation(school_group, row)
+    school_group.postcode = row['Group Postcode']
+    school_group.name = row['Group Name']&.titlecase
+    school_group.address = row['Group Locality']
+    school_group.town = row['Group Town']
+    school_group.county = row['Group County']
+    set_geolocation(school_group)
     school_group
   end
 
-  def set_geolocation(school_group, row)
-    if row['Group Postcode']&.present? && (school_group.geolocation.blank? || school_group.postcode != row['Group Postcode'])
-      coordinates = Geocoding.new(row['Group Postcode']).coordinates
-      school_group.geolocation = coordinates unless coordinates == [0, 0]
-    end
+  def set_geolocation(school_group)
+    coordinates = Geocoding.new(school_group.postcode).coordinates
+    school_group.geolocation = coordinates unless coordinates == [0, 0]
   end
 
   def set_gias_data_as_json(school_group, row)

--- a/spec/factories/school_groups.rb
+++ b/spec/factories/school_groups.rb
@@ -1,13 +1,23 @@
 FactoryBot.define do
   factory :school_group do
-    uid { Faker::Number.number(digits: 5).to_s }
+    address { Faker::Address.street_name.gsub("'", '') }
+    county { Faker::Address.state_abbr }
     gias_data do
       {
         "Group UID": uid,
-        "Group Name": 'Trust name',
-        "Group Type": 'Trust type'
+        "Group Name": name,
+        "Group Type": 'Trust type',
+        "Group Postcode": postcode,
+        "Group Type (code)": '06',
+        "Group Locality": address,
+        "Group Town": town,
+        "Group County": county
       }
     end
+    name { Faker::Company.name.gsub("'", '') + ' Trust' }
+    postcode { Faker::Address.postcode }
+    town { Faker::Address.city.gsub("'", '') }
+    uid { Faker::Number.number(digits: 5).to_s }
     website { Faker::Internet.url }
   end
 end

--- a/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Editing a published vacancy' do
       visit edit_organisation_job_path(vacancy.id)
 
       expect(page).to have_content(I18n.t('school_groups.job_location_heading.review.central_office'))
-      expect(page).to have_content(location(school_group))
+      expect(page).to have_content(full_address(school_group))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
         I18n.t('hiring_staff.organisations.readable_job_location.central_office'),
       )
@@ -62,7 +62,7 @@ RSpec.describe 'Editing a published vacancy' do
 
       expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t('school_groups.job_location_heading.review.central_office'))
-      expect(page).to have_content(location(school_group))
+      expect(page).to have_content(full_address(school_group))
       expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
         I18n.t('hiring_staff.organisations.readable_job_location.central_office'),
       )


### PR DESCRIPTION
As opposed to sourcing it from inside the gias_data json attribute

For example, this makes the method organisation.postcode work for both Schools and SchoolGroups, which is needed for encapsulation.
