### PR TITLE
TEVA-1492 Provide AWS region for S3 copy task using AWS CLI v2

### DIFF
--- a/.github/workflows/sync_staging_db.yml
+++ b/.github/workflows/sync_staging_db.yml
@@ -47,10 +47,14 @@ jobs:
         CF_POSTGRES_SERVICE_TARGET: teaching-vacancies-postgres-staging
       run: bin/sync-db
 
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-2
+
     - name: Upload backup to S3
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: bin/upload-db-backup
 
     - name: Send success message to twd_tv_dev channel


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1492

## Changes in this PR:

- Using `aws-actions` as a separate step to configure AWS credentials before relying on them in S3 step.

## Testing

Tested by temporarily reconfiguring `review.yml` to do 
```
    - name: Configure AWS credentials
      uses: aws-actions/configure-aws-credentials@v1
      with:
        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
        aws-region: eu-west-2

    - name: Upload backup to S3
      run: bin/s3-upload-test
```

with `bin/s3-upload-test` being altered to use the existing `Dockerfile` (rather than `backup.sql` which is generated by a different step in the backup job

```
#!/bin/bash
set -eu

FILENAME=Dockerfile
DATE=$(date +'%F')
BUCKET=530003481352-tv-db-backups

gzip "$FILENAME"
aws s3 cp "${FILENAME}.gz" "s3://${BUCKET}/${DATE}-${FILENAME}.gz"
```

Successful run in https://github.com/DFE-Digital/teacher-vacancy-service/runs/1375414380?check_suite_focus=true and verified in the S3 bucket that the temp file was successfully uploaded. 