### PR TITLE
Bigquery job alert active unsubscribed at

### DIFF
--- a/bigquery/scheduled_queries/calculate-daily-job-alert-metrics.sql
+++ b/bigquery/scheduled_queries/calculate-daily-job-alert-metrics.sql
@@ -73,11 +73,21 @@ WITH
       human IS NOT FALSE) AS job_alerts_updated,
     (
     SELECT
-      COUNTIF(created_date<=date)
+      COUNTIF(created_date<=date
+        AND ((unsubscribed_date IS NULL
+            AND active)
+          OR unsubscribed_date>date))
     FROM
       `teacher-vacancy-service.production_dataset.job_alert`
     WHERE
       human IS NOT FALSE ) AS job_alerts_live,
+    (
+    SELECT
+      COUNTIF(unsubscribed_date=date)
+    FROM
+      `teacher-vacancy-service.production_dataset.job_alert`
+    WHERE
+      human IS NOT FALSE ) AS job_alerts_unsubscribed,
     (
     SELECT
       COUNT(DISTINCT
@@ -108,7 +118,19 @@ WITH
     (date))
 UNION ALL (
   SELECT
-    *
+    date,
+    job_alerts_created,
+    job_alerts_updated,
+    job_alerts_live,
+    job_alerts_unsubscribed,
+    emails_subscribed_to_job_alerts,
+    number_of_alert_emails_sent,
+    number_of_alert_emails_clicked_on,
+    number_of_alert_emails_unsubscribed_from,
+    number_of_alert_emails_edited,
+    job_alert_email_vacancy_ctr,
+    job_alert_email_unsubscribe_ctr,
+    job_alert_email_edit_ctr
   FROM
     `teacher-vacancy-service.production_dataset.CALCULATED_job_alert_metrics`
   WHERE

--- a/bigquery/views/job-alert.sql
+++ b/bigquery/views/job-alert.sql
@@ -2,6 +2,14 @@ SELECT
   id,
   CAST(created_at AS date) AS created_date,
   CAST(updated_at AS date) AS updated_date,
+  active,
+  CAST(unsubscribed_at AS date) AS unsubscribed_date,
+IF
+  (NOT active,
+    DATETIME_DIFF(unsubscribed_at,
+      created_at,
+      DAY),
+    NULL) AS days_active,
   recaptcha_score,
   FIRST_VALUE(id) OVER (PARTITION BY email ORDER BY created_at) AS email_address_id,
   #the ID of the first job alert with this email address - allows us to string job alerts with the same email address together without including the PII in this view


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1539

## Changes in this PR:
Changes to BigQuery scheduled queries and views to handle / exploit the new active and unsubscribed_at fields in the subscription table:
- Add active, unsubscribed_date and days_active fields to job_alert view of subscription table.
- Add job alert creation/unsubscription counts to daily time metrics table.
- Add job alert creation CTR to daily time metrics table. (now possible because we have this goal set up in the table of daily users from Cloudfront logs)
- Add unsubscription count to daily job alert metrics table.
- Take unsubscriptions into account when calculating the number of live job alerts for each day for daily job alert metrics table.
