### PR TITLE
[TEVA-1463] Do not omit nil vacancy attributes when merging to session

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -26,7 +26,7 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
 
   def store_vacancy_attributes(attributes)
     session[:vacancy_attributes] ||= {}
-    session[:vacancy_attributes].merge!(attributes.compact)
+    session[:vacancy_attributes].merge!(attributes)
   end
 
   def update_vacancy(attributes, vacancy = nil)


### PR DESCRIPTION
If we omit 'nil' attributes, then no overwriting of previous values happens for `nil`s.

We want to overwrite previous session attributes when the user goes back a step
and reselects a different option.

For example, when selecting 'at one school' on Step 1, the readable_job_location
should be set to nil, otherwise the previous value will be used instead in
the page heading ('Create a job listing at More than one school ()', in this
case.)

## Question

Does this justify writing a regression test?

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1463

## Screenshots of UI changes:

### Before

![Screenshot 2020-10-28 at 15 39 08](https://user-images.githubusercontent.com/60350599/97869243-0aeac000-1d09-11eb-9f6a-9ec2ec3d7413.png)

### After

![Screenshot 2020-11-02 at 12 38 50](https://user-images.githubusercontent.com/60350599/97869266-163deb80-1d09-11eb-9143-b8074da1972e.png)
