### PR TITLE
Allow subscription.alert_run_today to be nil

### DIFF
--- a/app/helpers/notify_view_helper.rb
+++ b/app/helpers/notify_view_helper.rb
@@ -45,6 +45,6 @@ module NotifyViewHelper
 private
 
   def utm_params(subscription)
-    { utm_source: subscription.alert_run_today.id, utm_medium: 'email', utm_campaign: "#{subscription.frequency}_alert" }
+    { utm_source: subscription.alert_run_today&.id, utm_medium: 'email', utm_campaign: "#{subscription.frequency}_alert" }
   end
 end

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -15,10 +15,8 @@ RSpec.describe SubscriptionMailer, type: :mailer do
     subscription
   end
 
-  let(:campaign_params) { { utm_source: subscription.alert_run_today.id, utm_medium: 'email', utm_campaign: 'daily_alert' } }
+  let(:campaign_params) { { utm_source: nil, utm_medium: 'email', utm_campaign: 'daily_alert' } }
   let(:body) { mail.body }
-
-  before { subscription.create_alert_run }
 
   describe '#confirmation' do
     let(:mail) { described_class.confirmation(subscription.id) }


### PR DESCRIPTION
My last PR breaks the job alert *confirmation* emails with this error: https://rollbar.com/dfe/teacher-vacancies/items/2526/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification

My strong hunch is that `subscription.alert_run_today.id` is the source of the error, in `utm_params`, and it returns no AlertRun because a confirmation email is not an alert run. (I reused the unsubscribe link method in both the confirmation and the job alert emails.)