### PR TITLE
[TEVA-1346] Let cloudfront forward Host header to allow redirects

### DIFF
--- a/terraform/app/modules/paas/data.tf
+++ b/terraform/app/modules/paas/data.tf
@@ -27,6 +27,11 @@ data cloudfoundry_domain cloudapps_digital {
   name = "london.cloudapps.digital"
 }
 
+data cloudfoundry_domain cloudfront {
+  for_each = toset(var.route53_zones)
+  name     = each.key
+}
+
 data cloudfoundry_service postgres {
   name = "postgres"
 }

--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -47,6 +47,19 @@ resource cloudfoundry_route web_app_route {
   hostname = local.web_app_name
 }
 
+resource cloudfoundry_route web_app_route_cloudfront_apex {
+  for_each = toset(var.route53_a_records)
+  domain   = data.cloudfoundry_domain.cloudfront[each.key].id
+  space    = data.cloudfoundry_space.space.id
+}
+
+resource cloudfoundry_route web_app_route_cloudfront_subdomain {
+  for_each = var.hostname_domain_map
+  domain   = data.cloudfoundry_domain.cloudfront[each.value["domain"]].id
+  space    = data.cloudfoundry_space.space.id
+  hostname = each.value["hostname"]
+}
+
 resource cloudfoundry_app worker_app {
   name              = local.worker_app_name
   command           = local.worker_app_start_command

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -59,6 +59,18 @@ variable worker_app_memory {
   default = 512
 }
 
+variable route53_zones {
+  type = list
+}
+
+variable route53_a_records {
+  type = list
+}
+
+variable hostname_domain_map {
+  type = map
+}
+
 locals {
   app_env_api_keys = merge(
     yamldecode(data.aws_ssm_parameter.app_env_api_key_big_query.value),

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -47,6 +47,10 @@ module cloudfront {
   offline_bucket_origin_path      = each.value.offline_bucket_origin_path
   cloudfront_enable_standard_logs = each.value.cloudfront_enable_standard_logs
   route53_zones                   = var.route53_zones
+  cloudfront_forward_host         = var.cloudfront_forward_host
+  is_production                   = local.is_production
+  route53_a_records               = local.route53_a_records
+  route53_cname_record            = local.route53_cname_record
   providers = {
     aws.default       = aws.default
     aws.aws_us_east_1 = aws.aws_us_east_1
@@ -84,7 +88,9 @@ module paas {
   worker_app_deployment_strategy    = var.paas_worker_app_deployment_strategy
   worker_app_instances              = var.paas_worker_app_instances
   worker_app_memory                 = var.paas_worker_app_memory
-
+  route53_zones                     = var.route53_zones
+  route53_a_records                 = local.route53_a_records
+  hostname_domain_map               = local.hostname_domain_map
 }
 
 module statuscake {

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -130,7 +130,21 @@ variable statuscake_alerts {
   default = {}
 }
 
+variable cloudfront_forward_host {
+  default = false
+}
+
 locals {
-  paas_app_env_values = yamldecode(file("${path.module}/../workspace-variables/${var.app_environment}_app_env.yml"))
-  infra_secrets       = yamldecode(data.aws_ssm_parameter.infra_secrets.value)
+  paas_app_env_values  = yamldecode(file("${path.module}/../workspace-variables/${var.app_environment}_app_env.yml"))
+  infra_secrets        = yamldecode(data.aws_ssm_parameter.infra_secrets.value)
+  is_production        = var.environment == "production"
+  route53_a_records    = local.is_production ? var.route53_zones : []
+  route53_cname_record = local.is_production ? "www" : var.environment
+  hostname_domain_map = {
+    for zone in var.route53_zones :
+    "${local.route53_cname_record}.${zone}" => {
+      hostname = local.route53_cname_record
+      domain   = zone
+    }
+  }
 }

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -35,3 +35,5 @@ paas_web_app_instances                 = 2
 paas_worker_app_deployment_strategy    = "blue-green-v2"
 paas_worker_app_instances              = 2
 paas_worker_app_memory                 = 512
+
+cloudfront_forward_host = true


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1346

## Changes in this PR:

Configure cloudfront to forward Host header so it's passed down to the app in paas. Then the redirect code will work. 
Enabled only for dev now.