### PR TITLE
Bigquery publisher organisation

### DIFF
--- a/bigquery/scheduled_queries/calculate-daily-mat-time-metrics.sql
+++ b/bigquery/scheduled_queries/calculate-daily-mat-time-metrics.sql
@@ -66,13 +66,9 @@ WITH
     ON
       CAST(user.organisation_uid AS STRING) = trust.uid
     LEFT JOIN
-      `teacher-vacancy-service.production_dataset.feb20_userpreference` AS tv_user_logged_in
-    ON
-      tv_user_logged_in.school_group_id=trust.id
-    LEFT JOIN
       `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
     ON
-      (vacancy.publisher_user_id=tv_user_logged_in.user_id
+      (vacancy.publisher_organisation_id=trust.id
         AND publish_on<date)
     WHERE
       #only include trusts that were open on each date we're calculating for in the counts above

--- a/bigquery/scheduled_queries/calculate-daily-vacancy-tag-time-metrics.sql
+++ b/bigquery/scheduled_queries/calculate-daily-vacancy-tag-time-metrics.sql
@@ -54,6 +54,8 @@ WITH
         WHEN "mat_level" THEN COUNTIF(publish_on=date
         AND schoolgroup_level)
         WHEN "multi_school" THEN COUNTIF(publish_on=date AND number_of_organisations > 1)
+        WHEN "published_by_mat" THEN COUNTIF(publish_on=date
+        AND schoolgroup_type="Multi-academy trust")
     END
       AS vacancies_published,
       CASE tags.tag
@@ -64,6 +66,8 @@ WITH
         WHEN "mat_level" THEN COUNTIF(expires_on=date
         AND schoolgroup_level)
         WHEN "multi_school" THEN COUNTIF(expires_on=date AND number_of_organisations > 1)
+        WHEN "published_by_mat" THEN COUNTIF(expires_on=date
+        AND schoolgroup_type="Multi-academy trust")
     END
       AS vacancies_expired,
     FROM
@@ -72,7 +76,7 @@ WITH
       SELECT
         *
       FROM
-        UNNEST(["all","has_documents","suitable_for_nqts","mat_level","multi_school"]) AS tag) AS tags
+        UNNEST(["all","has_documents","suitable_for_nqts","mat_level","multi_school","published_by_mat"]) AS tag) AS tags
     CROSS JOIN
       `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancies
     GROUP BY

--- a/bigquery/scheduled_queries/mats-with-metrics.sql
+++ b/bigquery/scheduled_queries/mats-with-metrics.sql
@@ -77,6 +77,14 @@ FROM (
         schoolgroupmembership.school_group_id=MAT.id
       GROUP BY
         user.email )) AS number_of_mat_access_workaround_users,
+    #count vacancies published by this trust using MAT level access
+    (
+    SELECT
+      COUNT(vacancy.id)
+    FROM
+      `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
+    WHERE
+      MAT.id=vacancy.publisher_organisation_id) AS vacancies_published_using_MAT_access,
     #count trust-level vacancies published by this trust
     (
     SELECT

--- a/bigquery/views/vacancies_published.sql
+++ b/bigquery/views/vacancies_published.sql
@@ -32,18 +32,12 @@ IF
   WHERE
     organisationvacancy.vacancy_id=vacancy.id) AS number_of_organisations,
   #whether the vacancy was published by a schoolgroup e.g. a MAT
-  (
-  SELECT
-    COUNT(organisationvacancy.id)
-  FROM
-    `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
-  LEFT JOIN
-    `teacher-vacancy-service.production_dataset.feb20_organisation` AS organisation
-  ON
-    organisation.id=organisationvacancy.organisation_id
-  WHERE
-    organisation.type="SchoolGroup"
-    AND organisationvacancy.vacancy_id=vacancy.id) > 0 AS schoolgroup_level,
+IF
+  (job_location != "at_one_school"
+    OR publisher_organisation.type="SchoolGroup",
+    TRUE,
+    FALSE) AS schoolgroup_level,
+  publisher_organisation.group_type AS schoolgroup_type,
   (
   SELECT
     COUNT(document.id)
@@ -53,7 +47,13 @@ IF
     document.vacancy_id=vacancy.id) AS number_of_documents
 FROM
   `teacher-vacancy-service.production_dataset.feb20_vacancy` AS vacancy
+LEFT JOIN
+  `teacher-vacancy-service.production_dataset.feb20_organisation` AS publisher_organisation
+ON
+  vacancy.publisher_organisation_id = publisher_organisation.id
 WHERE
   vacancy.status NOT IN ("trashed",
     "draft",
     "deleted")
+ORDER BY
+  publish_on DESC


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1375

## Changes in this PR:

- In the vacancies_published view, work out whether a vacancy was school group level using the vacancy publisher_organisation_id instead of attempting to deduce it from whether it was published at a school which was part of a MAT with MAT level access.
- Add schoolgroup_type field to the vacancies_published view (useful to distinguish between MATs and LAs in future)
- Add published_by_mat tag to the daily vacancy tag time metrics table
- Add vacancies_published_using_MAT_access metric to the MATs table
- Simplify various subqueries now we have the new vacancy publisher_organisation_id field to use instead of having to guess it
- When calculating MAT takeup metrics, use vacancy publisher_organisation_id field to work out whether a MAT published a vacancy instead of trying to deduce this from the user that published the vacancy.