### PR TITLE
Bigquery job alert email ctrs

### DIFF
--- a/bigquery/views/job-alert.sql
+++ b/bigquery/views/job-alert.sql
@@ -6,7 +6,7 @@ SELECT
   FIRST_VALUE(id) OVER (PARTITION BY email ORDER BY created_at) AS email_address_id,
   #the ID of the first job alert with this email address - allows us to string job alerts with the same email address together without including the PII in this view
 IF
-  (recaptcha_score IS NOT NULL
+  (recaptcha_score IS NULL
     OR recaptcha_score > 0.5,
     TRUE,
     FALSE) AS human,


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1385

## Changes in this PR:

- Fix job alert humanity calculator
- Add CTRs for job alert emails (to vacancy, unsubscribe and edit).
- Recalculate job alert metrics query for the last 7 days only