### PR TITLE
Update mats-with-metrics.sql

### DIFF
--- a/bigquery/scheduled_queries/mats-with-metrics.sql
+++ b/bigquery/scheduled_queries/mats-with-metrics.sql
@@ -1,153 +1,184 @@
+  #scheduled query that appends new rows to CALCULATED_daily_MAT_time_metrics table 
+WITH
+  dates AS ( #the range of dates we're calculating for
+  SELECT
+    date
+  FROM
+    UNNEST(GENERATE_DATE_ARRAY('2020-09-01', DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY), INTERVAL 1 DAY)) AS date #all dates between 1/9/20 and yesterday
+  WHERE
+    #only calculate these metrics for dates we don't already have within this range
+    date NOT IN (
+    SELECT
+      DISTINCT date
+    FROM
+      `teacher-vacancy-service.production_dataset.CALCULATED_daily_MAT_time_metrics` ) ),
+  trust_metrics AS (
+  SELECT
+    date,
+    size_bracket,
+    COUNT(uid) AS trusts_in_scope,
+    COUNTIF(signed_up) AS trusts_signed_up,
+    COUNTIF(using_mat_access_workaround) AS trusts_using_mat_access_workaround,
+    COUNTIF(has_published_so_far) AS trusts_which_published_so_far,
+    COUNTIF(has_published_in_the_last_year) AS trusts_which_published_in_the_last_year,
+    COUNTIF(has_published_in_the_last_quarter) AS trusts_which_published_in_the_last_quarter,
+    COUNTIF(had_live_vacancies) AS trusts_which_had_vacancies_live,
+    COUNTIF(has_published_multischool_vacancies_so_far) AS trusts_which_published_multischool_vacancies_so_far,
+    COUNTIF(has_published_multischool_vacancies_in_the_last_year) AS trusts_which_published_multischool_vacancies_in_the_last_year,
+    COUNTIF(has_published_multischool_vacancies_in_the_last_quarter) AS trusts_which_published_multischool_vacancies_in_the_last_quarter,
+    COUNTIF(had_live_multischool_vacancies) AS trusts_which_had_multischool_vacancies_live,
+    COUNTIF(has_published_trust_level_vacancies_so_far) AS trusts_which_published_trust_level_vacancies_so_far,
+    COUNTIF(has_published_trust_level_vacancies_in_the_last_year) AS trusts_which_published_trust_level_vacancies_in_the_last_year,
+    COUNTIF(has_published_trust_level_vacancies_in_the_last_quarter) AS trusts_which_published_trust_level_vacancies_in_the_last_quarter,
+    COUNTIF(had_live_trust_level_vacancies) AS trusts_which_had_trust_level_vacancies_live
+  FROM (
+    SELECT
+      uid,
+      date,
+      size_bracket,
+      using_mat_access_workaround,
+      COUNTIF(CAST(user.approval_datetime AS DATE) <= date) >= 1 AS signed_up,
+      #Count the number of users who had access, see if it is 1 or more, and if so count the school as signed up
+      COUNTIF(vacancy.id IS NOT NULL) >= 1 AS has_published_so_far,
+      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 1 YEAR)) >= 1 AS has_published_in_the_last_year,
+      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 3 MONTH)) >= 1 AS has_published_in_the_last_quarter,
+      COUNTIF(vacancy.expires_on > date) >= 1 AS had_live_vacancies,
+      COUNTIF(number_of_organisations > 1) >= 1 AS has_published_multischool_vacancies_so_far,
+      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 1 YEAR)
+        AND number_of_organisations > 1) >= 1 AS has_published_multischool_vacancies_in_the_last_year,
+      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 3 MONTH)
+        AND number_of_organisations > 1) >= 1 AS has_published_multischool_vacancies_in_the_last_quarter,
+      COUNTIF(vacancy.expires_on > date
+        AND number_of_organisations > 1) >= 1 AS had_live_multischool_vacancies,
+      COUNTIF(schoolgroup_level) >= 1 AS has_published_trust_level_vacancies_so_far,
+      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 1 YEAR)
+        AND schoolgroup_level) >= 1 AS has_published_trust_level_vacancies_in_the_last_year,
+      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 3 MONTH)
+        AND schoolgroup_level) >= 1 AS has_published_trust_level_vacancies_in_the_last_quarter,
+      COUNTIF(vacancy.expires_on > date
+        AND schoolgroup_level) >= 1 AS had_live_trust_level_vacancies
+    FROM
+      `teacher-vacancy-service.production_dataset.CALCULATED_MATs_with_metrics` AS trust
+    CROSS JOIN
+      dates
+    LEFT JOIN
+      `teacher-vacancy-service.production_dataset.dsi_users` AS user
+    ON
+      CAST(user.organisation_uid AS STRING) = trust.uid
+    LEFT JOIN
+      `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
+    ON
+      (vacancy.publisher_organisation_id=trust.id
+        AND publish_on<date)
+    WHERE
+      #only include trusts that were open on each date we're calculating for in the counts above
+      (trust.status != "Closed"
+        OR trust.date_closed > dates.date) #if the trust is not currently closed or if it closed after the date we're calculating for
+      AND (trust.status != "Proposed to open" #and if the trust is not currently proposed to open
+        OR trust.date_opened <= dates.date #or if the trust opened before the date we're calculating for
+        )
+      AND trust.date_created <= dates.date
+    GROUP BY
+      uid,
+      date,
+      date_opened,
+      date_created,
+      date_closed,
+      trust.status,
+      trust.size_bracket,
+      trust.using_mat_access_workaround)
+  GROUP BY
+    date,
+    size_bracket )
 SELECT
   *,
-  SAFE_DIVIDE(schools_signed_up,
-    trust_size) AS proportion_of_schools_signed_up,
-  SAFE_DIVIDE(schools_that_published_vacancies_in_the_last_year,
-    trust_size) AS proportion_of_schools_that_published_vacancies_in_the_last_year,
-  SAFE_DIVIDE(schools_that_published_vacancies_in_the_last_quarter,
-    trust_size) AS proportion_of_schools_that_published_vacancies_in_the_last_quarter,
-  SAFE_DIVIDE(schools_that_published_vacancies,
-    trust_size) AS proportion_of_schools_that_published_vacancies,
-  SAFE_DIVIDE(schools_with_live_vacancies,
-    trust_size) AS proportion_of_schools_with_live_vacancies,
-  number_of_users > 0 AS signed_up,
-  number_of_mat_access_workaround_users > 0 AS using_mat_access_workaround,
-  CASE
-    WHEN trust_size < 2 THEN "0-1"
-    WHEN trust_size < 6 THEN "2-5"
-    WHEN trust_size < 11 THEN "6-10"
-    WHEN trust_size < 21 THEN "11-20"
-  ELSE
-  "21+"
-END
-  AS size_bracket,
-FROM (
-  SELECT
-    MAT.name AS trust_name,
-    MAT.id AS id,
-    MAT.uid AS uid,
-    MAT.data_ukprn AS ukprn,
-    MAT.address AS address,
-    MAT.town AS town,
-    MAT.county AS county,
-    MAT.postcode AS postcode,
-    CAST(MAT.created_at AS date) AS date_created,
-    CAST(MAT.updated_at AS date) AS date_updated,
-    MAT.data_closed_date AS date_closed,
-    data_incorporated_on_open_date AS date_opened,
-    data_companies_house_number AS companies_house_number,
-    data_group_status AS status,
-    COUNT(school.id) AS trust_size,
-    (
+  SAFE_DIVIDE(trusts_signed_up,
+    trusts_in_scope) AS proportion_of_trusts_signed_up,
+  SAFE_DIVIDE(trusts_using_mat_access_workaround,
+    trusts_in_scope) AS proportion_of_trusts_using_mat_access_workaround,
+  SAFE_DIVIDE(trusts_which_published_vacancies_in_the_last_year,
+    trusts_in_scope) AS proportion_of_trusts_which_published_in_the_last_year,
+  SAFE_DIVIDE(trusts_which_published_vacancies_in_the_last_quarter,
+    trusts_in_scope) AS proportion_of_trusts_which_published_in_the_last_quarter,
+  SAFE_DIVIDE(trusts_which_published_vacancies_so_far,
+    trusts_in_scope) AS proportion_of_trusts_which_published_so_far,
+  SAFE_DIVIDE(trusts_which_had_vacancies_live,
+    trusts_in_scope) AS proportion_of_trusts_which_had_vacancies_live,
+  SAFE_DIVIDE(trusts_which_published_multischool_vacancies_in_the_last_year,
+    trusts_in_scope) AS proportion_of_trusts_which_published_multischool_vacancies_in_the_last_year,
+  SAFE_DIVIDE(trusts_which_published_multischool_vacancies_in_the_last_quarter,
+    trusts_in_scope) AS proportion_of_trusts_which_published_multischool_vacancies_in_the_last_quarter,
+  SAFE_DIVIDE(trusts_which_published_multischool_vacancies_so_far,
+    trusts_in_scope) AS proportion_of_trusts_which_published_multischool_vacancies_so_far,
+  SAFE_DIVIDE(trusts_which_had_multischool_vacancies_live,
+    trusts_in_scope) AS proportion_of_trusts_which_had_multischool_vacancies_live,
+  SAFE_DIVIDE(trusts_which_published_trust_level_vacancies_in_the_last_year,
+    trusts_in_scope) AS proportion_of_trusts_which_published_trust_level_vacancies_in_the_last_year,
+  SAFE_DIVIDE(trusts_which_published_trust_level_vacancies_in_the_last_quarter,
+    trusts_in_scope) AS proportion_of_trusts_which_published_trust_level_vacancies_in_the_last_quarter,
+  SAFE_DIVIDE(trusts_which_published_trust_level_vacancies_so_far,
+    trusts_in_scope) AS proportion_of_trusts_which_published_trust_level_vacancies_so_far,
+  SAFE_DIVIDE(trusts_which_had_trust_level_vacancies_live,
+    trusts_in_scope) AS proportion_of_trusts_which_had_trust_level_vacancies_live,
+  SAFE_DIVIDE(trusts_which_published_vacancies_in_the_last_year,
+    trusts_signed_up) AS proportion_of_signed_up_trusts_which_published_in_the_last_year,
+  SAFE_DIVIDE(trusts_which_published_vacancies_in_the_last_quarter,
+    trusts_signed_up) AS proportion_of_signed_up_trusts_which_published_in_the_last_quarter,
+  SAFE_DIVIDE(trusts_which_published_vacancies_so_far,
+    trusts_signed_up) AS proportion_of_signed_up_trusts_which_published_so_far,
+  SAFE_DIVIDE(trusts_which_had_vacancies_live,
+    trusts_signed_up) AS proportion_of_signed_up_trusts_which_had_vacancies_live,
+FROM ( (
     SELECT
-      COUNT(user_id)
+      dates.date,
+      trust_metrics.size_bracket,
+      trust_metrics.trusts_signed_up,
+      trust_metrics.trusts_using_mat_access_workaround,
+      trust_metrics.trusts_in_scope,
+      trust_metrics.trusts_which_published_in_the_last_year AS trusts_which_published_vacancies_in_the_last_year,
+      trust_metrics.trusts_which_published_in_the_last_quarter AS trusts_which_published_vacancies_in_the_last_quarter,
+      trust_metrics.trusts_which_published_so_far AS trusts_which_published_vacancies_so_far,
+      trust_metrics.trusts_which_had_vacancies_live AS trusts_which_had_vacancies_live,
+      trust_metrics.trusts_which_published_multischool_vacancies_in_the_last_year AS trusts_which_published_multischool_vacancies_in_the_last_year,
+      trust_metrics.trusts_which_published_multischool_vacancies_in_the_last_quarter AS trusts_which_published_multischool_vacancies_in_the_last_quarter,
+      trust_metrics.trusts_which_published_multischool_vacancies_so_far AS trusts_which_published_multischool_vacancies_so_far,
+      trust_metrics.trusts_which_had_multischool_vacancies_live AS trusts_which_had_multischool_vacancies_live,
+      trust_metrics.trusts_which_published_trust_level_vacancies_in_the_last_year AS trusts_which_published_trust_level_vacancies_in_the_last_year,
+      trust_metrics.trusts_which_published_trust_level_vacancies_in_the_last_quarter AS trusts_which_published_trust_level_vacancies_in_the_last_quarter,
+      trust_metrics.trusts_which_published_trust_level_vacancies_so_far AS trusts_which_published_trust_level_vacancies_so_far,
+      trust_metrics.trusts_which_had_trust_level_vacancies_live AS trusts_which_had_trust_level_vacancies_live
     FROM
-      `teacher-vacancy-service.production_dataset.dsi_users` AS user
-    WHERE
-      CAST(user.organisation_uid AS STRING)=MAT.uid ) AS number_of_users,
-    (
-    SELECT
-      COUNT(user_id)
-    FROM
-      `teacher-vacancy-service.production_dataset.dsi_approvers` AS approver
-    WHERE
-      CAST(approver.organisation_uid AS STRING)=MAT.uid ) AS number_of_approvers,
-    (
-    SELECT
-      COUNT(
-      IF
-        (number_of_schools_user_has_access_to > 1,
-          email,
-          NULL))
-    FROM (
-      SELECT
-        email,
-        COUNT(school_urn) AS number_of_schools_user_has_access_to
-      FROM
-        `teacher-vacancy-service.production_dataset.dsi_users` AS user
-      LEFT JOIN
-        `teacher-vacancy-service.production_dataset.school` AS school
-      ON
-        CAST(user.school_urn AS STRING)=school.urn
-      LEFT JOIN
-        `teacher-vacancy-service.production_dataset.feb20_schoolgroupmembership` AS schoolgroupmembership
-      ON
-        school.id=schoolgroupmembership.school_id
-      WHERE
-        schoolgroupmembership.school_group_id=MAT.id
-      GROUP BY
-        user.email )) AS number_of_mat_access_workaround_users,
-    #count vacancies published by this trust using MAT level access
-    (
-    SELECT
-      COUNT(vacancy.id)
-    FROM
-      `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
-    WHERE
-      MAT.id=vacancy.publisher_organisation_id) AS vacancies_published_using_MAT_access,
-    #count trust-level vacancies published by this trust
-    (
-    SELECT
-      COUNTIF(schoolgroup_level)
-    FROM
-      `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
+      dates
     LEFT JOIN
-      `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
-    ON
-      vacancy.id=organisationvacancy.vacancy_id
-    WHERE
-      MAT.id=organisationvacancy.organisation_id) AS trust_level_vacancies_published,
-    #count multi-school vacancies where at least 1 of the schools is part of this trust
-    (
+      trust_metrics
+    USING
+      (date) )
+  UNION ALL (
     SELECT
-      COUNTIF(vacancy.number_of_organisations > 1)
+      dates.date,
+      "all" AS size_bracket,
+      SUM(trust_metrics.trusts_signed_up) AS trusts_signed_up,
+      SUM(trust_metrics.trusts_using_mat_access_workaround) AS trusts_using_mat_access_workaround,
+      SUM(trust_metrics.trusts_in_scope) AS trusts_in_scope,
+      SUM(trust_metrics.trusts_which_published_in_the_last_year) AS trusts_which_published_vacancies_in_the_last_year,
+      SUM(trust_metrics.trusts_which_published_in_the_last_quarter) AS trusts_which_published_vacancies_in_the_last_quarter,
+      SUM(trust_metrics.trusts_which_published_so_far) AS trusts_which_published_vacancies_so_far,
+      SUM(trust_metrics.trusts_which_had_vacancies_live) AS trusts_which_had_vacancies_live,
+      SUM(trust_metrics.trusts_which_published_multischool_vacancies_in_the_last_year) AS trusts_which_published_multischool_vacancies_in_the_last_year,
+      SUM(trust_metrics.trusts_which_published_multischool_vacancies_in_the_last_quarter) AS trusts_which_published_multischool_vacancies_in_the_last_quarter,
+      SUM(trust_metrics.trusts_which_published_multischool_vacancies_so_far) AS trusts_which_published_multischool_vacancies_so_far,
+      SUM(trust_metrics.trusts_which_had_multischool_vacancies_live) AS trusts_which_had_multischool_vacancies_live,
+      SUM(trust_metrics.trusts_which_published_trust_level_vacancies_in_the_last_year) AS trusts_which_published_trust_level_vacancies_in_the_last_year,
+      SUM(trust_metrics.trusts_which_published_trust_level_vacancies_in_the_last_quarter) AS trusts_which_published_trust_level_vacancies_in_the_last_quarter,
+      SUM(trust_metrics.trusts_which_published_trust_level_vacancies_so_far) AS trusts_which_published_trust_level_vacancies_so_far,
+      SUM(trust_metrics.trusts_which_had_trust_level_vacancies_live) AS trusts_which_had_trust_level_vacancies_live
     FROM
-      `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
+      dates
     LEFT JOIN
-      `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
-    ON
-      vacancy.id=organisationvacancy.vacancy_id
-    LEFT JOIN
-      `teacher-vacancy-service.production_dataset.feb20_organisation` AS organisation
-    ON
-      organisation.id=organisationvacancy.organisation_id
-    LEFT JOIN
-      `teacher-vacancy-service.production_dataset.feb20_schoolgroupmembership` AS schoolgroupmembership
-    ON
-      organisation.id=schoolgroupmembership.school_id
-    WHERE
-      MAT.id=schoolgroupmembership.school_group_id) AS multischool_vacancies_published,
-    COUNTIF(signed_up IS TRUE) AS schools_signed_up,
-    COUNTIF(vacancies_published_in_the_last_year>0) AS schools_that_published_vacancies_in_the_last_year,
-    COUNTIF(vacancies_published_in_the_last_quarter>0) AS schools_that_published_vacancies_in_the_last_quarter,
-    COUNTIF(vacancies_published>0) AS schools_that_published_vacancies,
-    COUNTIF(vacancies_currently_live>0) AS schools_with_live_vacancies
-  FROM
-    `teacher-vacancy-service.production_dataset.feb20_organisation` AS MAT
-  LEFT JOIN
-    `teacher-vacancy-service.production_dataset.feb20_schoolgroupmembership` AS schoolgroupmembership
-  ON
-    MAT.id=schoolgroupmembership.school_group_id
-  LEFT JOIN
-    `teacher-vacancy-service.production_dataset.CALCULATED_schools_joined_with_metrics` AS school
-  ON
-    schoolgroupmembership.school_id=school.id
-  WHERE
-    data_group_type = "Multi-academy trust"
-  GROUP BY
-    trust_name,
-    id,
-    uid,
-    ukprn,
-    address,
-    town,
-    county,
-    postcode,
-    date_created,
-    date_updated,
-    date_opened,
-    date_closed,
-    companies_house_number,
-    status )
+      trust_metrics
+    USING
+      (date)
+    GROUP BY
+      date ) )
 ORDER BY
