### PR TITLE
Remove custom routes that conflict with pagination links

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -28,7 +28,7 @@ private
 
   def add_location_categories(map)
     ALL_LOCATION_CATEGORIES.each do |location_category|
-      map.add location_category_path(location_category, protocol: 'https'), period: 'hourly'
+      map.add jobs_path(location: location_category, protocol: 'https'), period: 'hourly'
     end
   end
 

--- a/app/views/pages/home/_vacancy_facets.haml
+++ b/app/views/pages/home/_vacancy_facets.haml
@@ -4,7 +4,7 @@
     %ul.govuk-list.two-column-list{ aria: { label: "#{t('.cities')} list" } }
       - @cities_facets.each do |city, count|
         %li
-          = link_to city, location_category_path(city), class: 'govuk-link'
+          = link_to city, jobs_path(location: city), class: 'govuk-link'
           = "(#{count})"
 
   .govuk-grid-column-one-half
@@ -12,7 +12,7 @@
     %ul.govuk-list.two-column-list{ aria: { label: "#{t('.counties')} list" } }
       - @counties_facets.each do |county, count|
         %li
-          = link_to county, location_category_path(county), class: 'govuk-link'
+          = link_to county, jobs_path(location: county), class: 'govuk-link'
           = "(#{count})"
 
 .govuk-grid-row
@@ -21,7 +21,7 @@
     %ul.govuk-list.two-column-list{ aria: { label: "#{t('.subjects')} list" } }
       - @subjects_facets.each do |subject, count|
         %li
-          = link_to subject, subject_path(subject), class: 'govuk-link'
+          = link_to subject, jobs_path(keyword: subject), class: 'govuk-link'
           = "(#{count})"
 
   .govuk-grid-column-one-half
@@ -29,5 +29,5 @@
     %ul.govuk-list.two-column-list{ aria: { label: "#{t('.job_roles')} list" } }
       - @job_roles_facets.each do |job_role, count|
         %li
-          = link_to I18n.t("jobs.job_role_options.#{job_role.to_s}"), job_role_path(job_role), class: 'govuk-link'
+          = link_to I18n.t("jobs.job_role_options.#{job_role.to_s}"), jobs_path(job_roles: job_role), class: 'govuk-link'
           = "(#{count})"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,12 +156,6 @@ Rails.application.routes.draw do
   match '/404', to: 'errors#not_found', via: :all
   match '/422', to: 'errors#unprocessable_entity', via: :all
   match '/500', to: 'errors#internal_server_error', via: :all
-  match 'teaching-jobs-in-:location_category', to: 'vacancies#index', as: :location_category, via: :get,
-                                               constraints: ->(request) { LocationCategory.include?(request.params[:location_category]) }
-  match 'teaching-jobs-for-:job_roles', to: 'vacancies#index', as: :job_role, via: :get,
-                                        constraints: ->(request) { Vacancy::JOB_ROLE_OPTIONS.keys.include?(request.params[:job_roles].to_sym) }
-  match 'teaching-jobs-for-:keyword', to: 'vacancies#index', as: :subject, via: :get,
-                                      constraints: ->(request) { SUBJECT_OPTIONS.map(&:first).include?(request.params[:keyword]) }
   match '*path', to: 'errors#not_found', via: :all
 
   # External URL

--- a/spec/system/application_sitemap_spec.rb
+++ b/spec/system/application_sitemap_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Application sitemap', sitemap: true do
       end
 
       ALL_LOCATION_CATEGORIES.each do |location_category|
-        url = location_category_url(location_category, protocol: 'https')
+        url = jobs_url(location: location_category, protocol: 'https')
         expect(nodes.search("loc:contains('#{url}')").map(&:text)).to include(url)
       end
 

--- a/spec/system/jobseekers_can_see_homepage_facets_spec.rb
+++ b/spec/system/jobseekers_can_see_homepage_facets_spec.rb
@@ -14,21 +14,21 @@ RSpec.describe 'Using the vacancy facets to search for jobs' do
 
   scenario 'job role facets count and link are displayed' do
     expect(page).to have_content('Teacher (1)')
-    expect(page).to have_link('Teacher', href: job_role_path('teacher'))
+    expect(page).to have_link('Teacher', href: jobs_path(job_roles: 'teacher'))
   end
 
   scenario 'subject facets count and link are displayed' do
     expect(page).to have_content('Bengali (5)')
-    expect(page).to have_link('Bengali', href: subject_path('Bengali'))
+    expect(page).to have_link('Bengali', href: jobs_path(keyword: 'Bengali'))
   end
 
   scenario 'cities facets count and link are displayed' do
     expect(page).to have_content('London (10)')
-    expect(page).to have_link('London', href: location_category_path('London'))
+    expect(page).to have_link('London', href: jobs_path(location: 'London'))
   end
 
   scenario 'counties facets count and link are displayed' do
     expect(page).to have_content('Devon (15)')
-    expect(page).to have_link('Devon', href: location_category_path('Devon'))
+    expect(page).to have_link('Devon', href: jobs_path(location: 'Devon'))
   end
 end


### PR DESCRIPTION
we will lose nice URLs like

https://teaching-vacancies.service.gov.uk/teaching-jobs-in-Leeds

that will become:

https://teaching-vacancies.service.gov.uk/jobs?location=Leeds
