### PR TITLE
[TEVA-1469] Save search criteria as json not a hash

### DIFF
--- a/app/controllers/job_alert_feedbacks_controller.rb
+++ b/app/controllers/job_alert_feedbacks_controller.rb
@@ -38,8 +38,7 @@ class JobAlertFeedbacksController < ApplicationController
 private
 
   def job_alert_feedback_params
-    params.require(:job_alert_feedback)
-      .permit(:comment, :relevant_to_user, search_criteria: {}, vacancy_ids: [])
+    params.require(:job_alert_feedback).permit(:comment, :relevant_to_user, :search_criteria, vacancy_ids: [])
   end
 
   def form_params

--- a/app/helpers/notify_view_helper.rb
+++ b/app/helpers/notify_view_helper.rb
@@ -23,7 +23,7 @@ module NotifyViewHelper
       protocol: 'https',
       params: { job_alert_feedback: { relevant_to_user: relevant,
                                       vacancy_ids: vacancies.pluck(:id),
-                                      search_criteria: JSON.parse(subscription.search_criteria) } },
+                                      search_criteria: subscription.search_criteria } },
     )
   end
 

--- a/db/migrate/20201102120525_convert_job_alert_feedbacks_search_criteria_to_json.rb
+++ b/db/migrate/20201102120525_convert_job_alert_feedbacks_search_criteria_to_json.rb
@@ -1,0 +1,7 @@
+class ConvertJobAlertFeedbacksSearchCriteriaToJson < ActiveRecord::Migration[6.0]
+  def change
+    JobAlertFeedback.all.in_batches(of: 100).each_record do |feedback|
+      feedback.update_columns(search_criteria: feedback.search_criteria.to_json)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_27_163927) do
+ActiveRecord::Schema.define(version: 2020_11_02_120525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe AlertMailer, type: :mailer do
       protocol: 'https',
       params: { job_alert_feedback: { relevant_to_user: true,
                                       vacancy_ids: vacancies.pluck(:id),
-                                      search_criteria: JSON.parse(subscription.search_criteria) } },
+                                      search_criteria: subscription.search_criteria } },
     ).gsub('&', '&amp;')
   end
   let(:irrelevant_job_alert_feedback_url) do
@@ -37,7 +37,7 @@ RSpec.describe AlertMailer, type: :mailer do
       protocol: 'https',
       params: { job_alert_feedback: { relevant_to_user: false,
                                       vacancy_ids: vacancies.pluck(:id),
-                                      search_criteria: JSON.parse(subscription.search_criteria) } },
+                                      search_criteria: subscription.search_criteria } },
     ).gsub('&', '&amp;')
   end
 

--- a/spec/system/job_seekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/job_seekers_can_give_job_alert_feedback_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'A job seeker can give feedback on a job alert' do
       protocol: 'https',
       params: { job_alert_feedback: { relevant_to_user: relevant_to_user,
                                       vacancy_ids: vacancies.pluck(:id),
-                                      search_criteria: JSON.parse(subscription.search_criteria) } },
+                                      search_criteria: subscription.search_criteria } },
     )
   end
 
@@ -25,7 +25,7 @@ RSpec.describe 'A job seeker can give feedback on a job alert' do
     context 'when the user selects Yes' do
       it 'creates a JobAlertFeedback with the correct attributes' do
         expect(feedback.relevant_to_user).to eq true
-        expect(feedback.search_criteria).to eq JSON.parse(subscription.search_criteria)
+        expect(feedback.search_criteria).to eq subscription.search_criteria
         expect(feedback.vacancy_ids).to include vacancies.first.id
         expect(feedback.vacancy_ids).to include vacancies.second.id
         expect(feedback.subscription_id).to eq subscription.id
@@ -46,7 +46,7 @@ RSpec.describe 'A job seeker can give feedback on a job alert' do
 
       it 'creates a JobAlertFeedback with the correct attributes' do
         expect(feedback.relevant_to_user).to eq false
-        expect(feedback.search_criteria).to eq JSON.parse(subscription.search_criteria)
+        expect(feedback.search_criteria).to eq subscription.search_criteria
         expect(feedback.vacancy_ids).to include vacancies.first.id
         expect(feedback.vacancy_ids).to include vacancies.second.id
         expect(feedback.subscription_id).to eq subscription.id


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1469

## Changes in this PR:
- Don't convert search criteria from JSON to a hash
- Convert existing job alert feedbacks