### PR TITLE
[TEVA-1536] Remove dangling terraform/app in destroy workflow

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -64,7 +64,7 @@ jobs:
         export TF_VAR_environment=review-${PR_NAME}
         cd terraform/app
         terraform init -reconfigure -input=false -backend-config="workspace_key_prefix=review:"
-        terraform workspace select review-${PR_NAME} terraform/app || terraform workspace new review-${PR_NAME}
+        terraform workspace select review-${PR_NAME} || terraform workspace new review-${PR_NAME}
         terraform plan -var-file ../workspace-variables/review.tfvars -destroy -out=tfdestroy
         terraform apply -auto-approve "tfdestroy"
         terraform workspace select default && terraform workspace delete review-${PR_NAME}


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1536

## Changes in this PR:

- Removed `terraform/app` from `Destroy` workflow that was still present.
