### PR TITLE
[TEVA-1534] Remove TF workspace on review app destroy

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -67,6 +67,7 @@ jobs:
         terraform workspace select review-${PR_NAME} terraform/app || terraform workspace new review-${PR_NAME} terraform/app
         terraform plan -var-file terraform/workspace-variables/review.tfvars -destroy -out=tfdestroy terraform/app
         terraform apply -auto-approve "tfdestroy"
+        terraform workspace select default terraform/app && terraform workspace delete review-${PR_NAME} terraform/app
 
     - name: Send failure message to twd_tv_dev channel
       if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ review-destroy: init-terraform ## make CONFIRM_DESTROY=true passcode=MyPasscode 
 		$(if $(CONFIRM_DESTROY), , $(error Can only run with CONFIRM_DESTROY))
 		terraform plan -var-file terraform/workspace-variables/review.tfvars -destroy -out=destroy-$(env).plan terraform/app
 		terraform apply "destroy-$(env).plan"
+		terraform workspace select default terraform/app && terraform workspace delete $(env) terraform/app
 
 ##@ terraform/common code. Requires privileged IAM account to run
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1534

## Changes in this PR:

- In `destroy.yml` and in Makefile `review-destroy` target, switch to terraform default workspace and delete review workspace
