### PR TITLE
Remove unused method

### DIFF
--- a/app/models/general_feedback.rb
+++ b/app/models/general_feedback.rb
@@ -1,5 +1,4 @@
 class GeneralFeedback < ApplicationRecord
-  include Auditor::Model
   include FeedbackValidations
 
   enum visit_purpose: { other_purpose: 0, find_teaching_job: 1, list_teaching_job: 2 }

--- a/app/models/general_feedback.rb
+++ b/app/models/general_feedback.rb
@@ -9,17 +9,4 @@ class GeneralFeedback < ApplicationRecord
   validates :visit_purpose_comment, length: { maximum: 1200 }, if: :visit_purpose_comment?
 
   scope :published_on, (->(date) { where(created_at: date.all_day) })
-
-  def to_row
-    [
-      Time.zone.now.to_s,
-      visit_purpose,
-      visit_purpose_comment,
-      rating,
-      comment,
-      created_at.to_s,
-      user_participation_response,
-      email,
-    ]
-  end
 end

--- a/app/models/vacancy_publish_feedback.rb
+++ b/app/models/vacancy_publish_feedback.rb
@@ -7,18 +7,4 @@ class VacancyPublishFeedback < ApplicationRecord
   belongs_to :user
 
   scope :published_on, (->(date) { where(created_at: date.all_day) })
-
-  def to_row
-    [
-      Time.zone.now.to_s,
-      user&.oid,
-      vacancy.id,
-      vacancy.parent_organisation.urn,
-      rating,
-      comment,
-      created_at.to_s,
-      user_participation_response,
-      email,
-    ]
-  end
 end

--- a/spec/models/general_feedback_spec.rb
+++ b/spec/models/general_feedback_spec.rb
@@ -54,34 +54,4 @@ RSpec.describe GeneralFeedback, type: :model do
       expect(GeneralFeedback.published_on(1.month.ago)).to match_array(feedback_some_other_day)
     end
   end
-
-  describe '#to_row' do
-    let(:created_at) { '2019-01-01T00:00:00+00:00' }
-    let(:visit_purpose) { :other_purpose }
-    let(:visit_purpose_comment) { 'For reasons...' }
-    let(:comment) { 'Great!' }
-    let(:user_participation_response) { :interested }
-    let(:email) { 'hello@research.com' }
-
-    let(:feedback) do
-      travel_to created_at do
-        create(:general_feedback, visit_purpose: visit_purpose,
-                                  visit_purpose_comment: visit_purpose_comment,
-                                  comment: comment,
-                                  user_participation_response: user_participation_response,
-                                  email: email)
-      end
-    end
-
-    it 'returns an array of data' do
-      expect(feedback.to_row[0]).to eq(Time.zone.now.to_s)
-      expect(feedback.to_row[1]).to eq(visit_purpose.to_s)
-      expect(feedback.to_row[2]).to eq(visit_purpose_comment)
-      expect(feedback.to_row[3]).to eq(nil) # Rating column: we no longer take these as feedback
-      expect(feedback.to_row[4]).to eq(comment)
-      expect(feedback.to_row[5]).to eq(feedback.created_at.to_s)
-      expect(feedback.to_row[6]).to eq(user_participation_response.to_s)
-      expect(feedback.to_row[7]).to eq(email)
-    end
-  end
 end

--- a/spec/models/vacancy_publish_feedback_spec.rb
+++ b/spec/models/vacancy_publish_feedback_spec.rb
@@ -54,35 +54,4 @@ RSpec.describe VacancyPublishFeedback, type: :model do
       expect(VacancyPublishFeedback.published_on(1.month.ago)).to match_array(feedback_some_other_day)
     end
   end
-
-  describe '#to_row' do
-    let(:school) { create(:school) }
-    let(:created_at) { '2019-01-01T00:00:00+00:00' }
-    let(:user) { create(:user) }
-    let(:vacancy) { create(:vacancy) }
-    let!(:vacancy_organisation) { vacancy.organisation_vacancies.create(organisation: school) }
-    let(:rating) { 5 }
-    let(:comment) { 'Great!' }
-    let(:user_participation_response) { :interested }
-    let(:email) { 'user@email.com' }
-
-    let(:feedback) do
-      travel_to created_at do
-        create(:vacancy_publish_feedback, user: user, vacancy: vacancy, rating: rating, comment: comment,
-                                          user_participation_response: user_participation_response, email: email)
-      end
-    end
-
-    it 'returns an array of data' do
-      expect(feedback.to_row[0]).to eq(Time.zone.now.to_s)
-      expect(feedback.to_row[1]).to eq(user.oid)
-      expect(feedback.to_row[2]).to eq(vacancy.id)
-      expect(feedback.to_row[3]).to eq(school.urn)
-      expect(feedback.to_row[4]).to eq(rating)
-      expect(feedback.to_row[5]).to eq(comment)
-      expect(feedback.to_row[6]).to eq(feedback.created_at.to_s)
-      expect(feedback.to_row[7]).to eq(user_participation_response.to_s)
-      expect(feedback.to_row[8]).to eq(email)
-    end
-  end
 end


### PR DESCRIPTION
From git history, it appears we used to use to_row to convert the feedback objects to a row before adding them to a spreadsheet. We no longer use any spreadsheets.

https://github.com/DFE-Digital/teacher-vacancy-service/pull/766/files
https://github.com/DFE-Digital/teacher-vacancy-service/pull/855/files

Instead of spreadsheets, we have BigQuery storing the records, and also an audit table called activities.