### PR TITLE
Temporarily stop reporting CSP violations

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -44,7 +44,10 @@ Rails.application.config.content_security_policy do |policy|
                      "https://fonts.googleapis.com" # through Google Maps
 
   # Specify URI for violation reports
-  policy.report_uri "/errors/csp_violation"
+  # TODO: Temporarily commented out until bug in `rollbar` gem is fixed which is causing two violations per pageview
+  #       and making us go over our Rollbar quota
+  #       https://github.com/rollbar/rollbar-gem/pull/1010
+  # policy.report_uri "/errors/csp_violation"
 end
 
 # Enable automatic nonce generation for <script> tags


### PR DESCRIPTION
An issue in the rollbar gem is causing its JS output to violate our CSP
and generates two CSP violation reports per page view, ironically making
us go over our Rollbar quota. 😅 

Until the relevant PR gets merged, this suspends CSP violation reports:
https://github.com/rollbar/rollbar-gem/pull/1010