### PR TITLE
[TEVA-1266] Add Docker Buildx and login steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,15 @@ jobs:
         bin/run-in-env -t /tvs/production -o quiet \
           && echo Data in /tvs/production looks valid
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
     - name: Build and push docker image from builder target
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -67,6 +67,15 @@ jobs:
         bin/run-in-env -t "/tvs/${BRANCH}" -o quiet \
           && echo Data in "/tvs/${BRANCH}" looks valid
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
     - name: Build and push docker image from builder target
       uses: docker/build-push-action@v2
       with:


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1266

## Changes in this PR:

- `docker/build-push-action@v2` doesn't have auto-push enabled. Added steps to `deploy.yml` and `deploy_branch.yml` to enable `buildx` and log in to Docker Hub, to match `review.yml` workflow which does successfully push images to Docker Hub.
