### PR TITLE
[TEVA-1283] Review apps DB seed - run db:setup

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -19,7 +19,7 @@ resource cloudfoundry_user_provided_service papertrail {
 
 resource cloudfoundry_app web_app {
   name                       = local.web_app_name
-  command                    = local.web_app_start_command
+  command                    = var.web_app_start_command
   docker_image               = var.app_docker_image
   health_check_type          = "http"
   health_check_http_endpoint = "/check"

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -48,6 +48,9 @@ variable web_app_memory {
   default = 512
 }
 
+variable web_app_start_command {
+}
+
 variable worker_app_deployment_strategy {
 }
 
@@ -98,7 +101,6 @@ locals {
   postgres_service_name    = "${var.project_name}-postgres-${var.environment}"
   redis_service_name       = "${var.project_name}-redis-${var.environment}"
   web_app_name             = "${var.project_name}-${var.environment}"
-  web_app_start_command    = "bundle exec rake cf:on_first_instance db:migrate && rails s"
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "${var.project_name}-worker-${var.environment}"
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -85,6 +85,7 @@ module paas {
   web_app_deployment_strategy       = var.paas_web_app_deployment_strategy
   web_app_instances                 = var.paas_web_app_instances
   web_app_memory                    = var.paas_web_app_memory
+  web_app_start_command             = var.paas_web_app_start_command
   worker_app_deployment_strategy    = var.paas_worker_app_deployment_strategy
   worker_app_instances              = var.paas_worker_app_instances
   worker_app_memory                 = var.paas_worker_app_memory

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -100,6 +100,10 @@ variable paas_web_app_memory {
   default = 512
 }
 
+variable paas_web_app_start_command {
+  default = "bundle exec rake cf:on_first_instance db:migrate && rails s"
+}
+
 variable paas_worker_app_deployment_strategy {
   default = "blue-green-v2"
 }

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -32,6 +32,7 @@ paas_app_start_timeout                 = "180"
 paas_app_stopped                       = false
 paas_web_app_deployment_strategy       = "blue-green-v2"
 paas_web_app_instances                 = 2
+paas_web_app_start_command             = "bundle exec rake cf:on_first_instance db:setup && rails s"
 paas_worker_app_deployment_strategy    = "blue-green-v2"
 paas_worker_app_instances              = 2
 paas_worker_app_memory                 = 512


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1283

## Changes in this PR:

- For review apps only, change the rake task from `db:migrate` to `db:setup`

## Testing methodology

Ran terraform plan locally via Makefile against an existing review app environment (PR 2178)
```
make review pr=2178 passcode=GovUKPasscode tag=review-pr-2178-945df00029adae3c3502980c545124ddd4ec6b23-20201021153627 deploy-plan
```

With output 
```
Terraform will perform the following actions:

  # module.paas.cloudfoundry_app.web_app will be updated in-place
  ~ resource "cloudfoundry_app" "web_app" {
      ~ command                    = "bundle exec rake cf:on_first_instance db:migrate && rails s" -> "bundle exec rake cf:on_first_instance db:setup && rails s"
```

And to confirm that this wouldn't run the `db:setup` in a non-review environment, ran terraform plan locally via Makefile against the dev environment
```
make dev passcode=GovUKPasscode tag=dev-70f8b61f13c7e9993b83ad7b003e2f9c4e8b05fd-20201019164540 deploy-plan
```

With output
```
No changes. Infrastructure is up-to-date.
```

## Next steps:

- [ ] Terraform deployment required