### PR TITLE
Prepare for Rails 6.1 upgrade

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -135,9 +135,10 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
     date_errors
   end
 
-  def add_errors_to_form(errors, form_object)
+  def replace_errors_in_form(errors, form_object)
     errors.each do |field, error|
-      form_object.errors.messages[field].unshift(error)
+      form_object.errors.delete(field)
+      form_object.errors.add(field, error)
     end
   end
 

--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -14,7 +14,7 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
       Auditor::Audit.new(new_vacancy, "vacancy.copy", current_session_id).log
       redirect_to organisation_job_review_path(new_vacancy.id)
     else
-      add_errors_to_form(@date_errors, @copy_form)
+      replace_errors_in_form(@date_errors, @copy_form)
       render :new
     end
   end

--- a/app/controllers/hiring_staff/vacancies/important_dates_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/important_dates_controller.rb
@@ -18,7 +18,7 @@ class HiringStaff::Vacancies::ImportantDatesController < HiringStaff::Vacancies:
       update_google_index(@vacancy) if @vacancy.listed?
       redirect_to_next_step_if_continue(@vacancy.id, @vacancy.job_title)
     else
-      add_errors_to_form(@date_errors, @important_dates_form)
+      replace_errors_in_form(@date_errors, @important_dates_form)
       render :show
     end
   end

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -1,6 +1,6 @@
 class AlertMailer < ApplicationMailer
   self.delivery_job = AlertMailerJob
-  add_template_helper(DatesHelper)
+  helper DatesHelper
 
   def alert(subscription_id, vacancy_ids)
     subscription = Subscription.find(subscription_id)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < Mail::Notify::Mailer
-  add_template_helper(NotifyViewHelper)
-  add_template_helper(OrganisationHelper)
+  helper NotifyViewHelper
+  helper OrganisationHelper
 end

--- a/app/validators/concerns/validator_concerns.rb
+++ b/app/validators/concerns/validator_concerns.rb
@@ -8,6 +8,6 @@ module ValidatorConcerns
 private
 
   def error_message(record, attribute, message)
-    record.errors[attribute] << message
+    record.errors.add(attribute, message)
   end
 end

--- a/app/views/api/vacancies/index.json.jbuilder
+++ b/app/views/api/vacancies/index.json.jbuilder
@@ -15,7 +15,7 @@ end
 json.openapi "3.0.0"
 
 json.data @vacancies.decorated_collection do |vacancy|
-  json.partial! "show.json.jbuilder", vacancy: vacancy
+  json.partial! "show", vacancy: vacancy
 end
 
 json.links do

--- a/app/views/api/vacancies/show.jbuilder
+++ b/app/views/api/vacancies/show.jbuilder
@@ -1,1 +1,1 @@
-json.partial! "show.json.jbuilder", vacancy: @vacancy
+json.partial! "show", vacancy: @vacancy

--- a/app/views/hiring_staff/vacancies/_error_messages.html.haml
+++ b/app/views/hiring_staff/vacancies/_error_messages.html.haml
@@ -1,2 +1,2 @@
 - if errors.any?
-  = render(Shared::NotificationComponent.new(content: { title: t('messages.jobs.action_required.heading'), body: t('messages.jobs.action_required.message') }, style: 'danger', links: errors))
+  = render(Shared::NotificationComponent.new(content: { title: t('messages.jobs.action_required.heading'), body: t('messages.jobs.action_required.message') }, style: 'danger', links: errors.to_hash))

--- a/app/views/vacancies/show.html.haml
+++ b/app/views/vacancies/show.html.haml
@@ -1,4 +1,4 @@
 = render partial: 'vacancies/show'
 
 %script.jobref{ type: 'application/ld+json' }
-  = raw(render partial: 'api/vacancies/show.json.jbuilder', locals: { vacancy: @vacancy })
+  = raw(render partial: 'api/vacancies/show', formats: [:json], locals: { vacancy: @vacancy })

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,6 +59,7 @@ RSpec.configure do |config|
   end
 
   config.include ActionView::Helpers::NumberHelper
+  config.include ActiveSupport::Testing::Assertions # required for ActiveJob::TestHelper#perform_enqueued_jobs
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ApplicationHelpers
   config.include AuthHelpers

--- a/spec/requests/not_found_spec.rb
+++ b/spec/requests/not_found_spec.rb
@@ -21,13 +21,6 @@ RSpec.describe "non-existent pages" do
     expect(JSON.parse(response.body)).to eq("error" => "Resource not found")
   end
 
-  it "returns a 404 for xml" do
-    get "/foo.xml"
-    expect(response).to have_http_status(404)
-    expect(response.header["Content-Type"]).to include "application/xml"
-    expect(response.body).to be_empty
-  end
-
   it "returns a 404 for unknown formats" do
     get "/foo.unknown"
     expect(response).to have_http_status(404)


### PR DESCRIPTION
- Fix use of removed private ActionPack `add_template_helper` in mailers
  (https://github.com/rails/rails/commit/cb3b37b37975ceb1d38bec9f02305ff5c14ba8e9)
- Fix deprecated use of full template filenames (with `.` in the name)
  in `render` calls
- Fix deprecated use of `ActiveModel::Error#<<`
- Include `ActiveSupport::Testing::Assertions` in RSpec config to work
  around `ActiveJob::TestHelper#perform_enqueued_jobs` implicitly
  depending on `ActiveSupport::Testing::Assertions#assert_nothing_raised`
- Remove not really useful test for 404 XML response that stops working
  under Rails 6.1 due to new `respond_to` defaults
- Fix deprecated direct manipulation of `ActiveModel::Error#messages`
  in `HiringStaff::Vacancies::ApplicationController#add_errors_to_form`
  and rename method for its purpose to be more obvious
- Pass errors into `Shared::NotificationComponent` as a hash instead of
  `ActiveModel::Errors` directly (which is now an array)

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1578