### PR TITLE
Reject facet/enum values that are nil

### DIFF
--- a/app/services/search/vacancy_filters_builder.rb
+++ b/app/services/search/vacancy_filters_builder.rb
@@ -35,9 +35,12 @@ private
 
   def build_filters
     @dates_filter = build_date_filters
-    @job_roles_filter = @job_roles&.map { |job_role| build_filter_string('job_roles', job_role) }&.join(' OR ')
-    @phases_filter = @phases&.map { |phase| build_filter_string('education_phases', phase) }&.join(' OR ')
-    @working_patterns_filter = @working_patterns&.map { |pattern| build_filter_string('working_patterns', pattern) }
+    @job_roles_filter = @job_roles&.reject(&:blank?)
+                                  &.map { |job_role| build_filter_string('job_roles', job_role) }&.join(' OR ')
+    @phases_filter = @phases&.reject(&:blank?)
+                            &.map { |phase| build_filter_string('education_phases', phase) }&.join(' OR ')
+    @working_patterns_filter = @working_patterns&.reject(&:blank?)
+                                                &.map { |pattern| build_filter_string('working_patterns', pattern) }
                                                 &.join(' OR ')
     @suitable_for_nqt_filter = build_filter_string('job_roles', 'nqt_suitable') if @suitable_for_nqt == 'true'
   end

--- a/spec/services/search/vacancy_filters_builder_spec.rb
+++ b/spec/services/search/vacancy_filters_builder_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe Search::VacancyFiltersBuilder do
       end
     end
 
+    context 'when a filter contains enum values that no longer exist' do
+      let(:working_patterns) { ['full_time', nil] }
+
+      it 'only filters the valid working pattern' do
+        expect(subject.filter_query).to include('(working_patterns:full_time)')
+      end
+    end
+
     context 'when subscription was created before algolia' do
       let(:newly_qualified_teacher) { 'true' }
 


### PR DESCRIPTION
Old expired jobs are crawled by bots, and the Rollbar logs are annoying.

Fixes https://rollbar.com/dfe/teacher-vacancies/items/2505/