### PR TITLE
[TEVA-1329] smoke test workflow dispatch

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Run Smoke Test
       uses: benc-uk/workflow-dispatch@v1
       with:
-        workflow: Smoke Test Dispatch # Workflow name
+        workflow: Smoke Test Manual # Workflow name
         token: ${{ secrets.PERSONAL_TOKEN }}
         inputs: '{ "environment": "staging" }'
 
@@ -105,8 +105,8 @@ jobs:
     - name: Wait on Smoke Test result
       uses: lewagon/wait-on-check-action@v0.1
       with:
-        ref: ${{ github.sha }} # can be commit SHA or tag too
-        check-name: Smoke Test Dispatch Job # Job name within workflow
+        ref: ${{ github.event.pull_request.head.ref }} # can be commit SHA or tag too
+        check-name: Smoke Test Manual Job # Job name within workflow
         repo-token: ${{ secrets.PERSONAL_TOKEN }}
         wait-interval: 120 # seconds
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -100,6 +100,16 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         inputs: '{ "environment": "staging" }'
 
+    # This step will retry until required check passes
+    # and will fail the whole workflow if the check conclusion is not a success
+    - name: Wait on Smoke Test result
+      uses: lewagon/wait-on-check-action@v0.1
+      with:
+        ref: ${{ github.sha }} # can be commit SHA or tag too
+        check-name: Smoke Test Dispatch # name of the existing check
+        repo-token: ${{ secrets.PERSONAL_TOKEN }}
+        wait-interval: 120 # seconds
+
     - name: Terraform deploy
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -93,6 +93,13 @@ jobs:
           ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
         target: production
 
+    - name: Run Smoke Test
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: Smoke Test Dispatch
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        inputs: '{ "environment": "staging" }'
+
     - name: Terraform deploy
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Run Smoke Test
       uses: benc-uk/workflow-dispatch@v1
       with:
-        workflow: Smoke Test Dispatch
+        workflow: Smoke Test Dispatch # Workflow name
         token: ${{ secrets.PERSONAL_TOKEN }}
         inputs: '{ "environment": "staging" }'
 
@@ -106,7 +106,7 @@ jobs:
       uses: lewagon/wait-on-check-action@v0.1
       with:
         ref: ${{ github.sha }} # can be commit SHA or tag too
-        check-name: Smoke Test Dispatch # name of the existing check
+        check-name: Smoke Test Dispatch Job # Job name within workflow
         repo-token: ${{ secrets.PERSONAL_TOKEN }}
         wait-interval: 120 # seconds
 

--- a/.github/workflows/smoke-test-dispatch.yml
+++ b/.github/workflows/smoke-test-dispatch.yml
@@ -9,8 +9,8 @@ on:
         default: 'staging'
 
 jobs:
-  smoke-test:
-    name: Run ${{ github.event.inputs.environment }} website smoke test
+  smoke-test-dispatch:
+    name: Smoke Test Dispatch
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/smoke-test-dispatch.yml
+++ b/.github/workflows/smoke-test-dispatch.yml
@@ -1,12 +1,16 @@
-name: Smoke Test
+name: Smoke Test Dispatch
 
-on:
-  schedule:
-    - cron: '10 * * * *'
+on: 
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment'     
+        required: true
+        default: 'staging'
 
 jobs:
   smoke-test:
-    name: Run staging website smoke test
+    name: Run ${{ github.event.inputs.environment }} website smoke test
 
     runs-on: ubuntu-latest
 
@@ -41,7 +45,7 @@ jobs:
           node-version: '12.x'
 
       - name: Run smoke test
-        run: bundle exec rspec spec/smoke_tests/job_seekers_can_view_homepage_staging_spec.rb --tag smoke_test
+        run: bundle exec rspec spec/smoke_tests/job_seekers_can_view_homepage_${{ github.event.inputs.environment }}_spec.rb --tag smoke_test
 
       - name: Slack notification
         if: ${{ failure() }}
@@ -51,5 +55,5 @@ jobs:
           SLACK_USERNAME: Smoke Test
           SLACK_ICON_EMOJI: ':cry:'
           SLACK_TITLE: Smoke test failed
-          SLACK_MESSAGE: 'Staging website smoke test has failed @channel'
+          SLACK_MESSAGE: '${{ github.event.inputs.environment }} website smoke test has failed @channel'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/smoke-test-dispatch.yml
+++ b/.github/workflows/smoke-test-dispatch.yml
@@ -9,8 +9,8 @@ on:
         default: 'staging'
 
 jobs:
-  smoke-test-dispatch:
-    name: Smoke Test Dispatch
+  smoke-test-dispatch-job:
+    name: Smoke Test Dispatch Job
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/smoke-test-manual.yml
+++ b/.github/workflows/smoke-test-manual.yml
@@ -1,4 +1,4 @@
-name: Smoke Test Dispatch
+name: Smoke Test Manual
 
 on: 
   workflow_dispatch:
@@ -9,8 +9,8 @@ on:
         default: 'staging'
 
 jobs:
-  smoke-test-dispatch-job:
-    name: Smoke Test Dispatch Job
+  smoke-test-manual-job:
+    name: Smoke Test Manual Job
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1329

## Changes in this PR:

[WIP] - testing with review workflow. Once proven, to be added to `deploy` workflow in order to Smoke Test staging before carrying on with deployment to production.

- Change Smoke Test to be triggered on dispatch, and take inputs (defaults to staging)
- Use `benc-uk/workflow-dispatch@v1` action to dispatch a dependent workflow
- Use `lewagon/wait-on-check-action@v0.1` to determine result of dependent workflow