### PR TITLE
[TEVA-1463] hiring staff journey page heading bugfix

### DIFF
--- a/app/components/hiring_staff/vacancy_form_page_heading_component.html.haml
+++ b/app/components/hiring_staff/vacancy_form_page_heading_component.html.haml
@@ -1,0 +1,5 @@
+%h1.govuk-heading-m
+  = heading
+  - if show_current_step?
+    %span.govuk-caption-m
+      = t('jobs.current_step', step: current_step, total: total_steps)

--- a/app/components/hiring_staff/vacancy_form_page_heading_component.rb
+++ b/app/components/hiring_staff/vacancy_form_page_heading_component.rb
@@ -1,0 +1,50 @@
+class HiringStaff::VacancyFormPageHeadingComponent < ViewComponent::Base
+  delegate :current_organisation, to: :helpers
+  delegate :current_step, to: :helpers
+  delegate :total_steps, to: :helpers
+
+  def initialize(vacancy, session_vacancy_attributes)
+    unless session_vacancy_attributes.nil?
+      @session_job_location = session_vacancy_attributes["job_location"]
+      @session_readable_job_location = session_vacancy_attributes["readable_job_location"]
+    end
+    @vacancy = vacancy
+  end
+
+  def heading
+    vacancy.present? ? page_title : page_title_no_vacancy
+  end
+
+  def show_current_step?
+    %w[copy edit edit_published].exclude?(vacancy&.state)
+  end
+
+private
+
+  attr_reader :session_job_location, :session_readable_job_location, :vacancy
+
+  def page_title_no_vacancy
+    organisation_for_title =
+      if session_job_location == "at_one_school"
+        session_readable_job_location
+      elsif session_job_location == "at_multiple_schools"
+        "multiple schools"
+      else
+        current_organisation.name
+      end
+
+    organisation_for_title ? I18n.t("jobs.create_a_job_title", organisation: organisation_for_title) : I18n.t("jobs.create_a_job_title_no_org")
+  end
+
+  def page_title
+    return I18n.t("jobs.copy_job_title", job_title: vacancy.job_title) if vacancy.state == "copy"
+    return I18n.t("jobs.create_a_job_title", organisation: organisation_from_job_location) if
+      %w[create review].include?(vacancy.state)
+
+    I18n.t("jobs.edit_job_title", job_title: vacancy.job_title)
+  end
+
+  def organisation_from_job_location
+    vacancy.job_location == "at_multiple_schools" ? "multiple schools" : vacancy.parent_organisation_name
+  end
+end

--- a/app/components/hiring_staff/vacancy_form_page_heading_component.rb
+++ b/app/components/hiring_staff/vacancy_form_page_heading_component.rb
@@ -24,6 +24,8 @@ private
   attr_reader :session_job_location, :session_readable_job_location, :vacancy
 
   def page_title_no_vacancy
+    return I18n.t("jobs.create_a_job_title_no_org") unless current_organisation.is_a?(School) || current_step > 1
+
     organisation_for_title =
       if session_job_location == "at_one_school"
         session_readable_job_location

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -40,31 +40,6 @@ module VacanciesHelper
     I18n.t("jobs.review_heading")
   end
 
-  def page_title(vacancy)
-    return I18n.t("jobs.copy_job_title", job_title: vacancy.job_title) if vacancy.state == "copy"
-    return I18n.t("jobs.create_a_job_title", organisation: organisation_from_job_location(vacancy)) if
-      %w[create review].include?(vacancy.state)
-
-    I18n.t("jobs.edit_job_title", job_title: vacancy.job_title)
-  end
-
-  def organisation_from_job_location(vacancy)
-    vacancy.job_location == "at_multiple_schools" ? "multiple schools" : vacancy.parent_organisation_name
-  end
-
-  def page_title_no_vacancy
-    organisation_for_title =
-      if session[:vacancy_attributes] && session[:vacancy_attributes]["job_location"] == "at_one_school"
-        session[:vacancy_attributes]["readable_job_location"]
-      elsif session[:vacancy_attributes] && session[:vacancy_attributes]["job_location"] == "at_multiple_schools"
-        "multiple schools"
-      else
-        current_organisation.name
-      end
-
-    organisation_for_title ? I18n.t("jobs.create_a_job_title", organisation: organisation_for_title) : I18n.t("jobs.create_a_job_title_no_org")
-  end
-
   def hidden_state_field_value(vacancy, copy = false)
     return "copy" if copy
     return "edit_published" if vacancy&.published?

