### PR TITLE
[TEVA-1365] - Enable Cloudfront standard logs, and S3 lifecycle policy

### DIFF
--- a/terraform/common/s3.tf
+++ b/terraform/common/s3.tf
@@ -6,4 +6,27 @@ resource aws_s3_bucket db_backups {
 
 resource aws_s3_bucket cloudfront_logs {
   bucket = "${data.aws_caller_identity.current.account_id}-tv-cloudfront-logs"
+
+  lifecycle_rule {
+    id      = "staging"
+    enabled = true
+
+    prefix = "staging/"
+
+    expiration {
+      days = 3
+    }
+  }
+
+  lifecycle_rule {
+    id      = "production"
+    enabled = true
+
+    prefix = "production/"
+
+    expiration {
+      days = 35
+    }
+  }
+
 }

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -11,7 +11,7 @@ distribution_list = {
     offline_bucket_domain_name      = "tvs-offline.s3.amazonaws.com"
     offline_bucket_origin_path      = "/school-jobs-offline"
     cloudfront_origin_domain_name   = "teaching-vacancies-production.london.cloudapps.digital"
-    cloudfront_enable_standard_logs = false
+    cloudfront_enable_standard_logs = true
   }
 }
 

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -11,7 +11,7 @@ distribution_list = {
     offline_bucket_domain_name      = "tvs-offline.s3.amazonaws.com"
     offline_bucket_origin_path      = "/school-jobs-offline"
     cloudfront_origin_domain_name   = "teaching-vacancies-staging.london.cloudapps.digital"
-    cloudfront_enable_standard_logs = false
+    cloudfront_enable_standard_logs = true
   }
 }
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1365

## Changes in this PR:

- Enabled Cloudfront standard logging in staging and production via a Terraform variable
- Added S3 bucket lifecycle policy, setting staging to delete after 3 days, and production after 35 days (a full month, allowing for weekends including a public holiday)

## Next steps:

- [ ] Terraform deployment required