### PR TITLE
Allow non-LA users to log in when LA feature flag is on

### DIFF
--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -76,7 +76,9 @@ private
   end
 
   def local_authority_code
-    if LocalAuthorityAccessFeature.enabled?
+    # All organisations have an establishmentNumber, but we only want this for identifying LAs by.
+    # Assume that if and only if the organisation has no URN or UID, it is a Local Authority.
+    if LocalAuthorityAccessFeature.enabled? && school_urn.blank? && trust_uid.blank?
       auth_hash.dig('extra', 'raw_info', 'organisation', 'establishmentNumber') || ''
     end
   end
@@ -96,7 +98,7 @@ private
   end
 
   def check_authorisation(authorisation_permissions)
-    if authorisation_permissions.authorised? && organisation_id_present
+    if authorisation_permissions.authorised? && organisation_id_present?
       update_session(authorisation_permissions)
       update_user_last_activity_at
       redirect_to organisation_path
@@ -109,7 +111,7 @@ private
     redirect_to new_auth_email_path if AuthenticationFallback.enabled?
   end
 
-  def organisation_id_present
+  def organisation_id_present?
     school_urn.present? || trust_uid.present? || local_authority_code.present?
   end
 end

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -26,7 +26,7 @@ module AuthHelpers
   end
 
   def stub_authentication_step(organisation_id: '939eac36-0777-48c2-9c2c-b87c948a9ee0',
-                               school_urn: '110627', trust_uid: nil, la_code: nil,
+                               school_urn: '110627', trust_uid: nil, la_code: '123',
                                email: 'an-email@example.com')
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
       provider: 'dfe',

--- a/spec/system/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -95,6 +95,11 @@ RSpec.describe 'Hiring staff signing-in with DfE Sign In' do
 
     it_behaves_like 'a successful sign in'
 
+    context 'when LocalAuthorityAccessFeature enabled' do
+      before { allow(LocalAuthorityAccessFeature).to receive(:enabled?).and_return(true) }
+      it_behaves_like 'a successful sign in'
+    end
+
     scenario 'it redirects the sign in page to the school page' do
       visit new_identifications_path
       expect(page).to have_content("Jobs at #{organisation.name}")
@@ -152,6 +157,11 @@ RSpec.describe 'Hiring staff signing-in with DfE Sign In' do
       scenario 'it redirects the sign in page to the managed organisations user preference page' do
         expect(current_path).to eql(organisation_managed_organisations_path)
       end
+    end
+
+    context 'when LocalAuthorityAccessFeature enabled' do
+      before { allow(LocalAuthorityAccessFeature).to receive(:enabled?).and_return(true) }
+      it_behaves_like 'a successful sign in'
     end
   end
 


### PR DESCRIPTION
Previously, when the LA feature flag was set to true, you couldn't sign in locally as a non-LA organisation. (The precise error thrown was a Record Not Found when attempting to look up an LA using the establishmentNumber of a non-LA organisation.)

The bug here was due (I suspect) to a false assumption that only LA organisations have an establishmentNumber in the auth hash we get back from DSI.

This commit fixes this bug by only populating 'la_code' in the session if there is no URN or UID on the organisation in the auth hash. (If we populate la_code for every org, then most of the time it will simply be the establishmentNumber of a school or a trust, not that of an LA.)