### PR TITLE
Improve GCS/BigQuery initializers API key check

### DIFF
--- a/config/initializers/big_query.rb
+++ b/config/initializers/big_query.rb
@@ -2,7 +2,7 @@ require 'google/cloud/bigquery'
 
 BIG_QUERY_API_JSON_KEY = ENV['BIG_QUERY_API_JSON_KEY']
 
-if BIG_QUERY_API_JSON_KEY
+if BIG_QUERY_API_JSON_KEY.present?
   Google::Cloud::Bigquery.configure do |config|
     config.project_id  = 'teacher-vacancy-service'
     config.credentials = JSON.parse(BIG_QUERY_API_JSON_KEY)

--- a/config/initializers/google_cloud_storage.rb
+++ b/config/initializers/google_cloud_storage.rb
@@ -3,7 +3,7 @@ require 'google/cloud/storage'
 CLOUD_STORAGE_API_JSON_KEY = ENV['CLOUD_STORAGE_API_JSON_KEY']
 GOOGLE_CLOUD_PLATFORM_PROJECT_ID = ENV['GOOGLE_CLOUD_PLATFORM_PROJECT_ID']
 
-if CLOUD_STORAGE_API_JSON_KEY
+if CLOUD_STORAGE_API_JSON_KEY.present?
   Google::Cloud::Storage.configure do |config|
     config.project_id = GOOGLE_CLOUD_PLATFORM_PROJECT_ID
     config.credentials = JSON.parse(CLOUD_STORAGE_API_JSON_KEY)


### PR DESCRIPTION
Change checks for whether API keys for GCS and BigQuery are set to
check for presence, rather than just checking for them not being nil.
This avoids errors on first setup where a developer may have copied the
`.env.example` file without having set all of the optional variables,
leading to these coming through as empty strings.