### PR TITLE
[TEVA-1285] Remove expires_on column from subscriptions table

### DIFF
--- a/db/migrate/20201027093836_remove_expires_on_from_subscriptions.rb
+++ b/db/migrate/20201027093836_remove_expires_on_from_subscriptions.rb
@@ -1,0 +1,5 @@
+class RemoveExpiresOnFromSubscriptions < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :subscriptions, :expires_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_16_114844) do
+ActiveRecord::Schema.define(version: 2020_10_27_093836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -182,7 +182,6 @@ ActiveRecord::Schema.define(version: 2020_10_16_114844) do
   create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email"
     t.integer "frequency"
-    t.date "expires_on"
     t.jsonb "search_criteria"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-1285

## Changes in this PR:

- Created migration to remove the expires_on column in the subscriptions table