### PR TITLE
Create a content security policy

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,6 @@
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token,
-                     only: %i[not_found unprocessable_entity internal_server_error]
+                     only: %i[not_found unprocessable_entity internal_server_error csp_violation]
 
   def unauthorised
     respond_to do |format|
@@ -30,5 +30,10 @@ class ErrorsController < ApplicationController
       format.html { render status: :internal_server_error }
       format.json { render json: { error: "Internal server error" }, status: :internal_server_error }
     end
+  end
+
+  def csp_violation
+    Rollbar.error("CSP Violation", details: request.raw_post)
+    head :no_content
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,7 +30,7 @@
     = csrf_meta_tags
   %body{ class: body_class, data: { vacancy_state: @vacancy.present? ? @vacancy.state : 'create' } }
     = render partial: 'shared/google_tag_manager_body' if cookies['consented-to-cookies'] == 'yes'
-    :javascript
+    = javascript_tag(nonce: true) do
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     = render 'shared/skip_links'
     = render 'layouts/cookies_banner' unless controller_name == 'cookies_preferences' || cookies_preference_set?

--- a/app/views/shared/_google_tag_manager_head.html.haml
+++ b/app/views/shared/_google_tag_manager_head.html.haml
@@ -1,5 +1,5 @@
 / Google Tag Manager
-:javascript
+= javascript_tag(nonce: true) do
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/config/initializers/content_security_police.rb
+++ b/config/initializers/content_security_police.rb
@@ -1,1 +1,0 @@
-# policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,9 @@ Rails.application.config.content_security_policy do |policy|
   policy.object_src  :none
   policy.script_src  :self, "https://cdnjs.cloudflare.com", "https://cdn.rollbar.com",
                      "https://www.googletagmanager.com", "https://maps.googleapis.com"
-  policy.style_src   :self, "https://cdnjs.cloudflare.com", "https://fonts.googleapis.com"
+  # Google Maps embed will not work without 'unsafe-inline' styles
+  #   see: https://issuetracker.google.com/issues/132600807
+  policy.style_src   :self, "https://cdnjs.cloudflare.com", "https://fonts.googleapis.com", :unsafe_inline
   # Allow using webpack-dev-server in development
   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
@@ -22,8 +24,8 @@ end
 # Enable automatic nonce generation for <script> tags
 Rails.application.config.content_security_policy_nonce_generator = ->(_) { SecureRandom.base64(16) }
 
-# Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
+# Set the nonce only to `script-src` directive (because of Google Maps issue detailed above)
+Rails.application.config.content_security_policy_nonce_directives = %w[script-src]
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,23 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self
+  policy.font_src    :self, "https://cdnjs.cloudflare.com", "https://fonts.gstatic.com"
+  policy.img_src     :self, :https, :data
+  policy.object_src  :none
+  policy.script_src  :self, "https://cdnjs.cloudflare.com", "https://cdn.rollbar.com",
+                     "https://www.googletagmanager.com", "https://maps.googleapis.com"
+  policy.style_src   :self, "https://cdnjs.cloudflare.com", "https://fonts.googleapis.com"
+  # Allow using webpack-dev-server in development
+  policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Specify URI for violation reports
+  policy.report_uri "/errors/csp_violation"
+end
 
-# If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+# Enable automatic nonce generation for <script> tags
+Rails.application.config.content_security_policy_nonce_generator = ->(_) { SecureRandom.base64(16) }
 
 # Set the nonce only to specific directives
 # Rails.application.config.content_security_policy_nonce_directives = %w(script-src)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,7 @@ Rails.application.routes.draw do
                                      controller: "hiring_staff/organisations/managed_organisations"
   end
 
+  post "/errors/csp_violation", to: "errors#csp_violation"
   match "/401", to: "errors#unauthorised", via: :all
   match "/404", to: "errors#not_found", via: :all
   match "/422", to: "errors#unprocessable_entity", via: :all

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -21,4 +21,13 @@ RSpec.describe ErrorsController, type: :controller do
       expect(response).to have_http_status(:internal_server_error)
     end
   end
+
+  describe "POST #csp_violation" do
+    it "sends the error to Rollbar" do
+      expect(Rollbar).to receive(:error).with("CSP Violation", details: { foo: "bar" })
+
+      post :csp_violation, { body: { foo: "bar" } }
+      expect(response).to have_http_status(:no_content)
+    end
+  end
 end


### PR DESCRIPTION
- Adds a CSP (Content Security Policy) to the application to stop
  browsers from loading untrusted external resources or inline scripts
- Generate and use nonces for trusted inline scripts
- Adds a basic endpoint for browsers to report CSP violations

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-790