### PR TITLE
[TEVA-1534] bugfixes on review app workspace deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,8 @@ review-destroy: init-terraform ## make CONFIRM_DESTROY=true passcode=MyPasscode 
 
 .PHONY: terraform-common-init
 terraform-common-init:
-		terraform init terraform/common
+		terraform init -reconfigure terraform/common
+		terraform workspace select default terraform/common
 
 .PHONY: terraform-common-plan
 terraform-common-plan: terraform-common-init ## make terraform-common-plan

--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -30,7 +30,7 @@ data aws_iam_policy_document edit_terraform_state {
   }
   statement {
     actions   = ["s3:DeleteObject"]
-    resources = ["arn:aws:s3:::${var.s3_bucket_name}/:review/*"]
+    resources = ["arn:aws:s3:::${var.s3_bucket_name}/review:/*"]
   }
   statement {
     actions   = ["s3:ListBucket"]


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1534

## Changes in this PR:

- Corrected typo in Terraform state S3 bucket (`:review` vs `review:`)
- Added `terraform init -reconfigure` to terraform/common
- Explicitly select default workspace for terraform/common