### PR TITLE
Cloudfront SQL monitoring & job alert email counts

### DIFF
--- a/bigquery/scheduled_queries/monitor-tables-for-errors.sql
+++ b/bigquery/scheduled_queries/monitor-tables-for-errors.sql
@@ -1,80 +1,89 @@
 SELECT
-  table,
+  TABLE,
   creation_time,
   last_modified_time,
   row_count,
   size_bytes,
 IF
-  (table LIKE "scraped_vacancies%"
+  (TABLE = "cloudfront_logs"
     AND (
     SELECT
-      COUNTIF(CAST(timestamp AS DATE) >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY))
+      MAX(date)
     FROM
-      `teacher-vacancy-service.production_dataset.scraped_vacancies_raw_changelog`
-    WHERE
-      operation="CREATE")=0,
-    "No new URLs to crawl obtained last night.",
+      `teacher-vacancy-service.production_dataset.cloudfront_logs`) < DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY),
+    "No new cloudfront logs transferred last night.",
   IF
-    (table LIKE "scraped_vacancies%"
-      AND ((
-        SELECT
-          COUNTIF(CAST(timestamp AS DATE) >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY))
-        FROM
-          `teacher-vacancy-service.production_dataset.scraped_vacancies_raw_changelog`
-        WHERE
-          operation="UPDATE")=0),
-      "No new vacancies crawled last night.",
+    (TABLE LIKE "scraped_vacancies%"
+      AND (
+      SELECT
+        COUNTIF(CAST(timestamp AS DATE) >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY))
+      FROM
+        `teacher-vacancy-service.production_dataset.scraped_vacancies_raw_changelog`
+      WHERE
+        operation="CREATE")=0,
+      "No new URLs to crawl obtained last night.",
     IF
