### PR TITLE
[TEVA-1570] GH Actions use setup-ruby with .ruby-version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,10 +44,8 @@ jobs:
         TAG=${GITHUB_SHA}
         echo "TAG=${TAG}" >> $GITHUB_ENV
 
-    - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
 
     - name: Validate secrets
       env:

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -52,10 +52,8 @@ jobs:
         echo ::set-output name=BRANCH::${BRANCH}
         echo ::set-output name=TAG::${TAG}
 
-    - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
 
     - name: Validate secrets
       env:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -29,10 +29,8 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout Code
 
-    - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
 
     - name: Validate secrets
       env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,23 +16,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
-
-      - name: Set up ruby gem cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 20 --retry 3
+          bundler-cache: true
 
       - name: Run Rubocop
         run: bundle exec rubocop

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -34,10 +34,8 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout Code
 
-    - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
 
     - name: Validate secrets
       env:

--- a/.github/workflows/smoke-test-manual.yml
+++ b/.github/workflows/smoke-test-manual.yml
@@ -21,23 +21,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
-
-      - name: Set up ruby gem cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 20 --retry 3
+          bundler-cache: true
 
       - name: Set up Node
         uses: actions/setup-node@v2.1.2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,23 +17,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
-
-      - name: Set up ruby gem cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 20 --retry 3
+          bundler-cache: true
 
       - name: Set up Node
         uses: actions/setup-node@v2.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,23 +41,10 @@ jobs:
       - name: Setup sonarqube
         uses: warchant/setup-sonar-scanner@v3
 
-      - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
-
-      - name: Set up ruby gem cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 20 --retry 3
+          bundler-cache: true
 
       - name: Set up Node
         uses: actions/setup-node@v2.1.2


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1570

## Changes in this PR:

- Change from [actions/setup-ruby](https://github.com/actions/setup-ruby) to [ruby/setup-ruby](https://github.com/ruby/setup-ruby) which:
-- honours existing `.ruby-version`
-- has built in caching by using `bundler-cache: true`