### PR TITLE
[TEVA-1365] Add S3 bucket ACL grant for log delivery

### DIFF
--- a/terraform/common/s3.tf
+++ b/terraform/common/s3.tf
@@ -1,4 +1,5 @@
 data aws_caller_identity current {}
+data aws_canonical_user_id current {}
 
 resource aws_s3_bucket db_backups {
   bucket = "${data.aws_caller_identity.current.account_id}-tv-db-backups"
@@ -15,6 +16,20 @@ resource aws_s3_bucket db_backups {
 
 resource aws_s3_bucket cloudfront_logs {
   bucket = "${data.aws_caller_identity.current.account_id}-tv-cloudfront-logs"
+
+  # Specifically setting the ACL grant from awslogsdelivery
+  # By explicitly setting any grant, we must declare ALL grants (i.e. also the bucket owner)
+  grant {
+    id          = local.aws_canonical_user_id_awslogsdelivery
+    type        = "CanonicalUser"
+    permissions = ["FULL_CONTROL"]
+  }
+
+  grant {
+    id          = data.aws_canonical_user_id.current.id
+    type        = "CanonicalUser"
+    permissions = ["FULL_CONTROL"]
+  }
 
   lifecycle_rule {
     id      = "staging"

--- a/terraform/common/variables.tf
+++ b/terraform/common/variables.tf
@@ -3,6 +3,8 @@ variable region { default = "eu-west-2" }
 variable s3_bucket_name { default = "terraform-state-002" }
 
 locals {
-  primary_zone_name   = "teaching-vacancies.service.gov.uk"
-  secondary_zone_name = "teaching-jobs.service.gov.uk"
+  # awslogsdelivery ID from https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership
+  aws_canonical_user_id_awslogsdelivery = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
+  primary_zone_name                     = "teaching-vacancies.service.gov.uk"
+  secondary_zone_name                   = "teaching-jobs.service.gov.uk"
 }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1388

## Changes in this PR:

- Add ACL by Canonical Id of `awslogsdelivery` account for Cloudfront logging to S3 bucket
- By declaring a grant on the bucket for `awslogsdelivery`, we have to declare for the bucket owner too

## Next steps:

- [ ] Terraform deployment required