### PR TITLE
[TEVA-1434] Only add link to referrer if referred from jobs path

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   before_action :detect_device_format
   before_action :set_root_headers
 
-  helper_method :cookies_preference_set?, :referred_from_host?
+  helper_method :cookies_preference_set?, :referred_from_jobs_path?
 
   include AuthenticationConcerns
   include Ip
@@ -61,8 +61,9 @@ class ApplicationController < ActionController::Base
     cookies['consented-to-cookies'].present?
   end
 
-  def referred_from_host?
-    request.host == URI(request.referrer || '').host
+  def referred_from_jobs_path?
+    request_uri = URI(request.referrer || '')
+    request.host == request_uri.host && request_uri.path == jobs_path
   end
 
 private

--- a/app/views/shared/vacancy/_jobseeker_view.html.haml
+++ b/app/views/shared/vacancy/_jobseeker_view.html.haml
@@ -7,7 +7,7 @@
   .govuk-width-container
     = render(Shared::BreadcrumbComponent.new(collapse_on_mobile: false,
                                              crumbs: [{ link_path: root_path, link_text: t('breadcrumbs.home') },
-                                                      { link_path: referred_from_host? ? request.referrer : jobs_path, link_text: t('breadcrumbs.jobs') },
+                                                      { link_path: referred_from_jobs_path? ? request.referrer : jobs_path, link_text: t('breadcrumbs.jobs') },
                                                       { link_path: '#', link_text: @vacancy.job_title }]))
     .govuk-grid-row
       .govuk-grid-column-full


### PR DESCRIPTION
Given the ticket is a bug, I think this meets the definition of a fixed bug. Ensuring search parameters are persisted after a user navigates to `Get similar job alert` and back is outside the scope of this ticket, is functionality in it's own right, and not something I'm sure we should necessarily do anyway.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1434

## Changes in this PR:
- Only add referrer link for search results if the referrer path is the jobs page