### PR TITLE
[TEVA-1396] Update CloudFoundry provider to 0.12.6 in GH actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
 
 env:
  DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
- CF_PROVIDER_VERSION: 0.12.4
+ CF_PROVIDER_VERSION: 0.12.6
 
 jobs:
   turnstyle:

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -13,7 +13,7 @@ on:
 
 env:
  DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
- CF_PROVIDER_VERSION: 0.12.4
+ CF_PROVIDER_VERSION: 0.12.6
 
 jobs:
   turnstyle:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -6,7 +6,7 @@ on:
     types: [closed]
 
 env:
-  CF_PROVIDER_VERSION: 0.12.4
+  CF_PROVIDER_VERSION: 0.12.6
   DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
   PR_NAME: ${{ format('pr-{0}', github.event.number) }}
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize]
 
 env:
-  CF_PROVIDER_VERSION: 0.12.4
+  CF_PROVIDER_VERSION: 0.12.6
   DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
   PR_NAME: ${{ format('pr-{0}', github.event.number) }}
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1396

## Changes in this PR:

- Update CloudFoundry provider for Terraform to `0.12.6` for a version which corrects RPC errors present in previous versions