### PR TITLE
[TEVA-1532] Delete .terraform dir before deploying monitoring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,6 +138,8 @@ jobs:
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
         export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
+        echo Deleting .terraform directory...
+        rm -rf .terraform
         terraform init -upgrade=true -reconfigure -input=false terraform/monitoring
         terraform apply -input=false -auto-approve terraform/monitoring
 

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ terraform-common-apply: terraform-common-init ## make terraform-common-apply
 terraform-monitoring-init:
 		$(if $(passcode), , $(error Missing environment variable "passcode"))
 		$(eval export TF_VAR_paas_sso_passcode=$(passcode))
+		rm -rf .terraform
 		terraform init -upgrade=true -input=false -reconfigure terraform/monitoring
 
 .PHONY: terraform-monitoring-plan


### PR DESCRIPTION

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1532

## Changes in this PR:

The .terraform directory persists the workspace set by the terraform app
deployment. If monitoring deployment is run afterwards, it will look for
that workspace and hang indefinitely.

See: https://github.com/DFE-Digital/teacher-vacancy-service/runs/1391266386?check_suite_focus=true
## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
