### PR TITLE
Reduce dependency on external CDNs

### DIFF
--- a/app/components/shared/filters_component/filters_component.html.haml
+++ b/app/components/shared/filters_component/filters_component.html.haml
@@ -33,7 +33,7 @@
                 - if group[:selected]&.include?(tag.send(group[:value_method]))
                   %li
                     %button.moj-filter__tag{ data: { group: group[:key], key: tag.send(group[:value_method]) } }
-                      %i.fa.fa-close
+                      %i.fa.fa-times
                       %span.govuk-visually-hidden
                         = t('shared.filter_group.remove_filter_hidden')
                       = tag.send(group[:selected_method])

--- a/app/components/shared/filters_component/filters_component.scss
+++ b/app/components/shared/filters_component/filters_component.scss
@@ -159,8 +159,10 @@
             width: 0;
           }
 
-          .fa-close {
+          .fa-times {
             color: $govuk-link-colour;
+            font-size: 80%;
+            margin: 0 govuk-spacing(1);
           }
         }
       }

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -6,9 +6,13 @@
   @return url('~assets/images/' + $filename);
 }
 
+$fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
+
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 
+@import '~@fortawesome/fontawesome-free/scss/fontawesome';
+@import '~@fortawesome/fontawesome-free/scss/solid';
 @import '~govuk-frontend/govuk/all';
 @import '~@ministryofjustice/frontend/moj/all';
 
@@ -35,7 +39,7 @@ $govuk-image-url-function: frontend-image-url;
 @import 'application/signin';
 @import 'application/steps';
 @import 'application/tabs';
-@import 'application/timeline'; 
+@import 'application/timeline';
 
 @import 'application/jobSeekers/cookies-banner';
 @import 'application/jobSeekers/feedback-form';

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,15 +17,11 @@
     %link{ href: asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: "apple-touch-icon", sizes: "167x167" }/
     %link{ href: asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: "apple-touch-icon", sizes: "152x152" }/
     %link{ href: asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: "apple-touch-icon" }/
-    %link{ href: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css", rel: "stylesheet" }/
     - if content_for? :head_links
       = yield(:head_links)
-    /[if !IE 8]
     = stylesheet_pack_tag 'application', media: 'all'
-    /[if lte IE 8]
-    -# = stylesheet_link_tag '/govuk-frontend/all-ie8', media: 'all'
     /[if lt IE 9]
-    = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js'
+      = javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js", crossorigin: "anonymous", integrity: "sha256-3Jy/GbSLrg0o9y5Z5n1uw0qxZECH7C6OQpVBgNFYa0g="
     %meta{ content: asset_pack_path('media/images/govuk-opengraph-image.png'), property: "og:image" }/
     = csrf_meta_tags
   %body{ class: body_class, data: { vacancy_state: @vacancy.present? ? @vacancy.state : 'create' } }

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,13 +7,20 @@
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
 
+  development_env_additional_connect_src = %w[http://localhost:3035 ws://localhost:3035] if Rails.env.development?
+
+  policy.connect_src :self,
+                     "https://api.postcodes.io",
+                     "https://api.rollbar.com",
+                     "https://www.google-analytics.com",
+                     *development_env_additional_connect_src # Allow using webpack-dev-server in development
+
   policy.font_src    :self,
                      :data,
-                     "https://cdnjs.cloudflare.com",
-                     "https://fonts.gstatic.com"
+                     "https://fonts.gstatic.com" # through Google Maps
 
   policy.frame_src   :self,
-                     "https://www.google.com", # for reCAPTCHA
+                     "https://www.google.com", # through reCAPTCHA
                      "https://www.googletagmanager.com"
 
   policy.img_src     :self,
@@ -25,7 +32,6 @@ Rails.application.config.content_security_policy do |policy|
   policy.script_src  :self,
                      :unsafe_inline, # Backwards compatibility; ignored by modern browsers as we set a nonce for scripts
                      "https://cdn.rollbar.com",
-                     "https://cdnjs.cloudflare.com",
                      "https://maps.googleapis.com",
                      "https://www.google-analytics.com",
                      "https://www.googletagmanager.com",
@@ -35,16 +41,7 @@ Rails.application.config.content_security_policy do |policy|
   #   see: https://issuetracker.google.com/issues/132600807
   policy.style_src   :self,
                      :unsafe_inline,
-                     "https://cdnjs.cloudflare.com",
-                     "https://fonts.googleapis.com"
-
-  policy.connect_src :self,
-                     "https://api.postcodes.io",
-                     "https://api.rollbar.com",
-                     "https://www.google-analytics.com"
-
-  # Allow using webpack-dev-server in development
-  policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+                     "https://fonts.googleapis.com" # through Google Maps
 
   # Specify URI for violation reports
   policy.report_uri "/errors/csp_violation"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "classlist-polyfill": "^1.2.0",
     "clipboard": "^2.0.4",
     "es6-promise": "^4.2.8",
+    "@fortawesome/fontawesome-free": "^5.15.1",
     "govuk-frontend": "3.4.0",
     "jquery": "^3.5.0",
     "jsdom": "^16.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,6 +893,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fortawesome/fontawesome-free@^5.15.1":
+  version "5.15.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.1.tgz#ccfef6ddbe59f8fe8f694783e1d3eb88902dc5eb"
+  integrity sha512-OEdH7SyC1suTdhBGW91/zBfR6qaIhThbcN8PUXtXilY4GYnSBbVqOntdHbC1vXwsDnX0Qix2m2+DSU1J51ybOQ==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
- Include Font Awesome library through Webpack instead of Cloudflare
  CDN
    - Update library to 5.x (requires small cosmetic change as default
      icon size is larger, and changes class name of renamed icon)
- Add conditional comment to only load `html5shiv` for IE8 and below
  (and add an integrity hash - this is not actually supported by IE8,
  but adds a layer of defence in case we ever remove the conditional
  comment, making sure modern browsers will refuse to load a tampered
  with library)
- Remove Cloudflare CDN from CSP (it is now only used for `html5shiv`,
  which is only loaded for IE8 and below, which doesn't support CSP)
- Reorder and tidy up CSP
- Clarify in CSP which dependencies require certain directive values
  (where it isn't obvious)
- Remove unused IE conditional comments from layout template

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-791

## Screenshots

Slightly changed "x" icon:
<img width="238" alt="Screenshot 2020-11-10 at 15 01 28" src="https://user-images.githubusercontent.com/72141/98691221-b927e280-2365-11eb-904f-e9994b84ca35.png">