--- a/app/views/hiring_staff/vacancies/application_details/show.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/show.html.haml
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @application_details_form, t('jobs.application_details'))
-= render 'hiring_staff/vacancies/vacancy_form_partials/heading'
-
+= render HiringStaff::VacancyFormPageHeadingComponent.new(@vacancy, session[:vacancy_attributes])
 - if @vacancy.present? && @vacancy&.state != 'create'
   = render 'hiring_staff/vacancies/vacancy_form_partials/cancel_and_return_link'
 - else

--- a/app/views/hiring_staff/vacancies/documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/documents/show.html.haml
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @documents_form, t('jobs.supporting_documents'))
-= render 'hiring_staff/vacancies/vacancy_form_partials/heading'
-
+= render HiringStaff::VacancyFormPageHeadingComponent.new(@vacancy, session[:vacancy_attributes])
 - if @vacancy.present? && @vacancy&.state != 'create'
   = render 'hiring_staff/vacancies/vacancy_form_partials/cancel_and_return_link'
 - else

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, review_page_title_prefix(@vacancy)
-= render 'hiring_staff/vacancies/vacancy_form_partials/heading'
-
+= render HiringStaff::VacancyFormPageHeadingComponent.new(@vacancy, session[:vacancy_attributes])
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds
     = render 'hiring_staff/vacancies/edit_heading'

--- a/app/views/hiring_staff/vacancies/important_dates/show.html.haml
+++ b/app/views/hiring_staff/vacancies/important_dates/show.html.haml
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @important_dates_form, t('jobs.important_dates'))
-= render 'hiring_staff/vacancies/vacancy_form_partials/heading'
-
+= render HiringStaff::VacancyFormPageHeadingComponent.new(@vacancy, session[:vacancy_attributes])
 - if @vacancy.present? && @vacancy&.state != 'create'
   = render 'hiring_staff/vacancies/vacancy_form_partials/cancel_and_return_link'
 - else

--- a/app/views/hiring_staff/vacancies/job_location/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_location/show.html.haml
@@ -3,8 +3,7 @@
 - else
   - content_for :page_title_prefix, "#{@form.errors.present? ? 'Error: ' : ''}#{t('jobs.job_location')} — #{t('jobs.create_a_job_title_no_org')}"
 
-= render 'hiring_staff/vacancies/vacancy_form_partials/heading'
-
+= render HiringStaff::VacancyFormPageHeadingComponent.new(@vacancy, session[:vacancy_attributes])
 - if @vacancy.present? && @vacancy&.state != 'create'
   = render 'hiring_staff/vacancies/vacancy_form_partials/cancel_and_return_link'
 

--- a/app/views/hiring_staff/vacancies/job_specification/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/show.html.haml
@@ -3,8 +3,7 @@
 - else
   - content_for :page_title_prefix, "#{@form.errors.present? ? 'Error: ' : ''}#{t('jobs.job_details')} — #{t('jobs.create_a_job_title', organisation: current_organisation.name)}"
 
-= render 'hiring_staff/vacancies/vacancy_form_partials/heading'
-
+= render HiringStaff::VacancyFormPageHeadingComponent.new(@vacancy, session[:vacancy_attributes])
 - if @vacancy.present? && @vacancy&.state != 'create'
   = render 'hiring_staff/vacancies/vacancy_form_partials/cancel_and_return_link'
 - else

--- a/app/views/hiring_staff/vacancies/job_summary/show.html.haml
+++ b/app/views/hiring_staff/vacancies/job_summary/show.html.haml
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @job_summary_form, t('jobs.job_summary'))
-= render 'hiring_staff/vacancies/vacancy_form_partials/heading'
-
+= render HiringStaff::VacancyFormPageHeadingComponent.new(@vacancy, session[:vacancy_attributes])
 - if @vacancy.present? && @vacancy&.state != 'create'
   = render 'hiring_staff/vacancies/vacancy_form_partials/cancel_and_return_link'
 - else

