### PR TITLE
[TEVA-1388] Add lifecycle policy to S3 db backups bucket

### DIFF
--- a/terraform/common/s3.tf
+++ b/terraform/common/s3.tf
@@ -2,6 +2,15 @@ data aws_caller_identity current {}
 
 resource aws_s3_bucket db_backups {
   bucket = "${data.aws_caller_identity.current.account_id}-tv-db-backups"
+
+  lifecycle_rule {
+    id      = "backups"
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
 }
 
 resource aws_s3_bucket cloudfront_logs {


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1388

## Changes in this PR:

- Add lifecycle policy to S3 bucket
- Set at 35 days, to allow for a full month, even accounting for weekends including a bank holiday

## Next steps:

- [ ] Terraform deployment required