### PR TITLE
Enable `NewCops` in Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,6 @@ inherit_gem:
 inherit_mode:
   merge:
     - Exclude
+
+AllCops:
+  NewCops: enable

--- a/app/services/updates_parser.rb
+++ b/app/services/updates_parser.rb
@@ -22,7 +22,7 @@ private
   end
 
   def process_update_path(update_path)
-    path = update_path.split("/").last.split(".html").first[1..-1]
+    path = update_path.split("/").last.split(".html").first[1..]
     name = update_path.split("/").last.split(".html").first.split("_")[1..-4].join(" ").humanize
     date_array = update_path.split("/").last.split(".html").first.split("_").last(3).map(&:to_i)
     [path, name, date_array]

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,7 +3,7 @@ return if Rails.env.test?
 redis_url = "#{REDIS_URL}/0"
 
 options = {
-  concurrency: Integer(ENV.fetch("RAILS_MAX_THREADS") { 5 }),
+  concurrency: Integer(ENV.fetch("RAILS_MAX_THREADS", 5)),
 }
 
 # Redis concurrency must be plus 5 https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,13 +4,13 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
   post "sign-up-for-NQT-job-alerts", to: "nqt_job_alerts#create", as: "new_nqt_job_alert"
 
   namespace :api do
-    scope "v:api_version", api_version: /[1]/ do
+    scope "v:api_version", api_version: /1/ do
       resources :jobs, only: %i[index show], controller: "vacancies"
       get "/coordinates(/:location)", to: "coordinates#show"
       get "/location_suggestion(/:location)", to: "location_suggestion#show"

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -177,7 +177,7 @@ module VacancyHelpers
   end
 
   def vacancy_json_ld(vacancy)
-    json = {
+    {
       '@context': "http://schema.org",
       '@type': "JobPosting",
       'title': vacancy.job_title,
@@ -210,8 +210,6 @@ module VacancyHelpers
       },
       'validThrough': vacancy.expires_on.end_of_day.to_time.iso8601,
     }
-
-    json
   end
 
   def verify_vacancy_list_page_details(vacancy)


### PR DESCRIPTION
New rules added to Rubocop between major versions are disabled by
default. `rubocop-govuk` currently makes that setting explicit.

Enabling it means we get new rules as soon as they are added in minor
Rubocop versions, meaning we can deal with them bit by bit (and get
the benefit of nicer code early) instead of having them come through in
a huge wave on a major update.