### PR TITLE
[TEVA-1395] Update Terraform version to 0.13.4 in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Pin Terraform version
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.1
+        terraform_version: 0.13.4
 
     - name: Set environment variables
       id: set_env_vars

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Pin Terraform version
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.1
+        terraform_version: 0.13.4
 
     - name: Set environment variables
       id: set_env_vars

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Terraform pin version
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.1
+        terraform_version: 0.13.4
 
     - name: Set environment variables
       id: set_env_vars

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Terraform pin version
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.1
+        terraform_version: 0.13.4
 
     - name: Set environment variables
       id: set_env_vars


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1395

## Changes in this PR:

- Update Terraform version to 0.13.4 in GitHub Actions for consistency with `terraform/common` which is not run through GitHub Actions workflows