### PR TITLE
[TEVA-1263] Add KS1 and KS2 subject options

### DIFF
--- a/lib/tasks/data/subjects.yml
+++ b/lib/tasks/data/subjects.yml
@@ -25,6 +25,8 @@
 - ['ICT', '']
 - ['Italian', '']
 - ['Japanese', '']
+- ['KS1', '']
+- ['KS2', '']
 - ['Languages', 'includes MFL (Modern Foreign Languages)']
 - ['Law', '']
 - ['Mandarin', '']


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1263

## Changes in this PR
- Add KS1 and KS2 as subject options