### PR TITLE
Move away from deprecated `DeliveryJob`

### DIFF
--- a/app/jobs/alert_mailer_job.rb
+++ b/app/jobs/alert_mailer_job.rb
@@ -1,4 +1,4 @@
-class AlertMailerJob < ActionMailer::DeliveryJob
+class AlertMailerJob < ActionMailer::MailDeliveryJob
   EXPIRES_IN = 4.hours
 
   before_enqueue do
@@ -32,7 +32,7 @@ private
   end
 
   def subscription_id
-    arguments[3]
+    arguments.last[:args].first
   end
 
   def alert_run


### PR DESCRIPTION
This has been deprecated in favour of `MailDeliveryJob` and was causing
Rails 6.1 deprecation warnings.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1488