### PR TITLE
Bigquery remove job alert expires on

### DIFF
--- a/bigquery/views/job-alert.sql
+++ b/bigquery/views/job-alert.sql
@@ -2,7 +2,6 @@ SELECT
   id,
   CAST(created_at AS date) AS created_date,
   CAST(updated_at AS date) AS updated_date,
-  expires_on AS expires_date,
   recaptcha_score,
 IF
   (recaptcha_score IS NOT NULL

--- a/bigquery/views/job-alert.sql
+++ b/bigquery/views/job-alert.sql
@@ -3,6 +3,8 @@ SELECT
   CAST(created_at AS date) AS created_date,
   CAST(updated_at AS date) AS updated_date,
   recaptcha_score,
+  FIRST_VALUE(id) OVER (PARTITION BY email ORDER BY created_at) AS email_address_id,
+  #the ID of the first job alert with this email address - allows us to string job alerts with the same email address together without including the PII in this view
 IF
   (recaptcha_score IS NOT NULL
     OR recaptcha_score > 0.5,


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1285

## Changes in this PR:

- Remove expires_on from job alert view of subscription table
- Add email_address_id field (the ID of the first job alert with this email address) to job alert view of subscription table - allows us to string job alerts with the same email address together without including the PII in this view
- Remove references to now nonexistent expires_on field in job alert metrics query
- Refactor processing of subscription table out of job alert metrics query into the job_alert view to reduce duplication

