### PR TITLE
[TEVA-1492] Pin GH virtual env to ubuntu 20.04

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   turnstyle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
     - uses: softprops/turnstyle@v1
@@ -28,7 +28,7 @@ jobs:
   deploy:
     name: build docker image and deploy
     needs: turnstyle
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       name: Checkout Code

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   turnstyle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
     - uses: softprops/turnstyle@v1
@@ -29,7 +29,7 @@ jobs:
   deploy:
     name: build docker image and deploy
     needs: turnstyle
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       BRANCH: ${{ steps.set_env_vars.outputs.BRANCH }}
       TAG: ${{ steps.set_env_vars.outputs.TAG }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   turnstyle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
     - uses: softprops/turnstyle@v1
@@ -24,7 +24,7 @@ jobs:
   deploy:
     name: Destroy review app
     needs: turnstyle
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       name: Checkout Code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   backend-lint:
     name: Run Rubocop check
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout code
@@ -40,7 +40,7 @@ jobs:
   frontend-lint:
     name: Run ESLint check
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout code
@@ -75,7 +75,7 @@ jobs:
   terraform-lint:
     name: Run Terraform check
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   turnstyle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
     - uses: softprops/turnstyle@v1
@@ -29,7 +29,7 @@ jobs:
   deploy:
     name: Create review app
     needs: turnstyle
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       name: Checkout Code

--- a/.github/workflows/smoke-test-manual.yml
+++ b/.github/workflows/smoke-test-manual.yml
@@ -12,7 +12,7 @@ jobs:
   smoke-test-manual-job:
     name: Smoke Test Manual Job
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       RAILS_ENV: test

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -8,7 +8,7 @@ jobs:
   smoke-test:
     name: Run production website smoke test
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       RAILS_ENV: test

--- a/.github/workflows/sync_staging_db.yml
+++ b/.github/workflows/sync_staging_db.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   sync:
     name: Sync staging database from production
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   backend-tests:
     name: Run rspec
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       RAILS_ENV: test
@@ -108,7 +108,7 @@ jobs:
   frontend-tests:
     name: Run jest
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1492

## Changes in this PR:

- Update virtual environment to use `ubuntu-20.04` in advance of the automated change
