### PR TITLE
[TEVA-1441] Pass through utm parameters when setting cookie preferences

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   before_action :detect_device_format
   before_action :set_root_headers
 
-  helper_method :cookies_preference_set?, :referred_from_jobs_path?
+  helper_method :cookies_preference_set?, :referred_from_jobs_path?, :utm_parameters
 
   include AuthenticationConcerns
   include Ip
@@ -64,6 +64,10 @@ class ApplicationController < ActionController::Base
   def referred_from_jobs_path?
     request_uri = URI(request.referrer || '')
     request.host == request_uri.host && request_uri.path == jobs_path
+  end
+
+  def utm_parameters
+    params.permit(:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content)
   end
 
 private

--- a/app/controllers/cookies_preferences_controller.rb
+++ b/app/controllers/cookies_preferences_controller.rb
@@ -28,8 +28,8 @@ private
   end
 
   def set_previous_url_in_session
-    previous_path = URI(request.referrer || '').path
-    session[:previous_url] = previous_path unless previous_path == cookies_preferences_path
+    previous_uri = request.referrer.present? ? URI(request.referrer) : nil
+    session[:previous_url] = previous_uri&.request_uri unless previous_uri&.path == cookies_preferences_path
     session[:previous_url] = root_path if session[:previous_url].nil?
   end
 end

--- a/app/views/layouts/_cookies_banner.html.haml
+++ b/app/views/layouts/_cookies_banner.html.haml
@@ -2,5 +2,5 @@
   .govuk-width-container
     %h3.govuk-heading-s{ class: "govuk-!-margin-bottom-2" }= t("cookies.banner.heading")
     %p.govuk-body= t("cookies.banner.body")
-    = link_to t("cookies.banner.buttons.accept_all"), create_cookies_preferences_path(cookies_consent: "yes"), method: :post, class: "govuk-button govuk-!-margin-bottom-3 govuk-!-margin-right-2"
-    = link_to t("cookies.banner.buttons.set_preferences"), cookies_preferences_path, class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-3"
+    = link_to t("cookies.banner.buttons.accept_all"), create_cookies_preferences_path(cookies_consent: "yes", **utm_parameters), method: :post, class: "govuk-button govuk-!-margin-bottom-3 govuk-!-margin-right-2"
+    = link_to t("cookies.banner.buttons.set_preferences"), cookies_preferences_path(**utm_parameters), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-3"

--- a/spec/system/cookies_consent_spec.rb
+++ b/spec/system/cookies_consent_spec.rb
@@ -1,6 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe 'Cookies consent' do
+  let(:root_path_with_utm_parameters) do
+    root_path(utm_source: 'test', utm_medium: 'mob', utm_campaign: 'camp', utm_term: 'sep', utm_content: 'lots')
+  end
+  let(:jobs_path_with_utm_parameters) do
+    jobs_path(utm_source: 'test', utm_medium: 'mob', utm_campaign: 'camp', utm_term: 'sep', utm_content: 'lots')
+  end
+  let(:cookies_preferences_path_with_utm_parameters) do
+    cookies_preferences_path(utm_source: 'test', utm_medium: 'mob', utm_campaign: 'camp', utm_term: 'sep',
+                             utm_content: 'lots')
+  end
+
   before do
     allow(CookiesBannerFeature).to receive(:enabled?).and_return(cookies_banner_enabled)
   end
@@ -10,19 +21,69 @@ RSpec.describe 'Cookies consent' do
 
     scenario 'redirects to cookies page' do
       visit cookies_preferences_path
-      expect(page.current_path).to eql(page_path('cookies'))
+      expect(page).to have_current_path(page_path('cookies'))
     end
   end
 
   context 'when CookiesBannerFeature is enabled' do
     let(:cookies_banner_enabled) { true }
 