--- a/app/views/hiring_staff/vacancies/pay_package/show.html.haml
+++ b/app/views/hiring_staff/vacancies/pay_package/show.html.haml
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @pay_package_form, t('jobs.pay_package'))
-= render 'hiring_staff/vacancies/vacancy_form_partials/heading'
-
+= render HiringStaff::VacancyFormPageHeadingComponent.new(@vacancy, session[:vacancy_attributes])
 - if @vacancy.present? && @vacancy&.state != 'create'
   = render 'hiring_staff/vacancies/vacancy_form_partials/cancel_and_return_link'
 - else

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, review_page_title_prefix(@vacancy)
-= render 'hiring_staff/vacancies/vacancy_form_partials/heading'
-
+= render HiringStaff::VacancyFormPageHeadingComponent.new(@vacancy, session[:vacancy_attributes])
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds
     = render 'hiring_staff/vacancies/edit_heading'

--- a/app/views/hiring_staff/vacancies/schools/show.html.haml
+++ b/app/views/hiring_staff/vacancies/schools/show.html.haml
@@ -3,8 +3,7 @@
 - else
   - content_for :page_title_prefix, "#{@form.errors.present? ? 'Error: ' : ''}#{t('jobs.job_location')} — #{t('jobs.create_a_job_title_no_org')}"
 
-= render 'hiring_staff/vacancies/vacancy_form_partials/heading'
-
+= render HiringStaff::VacancyFormPageHeadingComponent.new(@vacancy, session[:vacancy_attributes])
 - if @vacancy.blank? || @vacancy&.state == 'create'
   = link_to t('buttons.back'), @previous_step_path, class: 'govuk-back-link'
 

--- a/app/views/hiring_staff/vacancies/supporting_documents/show.html.haml
+++ b/app/views/hiring_staff/vacancies/supporting_documents/show.html.haml
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @supporting_documents_form, t('jobs.supporting_documents'))
-= render 'hiring_staff/vacancies/vacancy_form_partials/heading'
-
+= render HiringStaff::VacancyFormPageHeadingComponent.new(@vacancy, session[:vacancy_attributes])
 - if @vacancy.present? && @vacancy&.state != 'create'
   = render 'hiring_staff/vacancies/vacancy_form_partials/cancel_and_return_link'
 - else

--- a/app/views/hiring_staff/vacancies/vacancy_form_partials/_heading.html.haml
+++ b/app/views/hiring_staff/vacancies/vacancy_form_partials/_heading.html.haml
@@ -1,5 +1,0 @@
-%h1.govuk-heading-m
-  = @vacancy.present? ? page_title(@vacancy) : page_title_no_vacancy
-  - unless %w(copy edit edit_published).include?(@vacancy&.state)
-    %span.govuk-caption-m
-      = t('jobs.current_step', step: current_step, total: total_steps)

