### PR TITLE
[TEVA-1534] Allow GH IAM user to delete review S3 state files

### DIFF
--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -29,6 +29,10 @@ data aws_iam_policy_document edit_terraform_state {
     resources = ["arn:aws:s3:::${var.s3_bucket_name}/*"]
   }
   statement {
+    actions   = ["s3:DeleteObject"]
+    resources = ["arn:aws:s3:::${var.s3_bucket_name}/:review/*"]
+  }
+  statement {
     actions   = ["s3:ListBucket"]
     resources = ["arn:aws:s3:::${var.s3_bucket_name}"]
   }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1534

## Changes in this PR:

- Extended IAM permission to the `:review` folder in S3 terraform bucket, to allow GitHub programmatic user to delete review app state files.
