### PR TITLE
[TEVA-1329] Smoke test - trigger manually; Support parameters

### DIFF
--- a/.github/workflows/smoke-test-manual.yml
+++ b/.github/workflows/smoke-test-manual.yml
@@ -1,12 +1,16 @@
-name: Smoke Test
+name: Smoke Test Manual
 
-on:
-  schedule:
-    - cron: '10 * * * *'
+on: 
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment'     
+        required: true
+        default: 'staging'
 
 jobs:
-  smoke-test:
-    name: Run staging website smoke test
+  smoke-test-manual-job:
+    name: Smoke Test Manual Job
 
     runs-on: ubuntu-latest
 
@@ -41,7 +45,7 @@ jobs:
           node-version: '12.x'
 
       - name: Run smoke test
-        run: bundle exec rspec spec/smoke_tests/job_seekers_can_view_homepage_staging_spec.rb --tag smoke_test
+        run: bundle exec rspec spec/smoke_tests/job_seekers_can_view_homepage_${{ github.event.inputs.environment }}_spec.rb --tag smoke_test
 
       - name: Slack notification
         if: ${{ failure() }}
@@ -51,5 +55,5 @@ jobs:
           SLACK_USERNAME: Smoke Test
           SLACK_ICON_EMOJI: ':cry:'
           SLACK_TITLE: Smoke test failed
-          SLACK_MESSAGE: 'Staging website smoke test has failed @channel'
+          SLACK_MESSAGE: '${{ github.event.inputs.environment }} website smoke test has failed @channel'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1329

## Changes in this PR:

- Change the scheduled smoke test on staging into a manually-triggered workflow, supporting parameters to allow triggering of smoke tests against `staging` or `production`