-  trust_size DESC
+  date

--- a/bigquery/scheduled_queries/mats-with-metrics.sql
+++ b/bigquery/scheduled_queries/mats-with-metrics.sql
@@ -1,184 +1,153 @@
-  #scheduled query that appends new rows to CALCULATED_daily_MAT_time_metrics table 
-WITH
-  dates AS ( #the range of dates we're calculating for
-  SELECT
-    date
-  FROM
-    UNNEST(GENERATE_DATE_ARRAY('2020-09-01', DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY), INTERVAL 1 DAY)) AS date #all dates between 1/9/20 and yesterday
-  WHERE
-    #only calculate these metrics for dates we don't already have within this range
-    date NOT IN (
-    SELECT
-      DISTINCT date
-    FROM
-      `teacher-vacancy-service.production_dataset.CALCULATED_daily_MAT_time_metrics` ) ),
-  trust_metrics AS (
-  SELECT
-    date,
-    size_bracket,
-    COUNT(uid) AS trusts_in_scope,
-    COUNTIF(signed_up) AS trusts_signed_up,
-    COUNTIF(using_mat_access_workaround) AS trusts_using_mat_access_workaround,
-    COUNTIF(has_published_so_far) AS trusts_which_published_so_far,
-    COUNTIF(has_published_in_the_last_year) AS trusts_which_published_in_the_last_year,
-    COUNTIF(has_published_in_the_last_quarter) AS trusts_which_published_in_the_last_quarter,
-    COUNTIF(had_live_vacancies) AS trusts_which_had_vacancies_live,
-    COUNTIF(has_published_multischool_vacancies_so_far) AS trusts_which_published_multischool_vacancies_so_far,
-    COUNTIF(has_published_multischool_vacancies_in_the_last_year) AS trusts_which_published_multischool_vacancies_in_the_last_year,
-    COUNTIF(has_published_multischool_vacancies_in_the_last_quarter) AS trusts_which_published_multischool_vacancies_in_the_last_quarter,
-    COUNTIF(had_live_multischool_vacancies) AS trusts_which_had_multischool_vacancies_live,
-    COUNTIF(has_published_trust_level_vacancies_so_far) AS trusts_which_published_trust_level_vacancies_so_far,
-    COUNTIF(has_published_trust_level_vacancies_in_the_last_year) AS trusts_which_published_trust_level_vacancies_in_the_last_year,
-    COUNTIF(has_published_trust_level_vacancies_in_the_last_quarter) AS trusts_which_published_trust_level_vacancies_in_the_last_quarter,
-    COUNTIF(had_live_trust_level_vacancies) AS trusts_which_had_trust_level_vacancies_live
-  FROM (
-    SELECT
-      uid,
-      date,
-      size_bracket,
-      using_mat_access_workaround,
-      COUNTIF(CAST(user.approval_datetime AS DATE) <= date) >= 1 AS signed_up,
-      #Count the number of users who had access, see if it is 1 or more, and if so count the school as signed up
-      COUNTIF(vacancy.id IS NOT NULL) >= 1 AS has_published_so_far,
-      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 1 YEAR)) >= 1 AS has_published_in_the_last_year,
-      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 3 MONTH)) >= 1 AS has_published_in_the_last_quarter,
-      COUNTIF(vacancy.expires_on > date) >= 1 AS had_live_vacancies,
-      COUNTIF(number_of_organisations > 1) >= 1 AS has_published_multischool_vacancies_so_far,
-      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 1 YEAR)
-        AND number_of_organisations > 1) >= 1 AS has_published_multischool_vacancies_in_the_last_year,
-      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 3 MONTH)
-        AND number_of_organisations > 1) >= 1 AS has_published_multischool_vacancies_in_the_last_quarter,
-      COUNTIF(vacancy.expires_on > date
-        AND number_of_organisations > 1) >= 1 AS had_live_multischool_vacancies,
-      COUNTIF(schoolgroup_level) >= 1 AS has_published_trust_level_vacancies_so_far,
-      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 1 YEAR)
-        AND schoolgroup_level) >= 1 AS has_published_trust_level_vacancies_in_the_last_year,
-      COUNTIF(vacancy.publish_on >= DATE_SUB(date,INTERVAL 3 MONTH)
-        AND schoolgroup_level) >= 1 AS has_published_trust_level_vacancies_in_the_last_quarter,
-      COUNTIF(vacancy.expires_on > date
-        AND schoolgroup_level) >= 1 AS had_live_trust_level_vacancies
-    FROM
-      `teacher-vacancy-service.production_dataset.CALCULATED_MATs_with_metrics` AS trust
-    CROSS JOIN
-      dates
-    LEFT JOIN
-      `teacher-vacancy-service.production_dataset.dsi_users` AS user
-    ON
-      CAST(user.organisation_uid AS STRING) = trust.uid
-    LEFT JOIN
-      `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
-    ON
-      (vacancy.publisher_organisation_id=trust.id
-        AND publish_on<date)
-    WHERE
-      #only include trusts that were open on each date we're calculating for in the counts above
-      (trust.status != "Closed"
-        OR trust.date_closed > dates.date) #if the trust is not currently closed or if it closed after the date we're calculating for
-      AND (trust.status != "Proposed to open" #and if the trust is not currently proposed to open
-        OR trust.date_opened <= dates.date #or if the trust opened before the date we're calculating for
-        )
-      AND trust.date_created <= dates.date
-    GROUP BY
-      uid,
-      date,
-      date_opened,
-      date_created,
-      date_closed,
-      trust.status,
-      trust.size_bracket,
-      trust.using_mat_access_workaround)
-  GROUP BY
-    date,
-    size_bracket )
 SELECT
   *,
-  SAFE_DIVIDE(trusts_signed_up,
-    trusts_in_scope) AS proportion_of_trusts_signed_up,
-  SAFE_DIVIDE(trusts_using_mat_access_workaround,
-    trusts_in_scope) AS proportion_of_trusts_using_mat_access_workaround,
-  SAFE_DIVIDE(trusts_which_published_vacancies_in_the_last_year,
-    trusts_in_scope) AS proportion_of_trusts_which_published_in_the_last_year,
-  SAFE_DIVIDE(trusts_which_published_vacancies_in_the_last_quarter,
-    trusts_in_scope) AS proportion_of_trusts_which_published_in_the_last_quarter,
-  SAFE_DIVIDE(trusts_which_published_vacancies_so_far,
-    trusts_in_scope) AS proportion_of_trusts_which_published_so_far,
-  SAFE_DIVIDE(trusts_which_had_vacancies_live,
-    trusts_in_scope) AS proportion_of_trusts_which_had_vacancies_live,
-  SAFE_DIVIDE(trusts_which_published_multischool_vacancies_in_the_last_year,
-    trusts_in_scope) AS proportion_of_trusts_which_published_multischool_vacancies_in_the_last_year,
-  SAFE_DIVIDE(trusts_which_published_multischool_vacancies_in_the_last_quarter,
-    trusts_in_scope) AS proportion_of_trusts_which_published_multischool_vacancies_in_the_last_quarter,
-  SAFE_DIVIDE(trusts_which_published_multischool_vacancies_so_far,
-    trusts_in_scope) AS proportion_of_trusts_which_published_multischool_vacancies_so_far,
-  SAFE_DIVIDE(trusts_which_had_multischool_vacancies_live,
-    trusts_in_scope) AS proportion_of_trusts_which_had_multischool_vacancies_live,
-  SAFE_DIVIDE(trusts_which_published_trust_level_vacancies_in_the_last_year,
-    trusts_in_scope) AS proportion_of_trusts_which_published_trust_level_vacancies_in_the_last_year,
-  SAFE_DIVIDE(trusts_which_published_trust_level_vacancies_in_the_last_quarter,
-    trusts_in_scope) AS proportion_of_trusts_which_published_trust_level_vacancies_in_the_last_quarter,
-  SAFE_DIVIDE(trusts_which_published_trust_level_vacancies_so_far,
-    trusts_in_scope) AS proportion_of_trusts_which_published_trust_level_vacancies_so_far,
-  SAFE_DIVIDE(trusts_which_had_trust_level_vacancies_live,
-    trusts_in_scope) AS proportion_of_trusts_which_had_trust_level_vacancies_live,
-  SAFE_DIVIDE(trusts_which_published_vacancies_in_the_last_year,
-    trusts_signed_up) AS proportion_of_signed_up_trusts_which_published_in_the_last_year,
-  SAFE_DIVIDE(trusts_which_published_vacancies_in_the_last_quarter,
-    trusts_signed_up) AS proportion_of_signed_up_trusts_which_published_in_the_last_quarter,
-  SAFE_DIVIDE(trusts_which_published_vacancies_so_far,
-    trusts_signed_up) AS proportion_of_signed_up_trusts_which_published_so_far,
-  SAFE_DIVIDE(trusts_which_had_vacancies_live,
-    trusts_signed_up) AS proportion_of_signed_up_trusts_which_had_vacancies_live,
-FROM ( (
+  SAFE_DIVIDE(schools_signed_up,
+    trust_size) AS proportion_of_schools_signed_up,
+  SAFE_DIVIDE(schools_that_published_vacancies_in_the_last_year,
+    trust_size) AS proportion_of_schools_that_published_vacancies_in_the_last_year,
+  SAFE_DIVIDE(schools_that_published_vacancies_in_the_last_quarter,
+    trust_size) AS proportion_of_schools_that_published_vacancies_in_the_last_quarter,
+  SAFE_DIVIDE(schools_that_published_vacancies,
+    trust_size) AS proportion_of_schools_that_published_vacancies,
+  SAFE_DIVIDE(schools_with_live_vacancies,
+    trust_size) AS proportion_of_schools_with_live_vacancies,
+  number_of_users > 0 AS signed_up,
+  number_of_mat_access_workaround_users > 0 AS using_mat_access_workaround,
+  CASE
+    WHEN trust_size < 2 THEN "0-1"
+    WHEN trust_size < 6 THEN "2-5"
+    WHEN trust_size < 11 THEN "6-10"
+    WHEN trust_size < 21 THEN "11-20"
+  ELSE
+  "21+"
+END
+  AS size_bracket,
+FROM (
+  SELECT
+    MAT.name AS trust_name,
+    MAT.id AS id,
+    MAT.uid AS uid,
+    MAT.data_ukprn AS ukprn,
+    MAT.address AS address,
+    MAT.town AS town,
+    MAT.county AS county,
+    MAT.postcode AS postcode,
+    CAST(MAT.created_at AS date) AS date_created,
+    CAST(MAT.updated_at AS date) AS date_updated,
+    MAT.data_closed_date AS date_closed,
+    data_incorporated_on_open_date AS date_opened,
+    data_companies_house_number AS companies_house_number,
+    data_group_status AS status,
+    COUNT(school.id) AS trust_size,
+    (
     SELECT
-      dates.date,
-      trust_metrics.size_bracket,
-      trust_metrics.trusts_signed_up,
-      trust_metrics.trusts_using_mat_access_workaround,
-      trust_metrics.trusts_in_scope,
-      trust_metrics.trusts_which_published_in_the_last_year AS trusts_which_published_vacancies_in_the_last_year,
-      trust_metrics.trusts_which_published_in_the_last_quarter AS trusts_which_published_vacancies_in_the_last_quarter,
-      trust_metrics.trusts_which_published_so_far AS trusts_which_published_vacancies_so_far,
-      trust_metrics.trusts_which_had_vacancies_live AS trusts_which_had_vacancies_live,
-      trust_metrics.trusts_which_published_multischool_vacancies_in_the_last_year AS trusts_which_published_multischool_vacancies_in_the_last_year,
-      trust_metrics.trusts_which_published_multischool_vacancies_in_the_last_quarter AS trusts_which_published_multischool_vacancies_in_the_last_quarter,
-      trust_metrics.trusts_which_published_multischool_vacancies_so_far AS trusts_which_published_multischool_vacancies_so_far,
-      trust_metrics.trusts_which_had_multischool_vacancies_live AS trusts_which_had_multischool_vacancies_live,
-      trust_metrics.trusts_which_published_trust_level_vacancies_in_the_last_year AS trusts_which_published_trust_level_vacancies_in_the_last_year,
-      trust_metrics.trusts_which_published_trust_level_vacancies_in_the_last_quarter AS trusts_which_published_trust_level_vacancies_in_the_last_quarter,
-      trust_metrics.trusts_which_published_trust_level_vacancies_so_far AS trusts_which_published_trust_level_vacancies_so_far,
-      trust_metrics.trusts_which_had_trust_level_vacancies_live AS trusts_which_had_trust_level_vacancies_live
+      COUNT(user_id)
     FROM
-      dates
-    LEFT JOIN
-      trust_metrics
-    USING
-      (date) )
-  UNION ALL (
+      `teacher-vacancy-service.production_dataset.dsi_users` AS user
+    WHERE
+      CAST(user.organisation_uid AS STRING)=MAT.uid ) AS number_of_users,
+    (
     SELECT
-      dates.date,
-      "all" AS size_bracket,
-      SUM(trust_metrics.trusts_signed_up) AS trusts_signed_up,
-      SUM(trust_metrics.trusts_using_mat_access_workaround) AS trusts_using_mat_access_workaround,
-      SUM(trust_metrics.trusts_in_scope) AS trusts_in_scope,
-      SUM(trust_metrics.trusts_which_published_in_the_last_year) AS trusts_which_published_vacancies_in_the_last_year,
-      SUM(trust_metrics.trusts_which_published_in_the_last_quarter) AS trusts_which_published_vacancies_in_the_last_quarter,
-      SUM(trust_metrics.trusts_which_published_so_far) AS trusts_which_published_vacancies_so_far,
-      SUM(trust_metrics.trusts_which_had_vacancies_live) AS trusts_which_had_vacancies_live,
-      SUM(trust_metrics.trusts_which_published_multischool_vacancies_in_the_last_year) AS trusts_which_published_multischool_vacancies_in_the_last_year,
-      SUM(trust_metrics.trusts_which_published_multischool_vacancies_in_the_last_quarter) AS trusts_which_published_multischool_vacancies_in_the_last_quarter,
-      SUM(trust_metrics.trusts_which_published_multischool_vacancies_so_far) AS trusts_which_published_multischool_vacancies_so_far,
-      SUM(trust_metrics.trusts_which_had_multischool_vacancies_live) AS trusts_which_had_multischool_vacancies_live,
-      SUM(trust_metrics.trusts_which_published_trust_level_vacancies_in_the_last_year) AS trusts_which_published_trust_level_vacancies_in_the_last_year,
-      SUM(trust_metrics.trusts_which_published_trust_level_vacancies_in_the_last_quarter) AS trusts_which_published_trust_level_vacancies_in_the_last_quarter,
-      SUM(trust_metrics.trusts_which_published_trust_level_vacancies_so_far) AS trusts_which_published_trust_level_vacancies_so_far,
-      SUM(trust_metrics.trusts_which_had_trust_level_vacancies_live) AS trusts_which_had_trust_level_vacancies_live
+      COUNT(user_id)
     FROM
-      dates
+      `teacher-vacancy-service.production_dataset.dsi_approvers` AS approver
+    WHERE
+      CAST(approver.organisation_uid AS STRING)=MAT.uid ) AS number_of_approvers,
+    (
+    SELECT
+      COUNT(DISTINCT
+      IF
+        (number_of_schools_user_has_access_to > 1,
+          email,
+          NULL))
+    FROM (
+      SELECT
+        email,
+        COUNT(DISTINCT school_urn) AS number_of_schools_user_has_access_to
+      FROM
+        `teacher-vacancy-service.production_dataset.dsi_users` AS user
+      LEFT JOIN
+        `teacher-vacancy-service.production_dataset.school` AS school
+      ON
+        CAST(user.school_urn AS STRING)=school.urn
+      LEFT JOIN
+        `teacher-vacancy-service.production_dataset.feb20_schoolgroupmembership` AS schoolgroupmembership
+      ON
+        school.id=schoolgroupmembership.school_id
+      WHERE
+        schoolgroupmembership.school_group_id=MAT.id
+      GROUP BY
+        user.email )) AS number_of_mat_access_workaround_users,
+    #count vacancies published by this trust using MAT level access
+    (
+    SELECT
+      COUNT(vacancy.id)
+    FROM
+      `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
+    WHERE
+      MAT.id=vacancy.publisher_organisation_id) AS vacancies_published_using_MAT_access,
+    #count trust-level vacancies published by this trust
+    (
+    SELECT
+      COUNTIF(schoolgroup_level)
+    FROM
+      `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
     LEFT JOIN
-      trust_metrics
-    USING
-      (date)
-    GROUP BY
-      date ) )
+      `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
+    ON
+      vacancy.id=organisationvacancy.vacancy_id
+    WHERE
+      MAT.id=organisationvacancy.organisation_id) AS trust_level_vacancies_published,
+    #count multi-school vacancies where at least 1 of the schools is part of this trust
+    (
+    SELECT
+      COUNTIF(vacancy.number_of_organisations > 1)
+    FROM
+      `teacher-vacancy-service.production_dataset.vacancies_published` AS vacancy
+    LEFT JOIN
+      `teacher-vacancy-service.production_dataset.feb20_organisationvacancy` AS organisationvacancy
+    ON
+      vacancy.id=organisationvacancy.vacancy_id
+    LEFT JOIN
+      `teacher-vacancy-service.production_dataset.feb20_organisation` AS organisation
+    ON
+      organisation.id=organisationvacancy.organisation_id
+    LEFT JOIN
+      `teacher-vacancy-service.production_dataset.feb20_schoolgroupmembership` AS schoolgroupmembership
+    ON
+      organisation.id=schoolgroupmembership.school_id
+    WHERE
+      MAT.id=schoolgroupmembership.school_group_id) AS multischool_vacancies_published,
+    COUNTIF(signed_up IS TRUE) AS schools_signed_up,
+    COUNTIF(vacancies_published_in_the_last_year>0) AS schools_that_published_vacancies_in_the_last_year,
+    COUNTIF(vacancies_published_in_the_last_quarter>0) AS schools_that_published_vacancies_in_the_last_quarter,
+    COUNTIF(vacancies_published>0) AS schools_that_published_vacancies,
+    COUNTIF(vacancies_currently_live>0) AS schools_with_live_vacancies
+  FROM
+    `teacher-vacancy-service.production_dataset.feb20_organisation` AS MAT
+  LEFT JOIN
+    `teacher-vacancy-service.production_dataset.feb20_schoolgroupmembership` AS schoolgroupmembership
+  ON
+    MAT.id=schoolgroupmembership.school_group_id
+  LEFT JOIN
+    `teacher-vacancy-service.production_dataset.CALCULATED_schools_joined_with_metrics` AS school
+  ON
+    schoolgroupmembership.school_id=school.id
+  WHERE
+    data_group_type = "Multi-academy trust"
+  GROUP BY
+    trust_name,
+    id,
+    uid,
+    ukprn,
+    address,
+    town,
+    county,
+    postcode,
+    date_created,
+    date_updated,
+    date_opened,
+    date_closed,
+    companies_house_number,
+    status )
 ORDER BY
-  date
+  trust_size DESC


### PR DESCRIPTION
- Fix to how we calculate the number of MAT access workaround users a MAT has (without the DISTINCT it was oversensitive to null values of schoolgroup coming out of the joins, which I think caused it to spike when LAs started appearing in the table as schoolgroups)