-      (table NOT LIKE "CALCULATED_working_patterns_by_month%"
-        AND table NOT LIKE "scraped_vacancies%"
-        AND updated_today IS FALSE,
-        "Table not updated last night as expected",
+      (TABLE LIKE "scraped_vacancies%"
+        AND ((
+          SELECT
+            COUNTIF(CAST(timestamp AS DATE) >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY))
+          FROM
+            `teacher-vacancy-service.production_dataset.scraped_vacancies_raw_changelog`
+          WHERE
+            operation="UPDATE")=0),
+        "No new vacancies crawled last night.",
       IF
-        (table LIKE "CALCULATED_working_patterns_by_month%"
-          AND updated_this_month IS FALSE,
-          "Table not updated last month as expected",
+        (TABLE NOT LIKE "CALCULATED_working_patterns_by_month%"
+          AND TABLE NOT LIKE "scraped_vacancies%"
+          AND TABLE != "cloudfront_logs"
+          AND updated_today IS FALSE,
+          "Table not updated last night as expected",
         IF
-          (table LIKE "%school"
-            AND row_count <28000,
-            #sets a minimum threshold for the number of schools that should be in the database - this should not change much unless we change the scope, so going below this threshold most likely means the dataset in BQ is incomplete
-            "Table appears incomplete",
-            #check whether there are at least this many schools in the schools table
+          (TABLE LIKE "CALCULATED_working_patterns_by_month%"
+            AND updated_this_month IS FALSE,
+            "Table not updated last month as expected",
           IF
-            (table LIKE "%vacancy"
-              AND row_count <29000,
+            (TABLE LIKE "%school"
+              AND row_count <28000,
               #sets a minimum threshold for the number of schools that should be in the database - this should not change much unless we change the scope, so going below this threshold most likely means the dataset in BQ is incomplete
               "Table appears incomplete",
               #check whether there are at least this many schools in the schools table
             IF
-              (table = "dsi_users"
-                AND row_count <25000,
-                #sets a minimum threshold for the number of users that should be in the DSI database - this should not decrease, so going below this threshold most likely means the dataset in BQ is incomplete
+              (TABLE LIKE "%vacancy"
+                AND row_count <29000,
+                #sets a minimum threshold for the number of schools that should be in the database - this should not change much unless we change the scope, so going below this threshold most likely means the dataset in BQ is incomplete
                 "Table appears incomplete",
-                #check whether there are at least this many users in the dsi_users table
+                #check whether there are at least this many schools in the schools table
               IF
-                (table = "dsi_approvers"
-                  AND row_count <35000,
-                  #sets a minimum threshold for the number of approvers that should be in the DSI database - this should not decrease, so going below this threshold most likely means the dataset in BQ is incomplete
+                (TABLE = "dsi_users"
+                  AND row_count <25000,
+                  #sets a minimum threshold for the number of users that should be in the DSI database - this should not decrease, so going below this threshold most likely means the dataset in BQ is incomplete
                   "Table appears incomplete",
-                  #check whether there are at least this many approvers in the dsi_approvers table
+                  #check whether there are at least this many users in the dsi_users table
                 IF
-                  ((table ="dsi_users"
-                      AND (
-                      SELECT
-                        MAX(update_datetime)
-                      FROM
-                        `teacher-vacancy-service.production_dataset.dsi_users` ) < TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 3 DAY)) #check the last updated date for any user's data from DSI - produce error if more than three days old (i.e. if longer ago than the last working day)
-                    OR (table LIKE "feb20_%"
-                      AND (
-                      SELECT
-                        MAX(run_on)
-                      FROM
-                        `teacher-vacancy-service.production_dataset.feb20_alertrun` ) < DATE_SUB(CURRENT_DATE(),INTERVAL 3 DAY)),
-                    "Latest date a row was updated in a frequently updated table from this source was at least 3 days ago",
-                    "OK"))))))))) AS status
+                  (TABLE = "dsi_approvers"
+                    AND row_count <35000,
+                    #sets a minimum threshold for the number of approvers that should be in the DSI database - this should not decrease, so going below this threshold most likely means the dataset in BQ is incomplete
+                    "Table appears incomplete",
+                    #check whether there are at least this many approvers in the dsi_approvers table
+                  IF
+                    ((TABLE ="dsi_users"
+                        AND (
+                        SELECT
+                          MAX(update_datetime)
+                        FROM
+                          `teacher-vacancy-service.production_dataset.dsi_users` ) < TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 3 DAY)) #check the last updated date for any user's data from DSI - produce error if more than three days old (i.e. if longer ago than the last working day)
+                      OR (TABLE LIKE "feb20_%"
+                        AND (
+                        SELECT
+                          MAX(run_on)
+                        FROM
+                          `teacher-vacancy-service.production_dataset.feb20_alertrun` ) < DATE_SUB(CURRENT_DATE(),INTERVAL 3 DAY)),
+                      "Latest date a row was updated in a frequently updated table from this source was at least 3 days ago",
+                      "OK")))))))))) AS status
 FROM (
   SELECT
-    table,
+    TABLE,
     creation_time,
     last_modified_time,
     row_count,
@@ -89,7 +98,7 @@ FROM (
       FALSE) AS updated_this_month
   FROM (
     SELECT
-      table_id AS table,
+      table_id AS TABLE,
       TIMESTAMP_MILLIS(creation_time) AS creation_time,
       TIMESTAMP_MILLIS(last_modified_time) AS last_modified_time,
       row_count,

--- a/bigquery/views/job-alert.sql
+++ b/bigquery/views/job-alert.sql
@@ -1,4 +1,5 @@
 SELECT
+  id,
   CAST(created_at AS date) AS created_date,
   CAST(updated_at AS date) AS updated_date,
   expires_on AS expires_date,
@@ -8,13 +9,15 @@ IF
     OR recaptcha_score > 0.5,
     TRUE,
     FALSE) AS human,
-  ARRAY_TO_STRING(ARRAY(   #extract all search criteria from the JSON, except radius (because this is meaningless without location)
+  ARRAY_TO_STRING(ARRAY(   #extract all search criteria from the JSON, except radius and location_category (because they are just location searches) and jobs_sort (because this isn't a search criterion)
     SELECT
       *
     FROM
       UNNEST(REGEXP_EXTRACT_ALL(search_criteria, r'\"([a-z_]+)\":')) AS criteria #we have to use REGEXP_EXTRACT_ALL here rather than JSON_EXTRACT... because the latter only supports value rather than key extraction
     WHERE
-      criteria NOT IN ("radius")
+      criteria NOT IN ("radius",
+        "jobs_sort",
+        "location_category")
     ORDER BY
       criteria ASC )," and ") AS search_criteria,
 IF


### PR DESCRIPTION
## Changes in this PR:

- Add monitoring for cloudfront_logs table in BigQuery (we're not overwriting it nightly so it it needs a different monitoring approach to the normal feb20_ tables)
- Add ID to job alert view of subscription table
- Add job_alert_emails_sent metric to daily job alert metrics table