### PR TITLE
[TEVA-1493] Authenticate Docker pulls in Gov.UK PaaS

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -40,6 +40,10 @@ resource cloudfoundry_app web_app {
       route = routes.value["id"]
     }
   }
+  docker_credentials = {
+    username = var.docker_username
+    password = var.docker_password
+  }
   space    = data.cloudfoundry_space.space.id
   stopped  = var.app_stopped
   strategy = var.web_app_deployment_strategy
@@ -88,6 +92,10 @@ resource cloudfoundry_app worker_app {
     content {
       service_instance = service_binding.value
     }
+  }
+  docker_credentials = {
+    username = var.docker_username
+    password = var.docker_password
   }
   environment = local.app_environment
 }

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -15,6 +15,12 @@ variable app_stopped {
   default = false
 }
 
+variable docker_username {
+}
+
+variable docker_password {
+}
+
 variable papertrail_service_binding_enable {
 }
 

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -74,6 +74,8 @@ module paas {
   app_env_values                    = local.paas_app_env_values
   app_start_timeout                 = var.paas_app_start_timeout
   app_stopped                       = var.paas_app_stopped
+  docker_username                   = local.infra_secrets.docker_username
+  docker_password                   = local.infra_secrets.docker_password
   papertrail_url                    = local.infra_secrets.papertrail_url
   papertrail_service_binding_enable = var.paas_papertrail_service_binding_enable
   parameter_store_environment       = var.parameter_store_environment


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1493

## Changes in this PR:

- Store DockerHub username and password in `/tvs/environment/infra/secrets` within Parameter Store
- Add `docker_credentials` block in web app and worker app terraform