--- a/spec/components/hiring_staff/vacancy_form_page_heading_component_spec.rb
+++ b/spec/components/hiring_staff/vacancy_form_page_heading_component_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe HiringStaff::VacancyFormPageHeadingComponent, type: :component do
+  let(:school) { create(:school, name: "Teaching Vacancies Academy") }
+  let(:state) { "create" }
+  let(:vacancy) { create(:vacancy, state: state, job_title: "Test job title") }
+  let(:session_job_location) { nil }
+  let(:session_readable_job_location) { nil }
+  let(:session_vacancy_attributes) { { "job_location" => session_job_location, "readable_job_location" => session_readable_job_location } }
+  let(:current_step) { 99 }
+
+  subject { described_class.new(vacancy, session_vacancy_attributes) }
+
+  before do
+    allow(subject).to receive(:current_step).and_return(100)
+    allow(subject).to receive(:total_steps).and_return(101)
+    allow(subject).to receive(:current_organisation).and_return(school)
+    vacancy.organisation_vacancies.create(organisation: school) if vacancy.present?
+    render_inline(subject)
+  end
+
+  describe "#show_current_step?" do
+    context "when vacancy state is create or review" do
+      let(:state) { "create" }
+
+      it "shows the current step" do
+        expect(rendered_component).to include(I18n.t("jobs.current_step", step: 100, total: 101))
+      end
+    end
+
+    context "when vacancy state is not create or review" do
+      let(:state) { "copy" }
+
+      it "does not show the current step" do
+        expect(rendered_component).not_to include(I18n.t("jobs.current_step", step: 100, total: 101))
+      end
+    end
+  end
+
+  describe "#heading" do
+    context "when there is no vacancy object" do
+      let(:vacancy) { nil }
+
+      context 'when job_location is "at_one_school"' do
+        let(:session_job_location) { "at_one_school" }
+        let(:session_readable_job_location) { "That Specific School" }
+
+        it "returns the create a job title with the session vacancy readable job location" do
+          expect(rendered_component).to include(I18n.t("jobs.create_a_job_title", organisation: session_readable_job_location))
+        end
+      end
+
+      context 'when job_location is "at_multiple_schools"' do
+        let(:session_job_location) { "at_multiple_schools" }
+
+        it "returns the create a job title with the session vacancy readable job location" do
+          expect(rendered_component).to include(I18n.t("jobs.create_a_job_title", organisation: "multiple schools"))
+        end
+      end
+    end
+
+    context "when there is a vacancy object" do
+      let(:state) { "copy" }
+
+      context "when a published vacancy is being edited" do
+        let(:vacancy) { create(:vacancy, :published, state: "edit", job_title: "Test job title") }
+
+        it "returns edit job title" do
+          expect(rendered_component).to include(I18n.t("jobs.edit_job_title", job_title: "Test job title"))
+        end
+      end
+
+      context "when the vacancy is not published" do
+        before { allow(vacancy).to receive(:published?).and_return(false) }
+
+        context "when the vacancy state is edit" do
+          let(:state) { "edit" }
+
+          before { allow(vacancy).to receive(:published?).and_return(false) }
+
+          it "returns edit job title" do
+            expect(rendered_component).to include(I18n.t("jobs.edit_job_title", job_title: "Test job title"))
+          end
+        end
+
+        context "when vacancy state is copy" do
+          let(:state) { "copy" }
+
+          it "returns copy job title " do
+            expect(rendered_component).to include(I18n.t("jobs.copy_job_title", job_title: "Test job title"))
+          end
+        end
+
+        context "when vacancy state is create" do
+          let(:state) { "create" }
+
+          it "returns create a job title" do
+            expect(rendered_component).to include(I18n.t("jobs.create_a_job_title", organisation: "Teaching Vacancies Academy"))
+          end
+        end
+
+        context "when vacancy state is review" do
+          let(:state) { "review" }
+
+          it "returns create a job title" do
+            expect(rendered_component).to include(I18n.t("jobs.create_a_job_title", organisation: "Teaching Vacancies Academy"))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/components/hiring_staff/vacancy_form_page_heading_component_spec.rb
+++ b/spec/components/hiring_staff/vacancy_form_page_heading_component_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe HiringStaff::VacancyFormPageHeadingComponent, type: :component do
-  let(:school) { create(:school, name: "Teaching Vacancies Academy") }
+  let(:organisation) { create(:school, name: "Teaching Vacancies Academy") }
   let(:state) { "create" }
   let(:vacancy) { create(:vacancy, state: state, job_title: "Test job title") }
   let(:session_job_location) { nil }
@@ -12,10 +12,10 @@ RSpec.describe HiringStaff::VacancyFormPageHeadingComponent, type: :component do
   subject { described_class.new(vacancy, session_vacancy_attributes) }
 
   before do
-    allow(subject).to receive(:current_step).and_return(100)
-    allow(subject).to receive(:total_steps).and_return(101)
-    allow(subject).to receive(:current_organisation).and_return(school)
-    vacancy.organisation_vacancies.create(organisation: school) if vacancy.present?
+    allow(subject).to receive(:current_step).and_return(current_step)
+    allow(subject).to receive(:total_steps).and_return(100)
+    allow(subject).to receive(:current_organisation).and_return(organisation)
+    vacancy.organisation_vacancies.create(organisation: organisation) if vacancy.present?
     render_inline(subject)
   end
 
@@ -24,7 +24,7 @@ RSpec.describe HiringStaff::VacancyFormPageHeadingComponent, type: :component do
       let(:state) { "create" }
 
       it "shows the current step" do
-        expect(rendered_component).to include(I18n.t("jobs.current_step", step: 100, total: 101))
+        expect(rendered_component).to include(I18n.t("jobs.current_step", step: current_step, total: 100))
       end
     end
 