+    context 'when utm parameters are present' do
+      scenario 'can accept all cookies' do
+        visit root_path_with_utm_parameters
+
+        click_on I18n.t('cookies.banner.buttons.accept_all')
+
+        expect(page).to have_current_path(root_path_with_utm_parameters)
+        expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
+
+        visit cookies_preferences_path
+        expect(find('#cookies-preferences-form-cookies-consent-yes-field')).to be_checked
+      end
+
+      describe 'setting your preferences' do
+        before do
+          visit jobs_path_with_utm_parameters
+          click_on I18n.t('cookies.banner.buttons.set_preferences')
+        end
+
+        scenario 'can consent to cookies' do
+          find('#cookies-preferences-form-cookies-consent-yes-field').click
+          click_on I18n.t('cookies.form.buttons.save_changes')
+
+          expect(page).to have_current_path(jobs_path_with_utm_parameters)
+          expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
+
+          visit cookies_preferences_path
+          expect(find('#cookies-preferences-form-cookies-consent-yes-field')).to be_checked
+        end
+
+        scenario 'can not consent to cookies' do
+          find('#cookies-preferences-form-cookies-consent-no-field').click
+          click_on I18n.t('cookies.form.buttons.save_changes')
+
+          expect(page).to have_current_path(jobs_path_with_utm_parameters)
+          expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
+
+          visit cookies_preferences_path
+          expect(find('#cookies-preferences-form-cookies-consent-no-field')).to be_checked
+        end
+
+        scenario 'renders error if no option selected' do
+          click_on I18n.t('cookies.form.buttons.save_changes')
+
+          expect(page).to have_current_path(cookies_preferences_path)
+          expect(page).to have_content(I18n.t('cookies_preferences_errors.cookies_consent.inclusion'))
+        end
+      end
+    end
+
     scenario 'can accept all cookies' do
       visit root_path
 
       click_on I18n.t('cookies.banner.buttons.accept_all')
 
-      expect(page.current_path).to eql(root_path)
+      expect(page).to have_current_path(root_path)
       expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
 
       visit cookies_preferences_path
@@ -39,7 +100,7 @@ RSpec.describe 'Cookies consent' do
         find('#cookies-preferences-form-cookies-consent-yes-field').click
         click_on I18n.t('cookies.form.buttons.save_changes')
 
-        expect(page.current_path).to eql(jobs_path)
+        expect(page).to have_current_path(jobs_path)
         expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
 
         visit cookies_preferences_path
@@ -50,7 +111,7 @@ RSpec.describe 'Cookies consent' do
         find('#cookies-preferences-form-cookies-consent-no-field').click
         click_on I18n.t('cookies.form.buttons.save_changes')
 
-        expect(page.current_path).to eql(jobs_path)
+        expect(page).to have_current_path(jobs_path)
         expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
 
         visit cookies_preferences_path
@@ -60,7 +121,7 @@ RSpec.describe 'Cookies consent' do
       scenario 'renders error if no option selected' do
         click_on I18n.t('cookies.form.buttons.save_changes')
 
-        expect(page.current_path).to eql(cookies_preferences_path)
+        expect(page).to have_current_path(cookies_preferences_path)
         expect(page).to have_content(I18n.t('cookies_preferences_errors.cookies_consent.inclusion'))
       end
     end
@@ -72,7 +133,7 @@ RSpec.describe 'Cookies consent' do
         find('#cookies-preferences-form-cookies-consent-yes-field').click
         click_on I18n.t('cookies.form.buttons.save_changes')
 
-        expect(page.current_path).to eql(root_path)
+        expect(page).to have_current_path(root_path)
         expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
       end
     end
@@ -83,7 +144,7 @@ RSpec.describe 'Cookies consent' do
 
         click_on I18n.t('cookies.banner.buttons.accept_all')
 
-        expect(page.current_path).to eql(root_path)
+        expect(page).to have_current_path(root_path)
         expect(page).to_not have_content(I18n.t('cookies.banner.heading'))
 
         travel_to 7.months.from_now


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1411

## Changes in this PR:
- Add utm_parameters helper method
- Pass through utm_parameters to cookie banner links
- Update cookie consent feature spec
