### PR TITLE
Randomly add assignees to Dependabot PRs

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,23 @@
+# Set to true to add reviewers to pull requests
+addReviewers: false
+
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of assignees to be added to pull requests (GitHub user name)
+assignees:
+  - david-mears-dfe
+  - csutter
+  - alexbowen
+  - josephhull676
+  - cpjmcquillan
+  - cesidio
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+numberOfAssignees: 1
+
+# A list of keywords to skip the PR if the title includes it
+skipKeywords:
+  - wip
+  - teva


### PR DESCRIPTION
This is to avoid the situation where nobody reviews the PR because it's too boring, and then the most altruistic person has to review all Dependabot PRs, and the PRs sit there saying 'high security issue' for weeks.

The auto-assignment bot will trigger unless the PR title contains `wip` or `teva`.

Unfortunately, this bot will trigger on PRs which are made by us humans, but don't contain those keywords, like this one doesn't. We could agree either:

(1) to add a keyword to all human PR titles that don't include `teva`, e.g. `*` (and add this to the list to skip)

or (2) ignore the assignee in these cases.
