### PR TITLE
[TEVA-1419] GitHub actions hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ on:
 
 env:
  DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
- CF_PROVIDER_VERSION: 0.12.6
 
 jobs:
   turnstyle:

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -13,7 +13,6 @@ on:
 
 env:
  DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
- CF_PROVIDER_VERSION: 0.12.6
 
 jobs:
   turnstyle:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -6,7 +6,6 @@ on:
     types: [closed]
 
 env:
-  CF_PROVIDER_VERSION: 0.12.6
   DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
   PR_NAME: ${{ format('pr-{0}', github.event.number) }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Terraform pin version
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.13.1
+          terraform_version: 0.13.4
 
       - name: Terraform fmt check
         run: |

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [ master ]
     types: [opened, synchronize]
+    paths-ignore:
+    - 'bigquery/**'
+    - 'documentation/**'    
+    - 'terraform/common/**'
+    - 'terraform/monitoring/**'
 
 env:
   CF_PROVIDER_VERSION: 0.12.6

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -11,7 +11,6 @@ on:
     - 'terraform/monitoring/**'
 
 env:
-  CF_PROVIDER_VERSION: 0.12.6
   DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
   PR_NAME: ${{ format('pr-{0}', github.event.number) }}
 

--- a/.github/workflows/sync_staging_db.yml
+++ b/.github/workflows/sync_staging_db.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Install cf client
       env:
-        CF_CLI_VERSION: 7.0.0-beta.30
+        CF_CLI_VERSION: 7.1.0
         CF_CLI_URL: https://packages.cloudfoundry.org/stable?release=linux64-binary&version=
       run: |
         curl -sL "${CF_CLI_URL}${CF_CLI_VERSION}" | sudo tar -zx -C /usr/local/bin


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1419

## Changes in this PR:

Five small fixes:
- Add dependabot for workflows as trialled in [Get into Teaching: Maintaining Actions ](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/2072903681/Maintaining+Actions)
- Do not generate a review app on changes to non-app folders
- CF_PROVIDER version is now set in Terraform code - remove environment variable in workflows
- Pin Terraform to version `0.13.4` in the lint workflow for consistency with others
- Bump CloudFoundry CLI from a beta version of `7.0.0` to `7.1.0`