### PR TITLE
Improve Content Security Policy

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,4 +29,8 @@ module ApplicationHelper
     "teacher,maths,primary,history,english,science,geography,\
     teaching,assistant,headteacher,class,French,job,vacancy,school,nqt"
   end
+
+  def recaptcha(action)
+    recaptcha_v3(action: action, nonce: request.content_security_policy_nonce)
+  end
 end

--- a/app/views/general_feedback/new.html.haml
+++ b/app/views/general_feedback/new.html.haml
@@ -22,6 +22,6 @@
 
       = render '/feedback/form', f: f
 
-      = recaptcha_v3(action: 'feedback')
+      = recaptcha('feedback')
 
       = f.govuk_submit t('buttons.submit_feedback')

--- a/app/views/job_alert_feedbacks/edit.html.haml
+++ b/app/views/job_alert_feedbacks/edit.html.haml
@@ -13,6 +13,6 @@
         max_chars: 1200,
         rows: 11
 
-      = recaptcha_v3(action: 'job_alert_feedback')
+      = recaptcha('job_alert_feedback')
 
       = f.govuk_submit t('buttons.submit'), classes: 'govuk-!-padding-left-8 govuk-!-padding-right-8'

--- a/app/views/nqt_job_alerts/new.html.haml
+++ b/app/views/nqt_job_alerts/new.html.haml
@@ -24,7 +24,7 @@
 
       = f.govuk_email_field :email, label: { size: 's' }, width: 'two-thirds', required: true
 
-      = recaptcha_v3(action: 'subscription')
+      = recaptcha('subscription')
 
       = render(Shared::NotificationComponent.new(content: t('nqt_job_alerts.intro.unsubscribe'), style: 'notice', background: true, alert: 'info', dismiss: false))
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -13,7 +13,7 @@
 
       = render(Shared::NotificationComponent.new(content: { body: t('subscriptions.info') }, style: 'notice', background: true, dismiss: false, alert: 'info'))
 
-      = recaptcha_v3(action: 'subscription')
+      = recaptcha('subscription')
 
       = f.govuk_submit t('buttons.subscribe'), classes: 'govuk-!-padding-left-8 govuk-!-padding-right-8'
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,16 +6,43 @@
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
-  policy.font_src    :self, :data, "https://cdnjs.cloudflare.com", "https://fonts.gstatic.com"
-  policy.img_src     :self, :https, :data
+
+  policy.font_src    :self,
+                     :data,
+                     "https://cdnjs.cloudflare.com",
+                     "https://fonts.gstatic.com"
+
+  policy.frame_src   :self,
+                     "https://www.google.com", # for reCAPTCHA
+                     "https://www.googletagmanager.com"
+
+  policy.img_src     :self,
+                     :https,
+                     :data
+
   policy.object_src  :none
-  policy.script_src  :self, "https://cdnjs.cloudflare.com", "https://cdn.rollbar.com",
-                     "https://www.googletagmanager.com", "https://maps.googleapis.com",
+
+  policy.script_src  :self,
+                     :unsafe_inline, # Backwards compatibility; ignored by modern browsers as we set a nonce for scripts
+                     "https://cdn.rollbar.com",
+                     "https://cdnjs.cloudflare.com",
+                     "https://maps.googleapis.com",
+                     "https://www.google-analytics.com",
+                     "https://www.googletagmanager.com",
                      "https://www.recaptcha.net"
+
   # Google Maps embed will not work without 'unsafe-inline' styles
   #   see: https://issuetracker.google.com/issues/132600807
-  policy.style_src   :self, "https://cdnjs.cloudflare.com", "https://fonts.googleapis.com", :unsafe_inline
-  policy.connect_src :self, "https://www.google-analytics.com", "https://api.postcodes.io"
+  policy.style_src   :self,
+                     :unsafe_inline,
+                     "https://cdnjs.cloudflare.com",
+                     "https://fonts.googleapis.com"
+
+  policy.connect_src :self,
+                     "https://api.postcodes.io",
+                     "https://api.rollbar.com",
+                     "https://www.google-analytics.com"
+
   # Allow using webpack-dev-server in development
   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -35,4 +35,18 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#recaptcha" do
+    let(:request) { double("Request", content_security_policy_nonce: "n0nc3") }
+    let(:captcha) { double("CAPTCHA") }
+
+    before do
+      allow(controller).to receive(:request).and_return(request)
+      allow(helper).to receive(:recaptcha_v3).with(action: "hello_world", nonce: "n0nc3").and_return(captcha)
+    end
+
+    it "delegates to recaptcha_v3 with the CSP nonce" do
+      expect(helper.recaptcha("hello_world")).to eq(captcha)
+    end
+  end
 end


### PR DESCRIPTION
- Add additional required directives
- Add `unsafe-inline` to `script-src` directive (will be ignored by non-
  legacy browsers due to a nonce being present)
- Add helper to wrap `recaptcha_v3` and add nonce
- Tidy up CSP initializer