### PR TITLE
Fix similar job alert bugs

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -25,7 +25,7 @@ class VacanciesController < ApplicationController
     return redirect_to(job_path(vacancy), status: :moved_permanently) if old_vacancy_path?(vacancy)
 
     @vacancy = VacancyPresenter.new(vacancy)
-    @devised_job_alert_search_criteria = Search::CriteriaDeviser.new(@vacancy).criteria
+    @devised_job_alert_search_criteria = Search::CriteriaDeviser.new(vacancy).criteria
 
     VacancyPageView.new(vacancy).track unless authenticated? || smoke_test?
 

--- a/app/frontend/styles/components/search_panel.scss
+++ b/app/frontend/styles/components/search_panel.scss
@@ -9,7 +9,7 @@
   width: 100vw;
 }
 
-.location-search {
+.search-panel {
   margin-bottom: govuk-spacing(5);
   margin-top: govuk-spacing(3);
 

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -4,7 +4,7 @@
   .govuk-width-container
     .govuk-grid-row
       .govuk-grid-column-two-thirds
-        .location-search= render 'pages/home/search'
+        .search-panel.location-search= render 'pages/home/search'
       .govuk-grid-column-one-third
         .signin
           - if ReadOnlyFeature.enabled?


### PR DESCRIPTION
## Changes in this PR
- Revert class name change that meant the subscription pages would not render correctly
- Ensure the criteria deviser is passed the vacancy rather than the vacancy presenter, to ensure similar job alerts are created properly (working patterns would previously not be respected, for example)