### PR TITLE
TEVA-1536 GH Action to refresh environment variables in apps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,9 +98,10 @@ jobs:
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
         export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
-        terraform init -input=false terraform/app
-        terraform workspace select staging terraform/app || terraform workspace new staging terraform/app
-        terraform apply -var-file terraform/workspace-variables/staging.tfvars -auto-approve -input=false terraform/app
+        cd terraform/app
+        terraform init -reconfigure -input=false
+        terraform workspace select staging || terraform workspace new staging
+        terraform apply -var-file ../workspace-variables/staging.tfvars -auto-approve -input=false
 
     - name: Trigger Smoke Test
       uses: benc-uk/workflow-dispatch@v1.1
@@ -128,8 +129,10 @@ jobs:
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
         export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
-        terraform workspace select production terraform/app || terraform workspace new production terraform/app
-        terraform apply -var-file terraform/workspace-variables/production.tfvars -auto-approve -input=false terraform/app
+        cd terraform/app
+        terraform init -reconfigure -input=false
+        terraform workspace select production || terraform workspace new production
+        terraform apply -var-file ../workspace-variables/production.tfvars -auto-approve -input=false
 
     - name: Deploy monitoring
       env:
@@ -139,10 +142,9 @@ jobs:
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
         export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
-        echo Deleting .terraform directory...
-        rm -rf .terraform
-        terraform init -upgrade=true -reconfigure -input=false terraform/monitoring
-        terraform apply -input=false -auto-approve terraform/monitoring
+        cd terraform/monitoring
+        terraform init -upgrade=true -reconfigure -input=false
+        terraform apply -input=false -auto-approve
 
     - name: Send success message to twd_tv_dev channel
       if: ${{ success() }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: eu-west-2
       run: |
         gem install aws-sdk-ssm --no-document
         bin/run-in-env -t /tvs/staging -o quiet \

--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -45,6 +45,6 @@ jobs:
       run: |
         export TF_VAR_paas_app_docker_image=${{ github.event.inputs.docker_image }}
         cd terraform/app
-        terraform init -input=false
+        terraform init -reconfigure -input=false
         terraform workspace select ${{ github.event.inputs.environment }} || terraform workspace new ${{ github.event.inputs.environment }}
-        terraform apply -var-file terraform/workspace-variables/${{ github.event.inputs.environment }}.tfvars -auto-approve -input=false
+        terraform apply -var-file ../workspace-variables/${{ github.event.inputs.environment }}.tfvars -auto-approve -input=false

--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -1,0 +1,50 @@
+name: Deploy App to Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_image:
+        description: Docker image (repository:tag)
+        required: true
+      environment:
+        description: Environment
+        required: true
+
+jobs:
+  deploy-app:
+    name: Deploy app to environment
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout Code
+
+    - name: Pin Terraform version
+      uses: hashicorp/setup-terraform@v1.2.1
+      with:
+        terraform_version: 0.13.4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+
+    - name: Validate secrets
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: eu-west-2
+      run: |
+        gem install aws-sdk-ssm --no-document
+        bin/run-in-env -t /tvs/${{ github.event.inputs.environment }} -o quiet \
+          && echo Data in /tvs/${{ github.event.inputs.environment }} looks valid
+
+    - name: Deploy to environment
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
+        TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
+      run: |
+        export TF_VAR_paas_app_docker_image=${{ github.event.inputs.docker_image }}
+        cd terraform/app
+        terraform init -input=false
+        terraform workspace select ${{ github.event.inputs.environment }} || terraform workspace new ${{ github.event.inputs.environment }}
+        terraform apply -var-file terraform/workspace-variables/${{ github.event.inputs.environment }}.tfvars -auto-approve -input=false

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -107,9 +107,10 @@ jobs:
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
         export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
-        terraform init -input=false terraform/app
-        terraform workspace select ${BRANCH} terraform/app || terraform workspace new ${BRANCH} terraform/app
-        terraform apply -var-file terraform/workspace-variables/${BRANCH}.tfvars -auto-approve -input=false terraform/app
+        cd terraform/app
+        terraform init -reconfigure -input=false
+        terraform workspace select ${BRANCH} || terraform workspace new ${BRANCH}
+        terraform apply -var-file ../workspace-variables/${BRANCH}.tfvars -auto-approve -input=false
 
     - name: Send success message to twd_tv_dev channel
       if: ${{ success() }}

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -59,6 +59,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: eu-west-2
       run: |
         gem install aws-sdk-ssm --no-document
         bin/run-in-env -t "/tvs/${BRANCH}" -o quiet \

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -62,11 +62,12 @@ jobs:
       run: |
         export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
         export TF_VAR_environment=review-${PR_NAME}
-        terraform init -input=false -backend-config="workspace_key_prefix=review:" terraform/app
-        terraform workspace select review-${PR_NAME} terraform/app || terraform workspace new review-${PR_NAME} terraform/app
-        terraform plan -var-file terraform/workspace-variables/review.tfvars -destroy -out=tfdestroy terraform/app
+        cd terraform/app
+        terraform init -reconfigure -input=false -backend-config="workspace_key_prefix=review:"
+        terraform workspace select review-${PR_NAME} terraform/app || terraform workspace new review-${PR_NAME}
+        terraform plan -var-file ../workspace-variables/review.tfvars -destroy -out=tfdestroy
         terraform apply -auto-approve "tfdestroy"
-        terraform workspace select default terraform/app && terraform workspace delete review-${PR_NAME} terraform/app
+        terraform workspace select default && terraform workspace delete review-${PR_NAME}
 
     - name: Send failure message to twd_tv_dev channel
       if: ${{ failure() }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -36,6 +36,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: eu-west-2
       run: |
         gem install aws-sdk-ssm --no-document
         bin/run-in-env -t /tvs/dev -o quiet \

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -31,7 +31,7 @@ jobs:
           TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
         run: |
           cd terraform/app
-          terraform init -input=false
+          terraform init -reconfigure -input=false
           terraform workspace select ${{ github.event.inputs.environment }} || terraform workspace new ${{ github.event.inputs.environment }}
           DOCKER_IMAGE=$(terraform output docker_image)
           echo "DOCKER_IMAGE=${DOCKER_IMAGE}" >> $GITHUB_ENV

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,0 +1,65 @@
+name: Refresh environment 
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment
+        required: true
+        default: staging
+
+jobs:
+  refresh-env-vars:
+    name: Refresh Env Vars
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Pin Terraform version
+        uses: hashicorp/setup-terraform@v1.2.1
+        with:
+          terraform_version: 0.13.4
+
+      - name: Determine current Docker image tag
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
+          TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
+        run: |
+          cd terraform/app
+          terraform init -input=false
+          terraform workspace select ${{ github.event.inputs.environment }} || terraform workspace new ${{ github.event.inputs.environment }}
+          DOCKER_IMAGE=$(terraform output docker_image)
+          echo "DOCKER_IMAGE=${DOCKER_IMAGE}" >> $GITHUB_ENV
+
+      - name: Trigger Deploy App Workflow
+        uses: benc-uk/workflow-dispatch@v1.1
+        with:
+          workflow: Deploy App to Environment # Workflow name
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          inputs: {"environment": "${{ github.event.inputs.environment }}", "docker_image": "${{ env.DOCKER_IMAGE }}"}
+
+      - name: Wait for Deploy App Workflow
+        id: wait_for_deploy_app
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        with:
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          checkName: Deploy app to environment # Job name within workflow
+          ref: ${{ github.ref }}
+          timeoutSeconds: 300
+          intervalSeconds: 15
+
+      - name: Send success message to twd_tv_dev channel
+        if: ${{ steps.wait_for_deploy_app.outputs.conclusion == 'success' }} && github.ref == 'refs/heads/master'          
+        uses: rtCamp/action-slack-notify@v2.1.0
+        env:
+          SLACK_CHANNEL: twd_tv_dev
+          SLACK_USERNAME: CI Deployment
+          SLACK_ICON_EMOJI: :tada:
+          SLACK_TITLE: ${{ github.event.inputs.environment }} env vars refresh successful
+          SLACK_MESSAGE: ${{ github.event.inputs.environment }} env vars refresh successful - Docker image ${{ env.DOCKER_IMAGE }} :rocket:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -41,6 +41,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: eu-west-2
       run: |
         gem install aws-sdk-ssm --no-document
         bin/run-in-env -t /tvs/dev -o quiet \

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -104,9 +104,10 @@ jobs:
       run: |
         export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
         export TF_VAR_environment=review-${PR_NAME}
-        terraform init -input=false -backend-config="workspace_key_prefix=review:" terraform/app
-        terraform workspace select review-${PR_NAME} terraform/app || terraform workspace new review-${PR_NAME} terraform/app
-        terraform apply -var-file terraform/workspace-variables/review.tfvars -auto-approve -input=false terraform/app
+        cd terraform/app
+        terraform init -reconfigure -input=false -backend-config="workspace_key_prefix=review:"
+        terraform workspace select review-${PR_NAME} || terraform workspace new review-${PR_NAME}
+        terraform apply -var-file ../workspace-variables/review.tfvars -auto-approve -input=false
 
     - name: Post PR comment
       if: ${{ success() }}

--- a/terraform/app/modules/paas/outputs.tf
+++ b/terraform/app/modules/paas/outputs.tf
@@ -1,0 +1,4 @@
+output docker_image {
+  value       = cloudfoundry_app.web_app.docker_image
+  description = "Docker image - repository:tag"
+}

--- a/terraform/app/output.tf
+++ b/terraform/app/output.tf
@@ -1,4 +1,8 @@
+output docker_image {
+  value       = module.paas.docker_image
+  description = "Docker image - repository:tag"
+}
+
 output workspace {
   value = terraform.workspace
 }
-


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1536

## Changes in this PR:

- Added Docker image tag as Terraform output
- Created `deploy-manual` workflow to receive tag and environment as inputs, and deploy to an environment
- Created `refresh` workflow to determine current docker image tag on an environment, and redeploy, which should have the effect of refreshing just the environment variables.
- Added `eu-west-2` region to AWS environment variables for `run-in-env` script which retrieves secrets from Parameter Store
