### PR TITLE
[TEVA-1387] Change GitHub actions to use paths-ignore, not paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-    paths:
-    - '!bigquery/**'
-    - '!documentation/**'    
-    - '!terraform/common/**'
-    - '!terraform/monitoring/**'
+    paths-ignore:
+    - 'bigquery/**'
+    - 'documentation/**'    
+    - 'terraform/common/**'
+    - 'terraform/monitoring/**'
 
 env:
  DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - dev
       - staging
-    paths:
-    - '!bigquery/**'
-    - '!documentation/**'    
-    - '!terraform/common/**'
-    - '!terraform/monitoring/**'
+    paths-ignore:
+    - 'bigquery/**'
+    - 'documentation/**'    
+    - 'terraform/common/**'
+    - 'terraform/monitoring/**'
 
 env:
  DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - '**'
-    paths:
-    - '!bigquery/**'
-    - '!documentation/**'    
-    - '!terraform/common/**'
-    - '!terraform/monitoring/**'
+    paths-ignore:
+    - 'bigquery/**'
+    - 'documentation/**'    
+    - 'terraform/common/**'
+    - 'terraform/monitoring/**'
 
 jobs:
   backend-tests:


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1387

## Changes in this PR:

- Change GitHub Actions workflows to use `paths-ignore`, rather than `paths` to exclude folders, following the [Example ignoring paths](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-ignoring-paths) in the documentation