@@ -40,6 +40,19 @@ RSpec.describe HiringStaff::VacancyFormPageHeadingComponent, type: :component do
   describe "#heading" do
     context "when there is no vacancy object" do
       let(:vacancy) { nil }
+
+      context "when the user is not signed in as a single school and the current step is 1" do
+        let(:organisation) { create(:trust) }
+        let(:current_step) { 1 }
+        let(:session_job_location) { "at_one_school" }
+        let(:session_readable_job_location) { "That Specific School" }
+
+        it "returns the create a job title without an organisation, ignoring the session parameters" do
+          expect(
+            page.text.split("Step").first.strip,
+          ).to eq(I18n.t("jobs.create_a_job_title_no_org"))
+        end
+      end
 
       context 'when job_location is "at_one_school"' do
         let(:session_job_location) { "at_one_school" }

--- a/spec/components/hiring_staff/vacancy_form_page_heading_component_spec.rb
+++ b/spec/components/hiring_staff/vacancy_form_page_heading_component_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe HiringStaff::VacancyFormPageHeadingComponent, type: :component do
       let(:state) { "copy" }
 
       it "does not show the current step" do
-        expect(rendered_component).not_to include(I18n.t("jobs.current_step", step: 100, total: 101))
+        expect(rendered_component).not_to include("Step")
       end
     end
   end

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -28,43 +28,6 @@ RSpec.describe VacanciesHelper, type: :helper do
     end
   end
 
-  describe "#page_title" do
-    let(:vacancy) { double("vacancy").as_null_object }
-    let(:school) { build(:school) }
-
-    it "returns copy job title if vacancy state is copy" do
-      allow(vacancy).to receive(:published?).and_return(false)
-      allow(vacancy).to receive(:state).and_return("copy")
-      allow(vacancy).to receive(:job_title).and_return("Test job title")
-
-      expect(page_title(vacancy)).to eql(I18n.t("jobs.copy_job_title", job_title: "Test job title"))
-    end
-
-    it "returns create a job title if vacancy state is create" do
-      allow(vacancy).to receive(:published?).and_return(false)
-      allow(vacancy).to receive(:state).and_return("create")
-      allow(vacancy).to receive(:job_location).and_return("at_one_school")
-      allow(vacancy).to receive(:parent_organisation_name).and_return("Teaching Vacancies Academy")
-
-      expect(page_title(vacancy)).to eql(I18n.t("jobs.create_a_job_title", organisation: "Teaching Vacancies Academy"))
-    end
-
-    it "returns create a job title if vacancy state is review" do
-      allow(vacancy).to receive(:published?).and_return(false)
-      allow(vacancy).to receive(:state).and_return("review")
-      allow(vacancy).to receive(:job_location).and_return("at_one_school")
-      allow(vacancy).to receive(:parent_organisation_name).and_return("Teaching Vacancies Academy")
-
-      expect(page_title(vacancy)).to eql(I18n.t("jobs.create_a_job_title", organisation: "Teaching Vacancies Academy"))
-    end
-
-    it "returns edit job title" do
-      allow(vacancy).to receive(:published?).and_return(true)
-
-      expect(page_title(vacancy)).to eql(I18n.t("jobs.edit_job_title", job_title: vacancy.job_title))
-    end
-  end
-
   describe "#hidden_state_field_value" do
     let(:vacancy) { double("vacancy").as_null_object }
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1463

## Changes in this PR:

- This was a lot simpler than I initially thought it was, because the first step (for school group hiring staff) actually only needs to have 'Create a job' as the title, which simplifies the task a lot.
- While trying to do the complicated version of this task I refactored the heading partial into its own view component in order to get the logic all in one place.

## Screenshots of UI changes:

### Before (this is what the bug looked like)

<img width="579" alt="Screenshot 2020-11-05 at 13 38 21" src="https://user-images.githubusercontent.com/60350599/98254950-c6fbf300-1f74-11eb-9d47-da6abdf8023d.png">

<img width="579" alt="Screenshot 2020-11-05 at 13 37 53" src="https://user-images.githubusercontent.com/60350599/98254926-c2373f00-1f74-11eb-800d-d36d6b96a9c1.png">

### After

![Screenshot 2020-11-05 at 14 40 18](https://user-images.githubusercontent.com/60350599/98255019-d4b17880-1f74-11eb-898d-bbb816a9900b.png)
