### PR TITLE
Put Steven's GSC account verification in the correct place

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,13 @@ class ApplicationController < ActionController::Base
   include AuthenticationConcerns
   include Ip
 
+  # TODO: remove this after Steven has verified his account
+  def google_search_console_verification
+    respond_to do |format|
+      format.html { render 'google_search_console_verification/googlef126f8525cc1ddc1.html', layout: false }
+    end
+  end
+
   def check
     render json: { status: 'OK' }, status: :ok
   end

--- a/app/views/google_search_console_verification/googlef126f8525cc1ddc1.html
+++ b/app/views/google_search_console_verification/googlef126f8525cc1ddc1.html
@@ -1,0 +1,1 @@
+google-site-verification: googlef126f8525cc1ddc1.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   root 'pages#home'
 
+  # TODO: remove this after Steven has verified his account
+  # Temporary path to verify Steven's Google Search Console account
+  get 'googlef126f8525cc1ddc1' => 'application#google_search_console_verification'
+
   get 'check' => 'application#check'
   get 'sitemap' => 'sitemap#show', format: 'xml'
 

--- a/googlef126f8525cc1ddc1.html
+++ b/googlef126f8525cc1ddc1.html
@@ -1,1 +1,0 @@
-google-site-verification: googlef126f8525cc1ddc1.html


### PR DESCRIPTION
Google needs to be able to access this html file at the address www.domain.com/googlef126f8525cc1ddc1.html in order to verify Steven's account. This is a one-off thing which can be removed as soon as it has been used.

Here it is on the review app: https://teaching-vacancies-review-pr-2173.london.cloudapps.digital/googlef126f8525cc1ddc1.html
